### PR TITLE
include filter.cpp in libjsk_pcl_ros.so

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -79,9 +79,9 @@ jsk_pcl_nodelet(src/rgb_color_filter_nodelet.cpp
 
 rosbuild_add_library (jsk_pcl_ros
   ${jsk_pcl_nodelet_sources}
-# ${pcl_ros_PACKAGE_PATH}/src/pcl_ros/features/feature.cpp
+#  ${pcl_ros_PACKAGE_PATH}/src/pcl_ros/features/feature.cpp
   src/filter.cpp # copy from pcl_ros https://github.com/ros-perception/perception_pcl/issues/9
-# src/color_filter_nodelet.cpp
+#  src/color_filter_nodelet.cpp
 )
 
 rosbuild_add_compile_flags (jsk_pcl_ros ${SSE_FLAGS})


### PR DESCRIPTION
Include filter.cpp in libjsk_pcl_ros.so.
Otherwise, following errors occur.

```
[ERROR] [1399945392.855390625]: Failed to load nodelet [/l_forearm_cam/lhand_resized_rotated] of type [jsk_pcl/ImageRotateNodelet]: Failed to load library /home/applications/ros
/groovy/jsk-ros-pkg/jsk_recognition/jsk_pcl_ros/lib/libjsk_pcl_ros.so. Make sure that you are calling the PLUGINLIB_EXPORT_CLASS macro in the library code, and that names are co
nsistent between this macro and your XML. Error string: Could not load library (Poco exception = /home/applications/ros/groovy/jsk-ros-pkg/jsk_recognition/jsk_pcl_ros/lib/libjsk
_pcl_ros.so: undefined symbol: _ZN11jsk_pcl_ros6Filter15config_callbackERN7pcl_ros12FilterConfigEj)
[ERROR] [1399945393.062348524]: Failed to load nodelet [/r_forearm_cam/rhand_resized_rotated] of type [jsk_pcl/ImageRotateNodelet]: MultiLibraryClassLoader: Could not create obj
ect of class type ImageRotateNodelet as no factory exists for it. Make sure that the library exists and was explicitly loaded through MultiLibraryClassLoader::loadLibrary()
```
