### PR TITLE
Add filter cpp to rosbuild

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -80,7 +80,7 @@ jsk_pcl_nodelet(src/rgb_color_filter_nodelet.cpp
 rosbuild_add_library (jsk_pcl_ros
   ${jsk_pcl_nodelet_sources}
 #  ${pcl_ros_PACKAGE_PATH}/src/pcl_ros/features/feature.cpp
-#  src/filter.cpp # copy from pcl_ros https://github.com/ros-perception/perception_pcl/issues/9
+   src/filter.cpp # copy from pcl_ros https://github.com/ros-perception/perception_pcl/issues/9
 #  src/color_filter_nodelet.cpp
 )
 


### PR DESCRIPTION
add filter.cpp to jsk_pcl_ros on rosbuild. because resize points publisher requires it.

this is a hotfix, so I will re-implement that nodelet w/o filter.cpp
