### PR TITLE
mux, demux and throttle of nodelet version for PointCloud and Image

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -60,7 +60,14 @@ jsk_pcl_nodelet(src/euclidean_cluster_extraction_nodelet.cpp "jsk_pcl/EuclideanC
 jsk_pcl_nodelet(src/cluster_point_indices_decomposer_nodelet.cpp "jsk_pcl/ClusterPointIndicesDecomposer" "cluster_point_indices_decomposer")
 jsk_pcl_nodelet(src/cluster_point_indices_decomposer_z_axis_nodelet.cpp "jsk_pcl/ClusterPointIndicesDecomposerZAxis" "cluster_point_indices_decomposer_z_axis")
 jsk_pcl_nodelet(src/centroid_publisher_nodelet.cpp "jsk_pcl/CentroidPublisher" "centroid_publisher")
-
+jsk_pcl_nodelet(src/pointcloud_throttle_nodelet.cpp
+  "jsk_pcl/NodeletPointCloudThrottle" "point_cloud_throttle")
+jsk_pcl_nodelet(src/image_throttle_nodelet.cpp
+  "jsk_pcl/NodeletImageThrottle" "image_throttle")
+jsk_pcl_nodelet(src/image_mux_nodelet.cpp
+  "jsk_pcl/NodeletImageMUX" "image_mux")
+jsk_pcl_nodelet(src/image_demux_nodelet.cpp
+  "jsk_pcl/NodeletImageDEMUX" "image_demux")
 
 rosbuild_add_library (jsk_pcl_ros
   ${jsk_pcl_nodelet_sources}

--- a/jsk_pcl_ros/catkin.cmake
+++ b/jsk_pcl_ros/catkin.cmake
@@ -56,6 +56,13 @@ jsk_pcl_nodelet(src/voxel_grid_downsample_decoder_nodelet.cpp "jsk_pcl/VoxelGrid
 jsk_pcl_nodelet(src/snapit_nodelet.cpp "jsk_pcl/Snapit" "snapit")
 jsk_pcl_nodelet(src/keypoints_publisher_nodelet.cpp "jsk_pcl/KeypointsPublisher" "keypoints_publisher")
 jsk_pcl_nodelet(src/hinted_plane_detector_nodelet.cpp "jsk_pcl/HintedPlaneDetector" "hinted_plane_detector")
+jsk_pcl_nodelet(src/pointcloud_throttle_nodelet.cpp "jsk_pcl/NodeletPointCloudThrottle" "point_cloud_throttle")
+jsk_pcl_nodelet(src/image_throttle_nodelet.cpp
+  "jsk_pcl/NodeletImageThrottle" "image_throttle")
+jsk_pcl_nodelet(src/image_mux_nodelet.cpp
+  "jsk_pcl/NodeletImageMUX" "image_mux")
+jsk_pcl_nodelet(src/image_demux_nodelet.cpp
+  "jsk_pcl/NodeletImageDEMUX" "image_demux")
 
 add_library(jsk_pcl_ros SHARED ${jsk_pcl_nodelet_sources})
 target_link_libraries(jsk_pcl_ros ${catkin_LIBRARIES} ${pcl_ros_LIBRARIES})

--- a/jsk_pcl_ros/jsk_pcl_nodelets.xml
+++ b/jsk_pcl_ros/jsk_pcl_nodelets.xml
@@ -1,5 +1,30 @@
 <library path="lib/libjsk_pcl_ros">
 
+  <class name="jsk_pcl/NodeletPointCloudThrottle" type="NodeletPointCloudThrottle"
+         base_class_type="nodelet::Nodelet">
+    <description>
+  
+    </description>
+  </class>
+  <class name="jsk_pcl/NodeletImageThrottle" type="NodeletImageThrottle"
+         base_class_type="nodelet::Nodelet">
+    <description>
+  
+    </description>
+  </class>
+  <class name="jsk_pcl/NodeletImageMUX" type="NodeletImageMUX"
+         base_class_type="nodelet::Nodelet">
+    <description>
+  
+    </description>
+  </class>
+  <class name="jsk_pcl/NodeletImageDEMUX" type="NodeletImageDEMUX"
+         base_class_type="nodelet::Nodelet">
+    <description>
+  
+    </description>
+  </class>
+
   <class name="jsk_pcl/ParticleFilterTracking" type="ParticleFilterTracking"
          base_class_type="nodelet::Nodelet">
     <description>

--- a/jsk_pcl_ros/launch/topic_tools.launch
+++ b/jsk_pcl_ros/launch/topic_tools.launch
@@ -1,0 +1,51 @@
+<launch>
+  <arg name="MANAGER" value="/camera/camera_nodelet_manager" />
+  <include file="$(find openni_launch)/launch/openni.launch" />
+  <group ns="camera">
+    <node name="pointcloud_throttle"
+          pkg="nodelet"
+          type="nodelet"
+          output="screen"
+          args="load jsk_pcl/NodeletPointCloudThrottle $(arg MANAGER)">
+      <remap from="topic_in"  to="/camera/depth_registered/points" />
+      <remap from="topic_out" to="/camera/depth_registered/points_throttle" />
+      <param name="update_rate" value="1.0" />
+    </node>
+    <node name="image_throttle"
+          pkg="nodelet"
+          type="nodelet"
+          output="screen"
+          args="load jsk_pcl/NodeletImageThrottle $(arg MANAGER)">
+      <remap from="topic_in"  to="/camera/rgb/image_rect_color" />
+      <remap from="topic_out" to="/camera/rgb/image_rect_color_throttle" />
+      <param name="update_rate" value="1.0" />
+    </node>
+
+    <node name="image_mux"
+          pkg="nodelet"
+          type="nodelet"
+          output="screen"
+          clear_params="true"
+          args="load jsk_pcl/NodeletImageMUX $(arg MANAGER)">
+      <rosparam>
+        input_topics: ["/camera/rgb/image_rect_color", "/camera/rgb/image_rect_mono"]
+      </rosparam>
+      <remap from="~output" to="/image_mux" />
+    </node>
+
+    <!-- NB: NodeletMux is unstable -->
+    <node name="image_demux"
+          pkg="nodelet"
+          if="false"
+          type="nodelet"
+          output="screen"
+          clear_params="true"
+          args="load jsk_pcl/NodeletImageDEMUX $(arg MANAGER)">
+      <rosparam>
+        output_topics: ["/camera/rgb/image_rect_color0", "/camera/rgb/image_rect_color1", "/camera/rgb/image_rect_color2"]
+      </rosparam>
+      <remap from="~input" to="/camera/rgb/image_rect_color" />
+    </node>
+    
+  </group>
+</launch>

--- a/jsk_pcl_ros/package.xml
+++ b/jsk_pcl_ros/package.xml
@@ -14,7 +14,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <!-- <build_depend>pcl</build_depend> -->
-  <build_depend>pcl_ros</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend><build_depend>pcl</build_depend>
+  <build_depend>pcl_ros</build_depend><build_depend>pcl</build_depend>
   <build_depend>pcl_msgs</build_depend>
   <build_depend>opencv2</build_depend>
   <build_depend>tf</build_depend>
@@ -36,7 +36,7 @@
   <!-- <run_depend>pcl</run_depend> -->
   <run_depend>eigen_conversions</run_depend>
   <run_depend>pcl_conversions</run_depend>
-  <run_depend>pcl_ros</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend><run_depend>pcl</run_depend>
+  <run_depend>pcl_ros</run_depend><run_depend>pcl</run_depend>
   <run_depend>pcl_msgs</run_depend>
   <run_depend>opencv2</run_depend>
   <run_depend>tf</run_depend>

--- a/jsk_pcl_ros/src/image_demux_nodelet.cpp
+++ b/jsk_pcl_ros/src/image_demux_nodelet.cpp
@@ -1,0 +1,40 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Ryohei Ueda and JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <nodelet_topic_tools/nodelet_demux.h>
+#include <sensor_msgs/Image.h>
+#include <pluginlib/class_list_macros.h>
+
+typedef nodelet::NodeletDEMUX<sensor_msgs::Image> NodeletImageDEMUX;
+PLUGINLIB_DECLARE_CLASS (jsk_pcl, NodeletImageDEMUX, NodeletImageDEMUX, nodelet::Nodelet);

--- a/jsk_pcl_ros/src/image_mux_nodelet.cpp
+++ b/jsk_pcl_ros/src/image_mux_nodelet.cpp
@@ -1,0 +1,41 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Ryohei Ueda and JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <nodelet_topic_tools/nodelet_mux.h>
+#include <message_filters/subscriber.h>
+#include <sensor_msgs/Image.h>
+#include <pluginlib/class_list_macros.h>
+
+typedef nodelet::NodeletMUX<sensor_msgs::Image, message_filters::Subscriber<sensor_msgs::Image> > NodeletImageMUX;
+PLUGINLIB_DECLARE_CLASS (jsk_pcl, NodeletImageMUX, NodeletImageMUX, nodelet::Nodelet);

--- a/jsk_pcl_ros/src/image_throttle_nodelet.cpp
+++ b/jsk_pcl_ros/src/image_throttle_nodelet.cpp
@@ -1,0 +1,40 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Ryohei Ueda and JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <nodelet_topic_tools/nodelet_throttle.h>
+#include <sensor_msgs/Image.h>
+#include <pluginlib/class_list_macros.h>
+
+typedef nodelet_topic_tools::NodeletThrottle<sensor_msgs::Image> NodeletImageThrottle;
+PLUGINLIB_DECLARE_CLASS (jck_pcl, NodeletImageThrottle, NodeletImageThrottle, nodelet::Nodelet);

--- a/jsk_pcl_ros/src/pointcloud_throttle_nodelet.cpp
+++ b/jsk_pcl_ros/src/pointcloud_throttle_nodelet.cpp
@@ -1,0 +1,40 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Ryohei Ueda and JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <nodelet_topic_tools/nodelet_throttle.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <pluginlib/class_list_macros.h>
+
+typedef nodelet_topic_tools::NodeletThrottle<sensor_msgs::PointCloud2> NodeletPointCloudThrottle;
+PLUGINLIB_DECLARE_CLASS (jck_pcl, NodeletPointCloudThrottle, NodeletPointCloudThrottle, nodelet::Nodelet);


### PR DESCRIPTION
adds following nodelets to jsk_pcl_ros:
- throttle nodelet for sensor_msgs/PointCloud2
- throttle nodelet for sensor_msgs/Image
- mux and demux nodelet for sensor_msgs/Image
