### PR TITLE
[rgb_color_filter] do not run callback simultaneously 

### DIFF
--- a/jsk_pcl_ros/src/rgb_color_filter_nodelet.cpp
+++ b/jsk_pcl_ros/src/rgb_color_filter_nodelet.cpp
@@ -100,6 +100,7 @@ namespace jsk_pcl_ros
   void RGBColorFilter::filter(const sensor_msgs::PointCloud2ConstPtr &input,
                               const PCLIndicesMsg::ConstPtr& indices)
   {
+    boost::mutex::scoped_lock lock (mutex_);
     pcl::PointCloud<pcl::PointXYZRGB> tmp_in, tmp_out;
     sensor_msgs::PointCloud2 out;
     fromROSMsg(*input, tmp_in);


### PR DESCRIPTION
simultaneous calling from dynamics reconfigure and input callback may cause SEGV
