### PR TITLE
Pulish output polygons as convex hull

### DIFF
--- a/jsk_pcl_ros/catkin.cmake
+++ b/jsk_pcl_ros/catkin.cmake
@@ -20,6 +20,7 @@ find_package(catkin REQUIRED COMPONENTS dynamic_reconfigure pcl_ros nodelet mess
   eigen_conversions tf_conversions tf2_ros tf image_transport nodelet cv_bridge)
 
 add_message_files(FILES IndicesArray.msg PointsArray.msg ClusterPointIndices.msg Int32Stamped.msg SnapItRequest.msg PolygonArray.msg
+  ModelCoefficientsArray.msg
   SlicedPointCloud.msg)
 add_service_files(FILES SwitchTopic.srv  TransformScreenpoint.srv CheckCircle.srv RobotPickupReleasePoint.srv  TowerPickUp.srv EuclideanSegment.srv TowerRobotMoveCommand.srv SetPointCloud2.srv
   CallSnapIt.srv CallPolygon.srv)

--- a/jsk_pcl_ros/cfg/OrganizedMultiPlaneSegmentation.cfg
+++ b/jsk_pcl_ros/cfg/OrganizedMultiPlaneSegmentation.cfg
@@ -21,6 +21,7 @@ gen.add("max_curvature", double_t, 0, "maximum curvature of organized plane segm
 gen.add("connect_plane_angle_threshold", double_t, 0, "plane angle threshold of connecting the planes", 0.1, 0, pi)
 gen.add("connect_plane_distance_threshold", double_t, 0, "plane distance threshold of connecting the planes", 0.01, 0, 1.0)
 gen.add("connect_distance_threshold", double_t, 0, "distance threshold of connectin the planes", 0.1, 0, 1.0)
+#gen.add("concave_alpha", double_t, 0, "alpha parameter for concave estimation", 0.1, 0, 1.0)
 
 exit (gen.generate (PACKAGE, "jsk_pcl_ros", "OrganizedMultiPlaneSegmentation"))
 

--- a/jsk_pcl_ros/include/jsk_pcl_ros/organized_multi_plane_segmentation.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/organized_multi_plane_segmentation.h
@@ -45,17 +45,18 @@
 #include <pcl/segmentation/organized_multi_plane_segmentation.h>
 #include <dynamic_reconfigure/server.h>
 #include "jsk_pcl_ros/OrganizedMultiPlaneSegmentationConfig.h"
-
+#include "jsk_pcl_ros/PolygonArray.h"
 namespace jsk_pcl_ros
 {
   class OrganizedMultiPlaneSegmentation: public pcl_ros::PCLNodelet
   {
   public:
   protected:
-    ros::Publisher org_pub_, org_polygon_pub_;
-    ros::Publisher pub_, polygon_pub_;
+    ros::Publisher org_pub_, org_polygon_pub_, org_coefficients_pub_;
+    ros::Publisher pub_, polygon_pub_, coefficients_pub_;
     ros::Subscriber sub_;
     int min_size_;
+    double concave_alpha_;
     double angular_threshold_;
     double distance_threshold_;
     double max_curvature_;
@@ -67,6 +68,25 @@ namespace jsk_pcl_ros
     boost::mutex mutex_;
     virtual void segment(const sensor_msgs::PointCloud2::ConstPtr& msg);
     virtual void configCallback (Config &config, uint32_t level);
+    virtual void pointCloudToPolygon(const pcl::PointCloud<pcl::PointNormal>& input,
+                                     geometry_msgs::Polygon& polygon);
+    virtual void pclIndicesArrayToClusterPointIndices(const std::vector<pcl::PointIndices>& inlier_indices,
+                                                      const std_msgs::Header& header,
+                                                      jsk_pcl_ros::ClusterPointIndices& output_indices);
+    virtual void connectPlanesMap(const pcl::PointCloud<pcl::PointNormal>::Ptr& input,
+                                  const std::vector<pcl::ModelCoefficients>& model_coefficients,
+                                  const std::vector<pcl::PointIndices>& boundary_indices,
+                                  std::vector<std::map<size_t, bool> >& connection_map);
+    virtual void buildConnectedPlanes(const pcl::PointCloud<pcl::PointNormal>::Ptr& input,
+                                      const std_msgs::Header& header,
+                                      const std::vector<pcl::PointIndices>& inlier_indices,
+                                      const std::vector<pcl::PointIndices>& boundary_indices,
+                                      const std::vector<pcl::ModelCoefficients>& model_coefficients,
+                                      std::vector<std::map<size_t, bool> > connection_map,
+                                      std::vector<pcl::PointIndices>& output_indices,
+                                      std::vector<pcl::ModelCoefficients>& output_coefficients,
+                                      std::vector<pcl::PointCloud<pcl::PointNormal> >& output_boundary_clouds);
+      
   private:
     virtual void onInit();
   };

--- a/jsk_pcl_ros/msg/ModelCoefficientsArray.msg
+++ b/jsk_pcl_ros/msg/ModelCoefficientsArray.msg
@@ -1,0 +1,2 @@
+Header header
+pcl_msgs/ModelCoefficients[] coefficients

--- a/jsk_pcl_ros/src/organized_multi_plane_segmentation_nodelet.cpp
+++ b/jsk_pcl_ros/src/organized_multi_plane_segmentation_nodelet.cpp
@@ -34,21 +34,26 @@
  *********************************************************************/
 
 #include "jsk_pcl_ros/organized_multi_plane_segmentation.h"
-#include "jsk_pcl_ros/PolygonArray.h"
+#include "jsk_pcl_ros/ModelCoefficientsArray.h"
 #include <pcl/segmentation/impl/organized_multi_plane_segmentation.hpp>
 #include <pcl/filters/extract_indices.h>
 #include <pcl/kdtree/kdtree_flann.h>
 #include <set>
-#include<Eigen/StdVector>
+#include <Eigen/StdVector>
+#include <pcl/surface/convex_hull.h>
+#include <pcl/filters/project_inliers.h>
+
 
 #include <pluginlib/class_list_macros.h>
 
 #if ROS_VERSION_MINIMUM(1, 10, 0)
 // hydro and later
 typedef pcl_msgs::PointIndices PCLIndicesMsg;
+typedef pcl_msgs::ModelCoefficients PCLModelCoefficientMsg;
 #else
 // groovy
 typedef pcl::PointIndices PCLIndicesMsg;
+typedef pcl::ModelCoefficients PCLModelCoefficientMsg;
 #endif
 
 
@@ -60,8 +65,10 @@ namespace jsk_pcl_ros
     PCLNodelet::onInit();
     pub_ = pnh_->advertise<jsk_pcl_ros::ClusterPointIndices>("output", 1);
     polygon_pub_ = pnh_->advertise<jsk_pcl_ros::PolygonArray>("output_polygon", 1);
+    coefficients_pub_ = pnh_->advertise<jsk_pcl_ros::ModelCoefficientsArray>("output_coefficients", 1);
     org_pub_ = pnh_->advertise<jsk_pcl_ros::ClusterPointIndices>("output_nonconnected", 1);
     org_polygon_pub_ = pnh_->advertise<jsk_pcl_ros::PolygonArray>("output_nonconnected_polygon", 1);
+    org_coefficients_pub_ = pnh_->advertise<jsk_pcl_ros::ModelCoefficientsArray>("output_nonconnected_coefficients", 1);
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&OrganizedMultiPlaneSegmentation::configCallback, this, _1, _2);
@@ -73,91 +80,26 @@ namespace jsk_pcl_ros
   void OrganizedMultiPlaneSegmentation::configCallback(Config &config, uint32_t level)
   {
     boost::mutex::scoped_lock(mutex_);
-    if (min_size_ != config.min_size) {
-      min_size_ = config.min_size;
-    }
-    if (angular_threshold_ != config.angular_threshold) {
-      angular_threshold_ = config.angular_threshold;
-    }
-    if (distance_threshold_ != config.distance_threshold) {
-      distance_threshold_ = config.distance_threshold;
-    }
-    if (max_curvature_ != config.max_curvature) {
-      max_curvature_ = config.max_curvature;
-    }
-    if (connect_plane_angle_threshold_ != config.connect_plane_angle_threshold) {
-      connect_plane_angle_threshold_ = config.connect_plane_angle_threshold;
-    }
-    if (connect_plane_distance_threshold_ != config.connect_plane_distance_threshold) {
-      connect_plane_distance_threshold_ = config.connect_plane_distance_threshold;
-    }
-    if (connect_distance_threshold_ != config.connect_distance_threshold) {
-      connect_distance_threshold_ = config.connect_distance_threshold;
-    }
+    min_size_ = config.min_size;
+    angular_threshold_ = config.angular_threshold;
+    distance_threshold_ = config.distance_threshold;
+    max_curvature_ = config.max_curvature;
+    connect_plane_angle_threshold_ = config.connect_plane_angle_threshold;
+    connect_plane_distance_threshold_ = config.connect_plane_distance_threshold;
+    connect_distance_threshold_ = config.connect_distance_threshold;
+    //concave_alpha_ = config.concave_alpha;
   }
-  
-  void OrganizedMultiPlaneSegmentation::segment
-  (const sensor_msgs::PointCloud2::ConstPtr& msg)
+
+  void OrganizedMultiPlaneSegmentation::connectPlanesMap(const pcl::PointCloud<pcl::PointNormal>::Ptr& input,
+                                                         const std::vector<pcl::ModelCoefficients>& model_coefficients,
+                                                         const std::vector<pcl::PointIndices>& boundary_indices,
+                                                         std::vector<std::map<size_t, bool> >& connection_map)
   {
-    boost::mutex::scoped_lock(mutex_);
-    pcl::PointCloud<pcl::PointNormal> input;
-    pcl::fromROSMsg(*msg, input);
-    pcl::OrganizedMultiPlaneSegmentation<pcl::PointNormal, pcl::PointNormal, pcl::Label> mps;
-    mps.setMinInliers(min_size_);
-    mps.setAngularThreshold(angular_threshold_);
-    mps.setDistanceThreshold(distance_threshold_);
-    mps.setMaximumCurvature(max_curvature_);
-    mps.setInputCloud(input.makeShared());
-    mps.setInputNormals(input.makeShared());
-
-    std::vector<pcl::PlanarRegion<pcl::PointNormal>, Eigen::aligned_allocator<pcl::PlanarRegion<pcl::PointNormal> > > regions;
-    std::vector<pcl::ModelCoefficients> model_coefficients;
-    std::vector<pcl::PointIndices> inlier_indices;
-    pcl::PointCloud<pcl::Label>::Ptr labels (new pcl::PointCloud<pcl::Label>());
-    std::vector<pcl::PointIndices> label_indices;
-    std::vector<pcl::PointIndices> boundary_indices;
-    
-    mps.segmentAndRefine(regions, model_coefficients, inlier_indices, labels, label_indices, boundary_indices);
-    {
-      jsk_pcl_ros::ClusterPointIndices indices;
-      jsk_pcl_ros::PolygonArray polygon_array;
-      indices.header = msg->header;
-      polygon_array.header = msg->header;
-      for (size_t i = 0; i < inlier_indices.size(); i++) {
-        pcl::PointIndices inlier = inlier_indices[i];
-        PCLIndicesMsg one_indices;
-        one_indices.indices = inlier.indices;
-        one_indices.header = msg->header;
-        indices.cluster_indices.push_back(one_indices);
-        geometry_msgs::PolygonStamped polygon;
-        polygon.header = msg->header;
-        for (size_t j = 0; j < boundary_indices[i].indices.size(); j++) {
-          geometry_msgs::Point32 point;
-          point.x = input.points[boundary_indices[i].indices[j]].x;
-          point.y = input.points[boundary_indices[i].indices[j]].y;
-          point.z = input.points[boundary_indices[i].indices[j]].z;
-          polygon.polygon.points.push_back(point);
-        }
-        polygon_array.polygons.push_back(polygon);
-      }
-      org_pub_.publish(indices);
-      org_polygon_pub_.publish(polygon_array);
-      if (regions.size() == 0) {
-        pub_.publish(indices);
-        return;
-      }
-    }
-
-    // connection
-    // this might be slow...
-    ros::Time before_connect_time = ros::Time::now();
-    NODELET_DEBUG("checking %lu connection", regions.size());
     pcl::ExtractIndices<pcl::PointNormal> extract;
-    extract.setInputCloud(input.makeShared());
-    std::vector<std::map<size_t, bool> > connection_map;
-    connection_map.resize(regions.size());
-    for (size_t i = 0; i < regions.size() - 1; i++) {
-      for (size_t j = i + 1; j < regions.size(); j++) {
+    extract.setInputCloud(input);
+    connection_map.resize(model_coefficients.size());
+    for (size_t i = 0; i < model_coefficients.size() - 1; i++) {
+      for (size_t j = i + 1; j < model_coefficients.size(); j++) {
         // check if i and j can be connected
         pcl::ModelCoefficients a_coefficient = model_coefficients[i];
         pcl::ModelCoefficients b_coefficient = model_coefficients[j];
@@ -222,61 +164,224 @@ namespace jsk_pcl_ros
         }
       }
     }
+  }
 
-    // connect the clouds
+  void OrganizedMultiPlaneSegmentation::pclIndicesArrayToClusterPointIndices(const std::vector<pcl::PointIndices>& inlier_indices,
+                                                                             const std_msgs::Header& header,
+                                                                             jsk_pcl_ros::ClusterPointIndices& output_indices)
+  {
+    for (size_t i = 0; i < inlier_indices.size(); i++) {
+      pcl::PointIndices inlier = inlier_indices[i];
+      PCLIndicesMsg one_indices;
+      one_indices.header = header;
+      one_indices.indices = inlier.indices;
+      output_indices.cluster_indices.push_back(one_indices);
+    }
+  }
+  
+  void OrganizedMultiPlaneSegmentation::pointCloudToPolygon(const pcl::PointCloud<pcl::PointNormal>& input,
+                                                            geometry_msgs::Polygon& polygon)
+  {
+    for (size_t i = 0; i < input.points.size(); i++) {
+      geometry_msgs::Point32 point;
+      point.x = input.points[i].x;
+      point.y = input.points[i].y;
+      point.z = input.points[i].z;
+      polygon.points.push_back(point);
+    }
+  }
+  
+  void OrganizedMultiPlaneSegmentation::buildConnectedPlanes(const pcl::PointCloud<pcl::PointNormal>::Ptr& input,
+                                                             const std_msgs::Header& header,
+                                                             const std::vector<pcl::PointIndices>& inlier_indices,
+                                                             const std::vector<pcl::PointIndices>& boundary_indices,
+                                                             const std::vector<pcl::ModelCoefficients>& model_coefficients,
+                                                             std::vector<std::map<size_t, bool> > connection_map,
+                                                             std::vector<pcl::PointIndices>& output_indices,
+                                                             std::vector<pcl::ModelCoefficients>& output_coefficients,
+                                                             std::vector<pcl::PointCloud<pcl::PointNormal> >& output_boundary_clouds)
+  { 
+    std::vector<std::set<int> > cloud_sets;
+    for (size_t i = 0; i < connection_map.size(); i++) {
+      bool i_done = false;
+      // check i is included in cloud_sets
+      for (size_t j = 0; j < cloud_sets.size(); j++) {
+        if (cloud_sets[j].find(i) != cloud_sets[j].end()) {
+          // i is included in cloud_sets[j]
+          NODELET_DEBUG("%lu is included in cloud_sets[%lu]", i, j);
+          for (std::map<size_t, bool>::iterator it = connection_map[i].begin();
+               it != connection_map[i].end(); it++) {
+            NODELET_DEBUG("%lu -> %lu", (*it).first, j);
+            cloud_sets[j].insert((*it).first);
+          }
+          i_done = true;
+          break;
+        }
+      }
+      // i is not yet included in cloud_sets
+      if (!i_done) {
+        std::set<int> new_set;
+        new_set.insert(i);
+        for (std::map<size_t, bool>::iterator it = connection_map[i].begin();
+             it != connection_map[i].end(); it++) {
+          new_set.insert((*it).first);
+        }
+        cloud_sets.push_back(new_set);
+      }
+    }
+      
+    for (size_t i = 0; i < cloud_sets.size(); i++) {
+      NODELET_DEBUG("%lu cloud", i);
+      
+      pcl::PointIndices one_indices;
+      pcl::PointIndices one_boundaries;
+      for (std::set<int>::iterator it = cloud_sets[i].begin();
+           it != cloud_sets[i].end();
+           it++) {
+        NODELET_DEBUG("%lu includes %d", i, *it);
+        pcl::PointIndices inlier = inlier_indices[*it];
+        pcl::PointIndices boundary_inlier = boundary_indices[*it];
+        // append indices...
+        for (size_t j = 0; j < inlier.indices.size(); j++) {
+          one_indices.indices.push_back(inlier.indices[j]);
+        }
+        for (size_t j = 0; j < boundary_inlier.indices.size(); j++) {
+          one_boundaries.indices.push_back(boundary_inlier.indices[j]);
+        }
+      }
+      if (one_indices.indices.size() == 0) {
+        continue;
+      }
+      output_indices.push_back(one_indices);
+      output_coefficients.push_back(model_coefficients[(*cloud_sets[i].begin())]);
+      // estimate concave hull
+
+      pcl::PointCloud<pcl::PointNormal>::Ptr cloud_projected (new pcl::PointCloud<pcl::PointNormal>());
+      pcl::PointIndices::Ptr indices_ptr = boost::make_shared<pcl::PointIndices>(one_boundaries);
+      pcl::ProjectInliers<pcl::PointNormal> proj;
+      proj.setModelType (pcl::SACMODEL_PLANE);
+      proj.setIndices (indices_ptr);
+      proj.setInputCloud (input);
+      proj.setModelCoefficients (boost::make_shared<pcl::ModelCoefficients>(output_coefficients[i]));
+      proj.filter (*cloud_projected);
+      
+      pcl::ConvexHull<pcl::PointNormal> chull;
+      chull.setInputCloud(input);
+      chull.setDimension(2);
+      //chull.setAlpha(concave_alpha_);      // should be parameterized
+      chull.setInputCloud(cloud_projected);
+      pcl::PointCloud<pcl::PointNormal> chull_output;
+      chull.reconstruct(chull_output);
+      output_boundary_clouds.push_back(chull_output);
+    }
+
+  }
+  
+  void OrganizedMultiPlaneSegmentation::segment
+  (const sensor_msgs::PointCloud2::ConstPtr& msg)
+  {
+    boost::mutex::scoped_lock(mutex_);
+    pcl::PointCloud<pcl::PointNormal>::Ptr input(new pcl::PointCloud<pcl::PointNormal>());
+    pcl::fromROSMsg(*msg, *input);
+    pcl::OrganizedMultiPlaneSegmentation<pcl::PointNormal, pcl::PointNormal, pcl::Label> mps;
+    mps.setMinInliers(min_size_);
+    mps.setAngularThreshold(angular_threshold_);
+    mps.setDistanceThreshold(distance_threshold_);
+    mps.setMaximumCurvature(max_curvature_);
+    mps.setInputCloud(input);
+    mps.setInputNormals(input);
+
+    std::vector<pcl::PlanarRegion<pcl::PointNormal>, Eigen::aligned_allocator<pcl::PlanarRegion<pcl::PointNormal> > > regions;
+    std::vector<pcl::ModelCoefficients> model_coefficients;
+    std::vector<pcl::PointIndices> inlier_indices;
+    pcl::PointCloud<pcl::Label>::Ptr labels (new pcl::PointCloud<pcl::Label>());
+    std::vector<pcl::PointIndices> label_indices;
+    std::vector<pcl::PointIndices> boundary_indices;
+    
+    mps.segmentAndRefine(regions, model_coefficients, inlier_indices, labels, label_indices, boundary_indices);
+    if (regions.size() == 0) {
+      NODELET_DEBUG("no region is segmented");
+      return;
+    }
+    
     {
+      jsk_pcl_ros::ClusterPointIndices indices;
+      jsk_pcl_ros::ModelCoefficientsArray coefficients_array;
+      jsk_pcl_ros::PolygonArray polygon_array;
+      indices.header = msg->header;
+      polygon_array.header = msg->header;
+      coefficients_array.header = msg->header;
+      pclIndicesArrayToClusterPointIndices(inlier_indices, msg->header,
+                                           indices);
+      pcl::ExtractIndices<pcl::PointNormal> extract;
+      extract.setInputCloud(input);
+      for (size_t i = 0; i < regions.size(); i++) {
+        pcl::PointCloud<pcl::PointNormal> boundary_cloud;
+        pcl::PointIndices::Ptr indices_ptr = boost::make_shared<pcl::PointIndices>(boundary_indices[i]);
+        extract.setIndices(indices_ptr);
+        extract.filter(boundary_cloud);
+        geometry_msgs::PolygonStamped polygon;
+        pointCloudToPolygon(boundary_cloud, polygon.polygon);
+        polygon.header = msg->header;
+        polygon_array.polygons.push_back(polygon);
+      }
+      org_pub_.publish(indices);
+      org_polygon_pub_.publish(polygon_array);
+
+      // coefficients
+      for (size_t i = 0; i < model_coefficients.size(); i++) {
+        PCLModelCoefficientMsg coefficient;
+        coefficient.values = model_coefficients[i].values;
+        coefficient.header = msg->header;
+        coefficients_array.coefficients.push_back(coefficient);
+      }
+      org_coefficients_pub_.publish(coefficients_array);
+    }
+
+    // connection
+    // this might be slow...
+    ros::Time before_connect_time = ros::Time::now();
+    NODELET_DEBUG("checking %lu connection", regions.size());
+    
+    std::vector<std::map<size_t, bool> > connection_map;
+    connectPlanesMap(input, model_coefficients, boundary_indices, connection_map);
+
+    {
+      std::vector<pcl::PointIndices> output_indices;
+      std::vector<pcl::ModelCoefficients> output_coefficients;
+      std::vector<pcl::PointCloud<pcl::PointNormal> > output_boundary_clouds;
+    
+      buildConnectedPlanes(input, msg->header,
+                           inlier_indices,
+                           boundary_indices,
+                           model_coefficients,
+                           connection_map,
+                           output_indices, output_coefficients, output_boundary_clouds);
+
+      
       jsk_pcl_ros::ClusterPointIndices indices;
       jsk_pcl_ros::PolygonArray polygon_array;
       indices.header = msg->header;
       polygon_array.header = msg->header;
-      std::vector<bool> skip_list;
-      skip_list.resize(connection_map.size());
-      std::vector<std::set<int> > cloud_sets;
-      for (size_t i = 0; i < connection_map.size(); i++) {
-        bool i_done = false;
-        // check i is included in cloud_sets
-        for (size_t j = 0; j < cloud_sets.size(); j++) {
-          if (cloud_sets[j].find(i) != cloud_sets[j].end()) {
-            // i is included in cloud_sets[j]
-            NODELET_DEBUG("%lu is included in cloud_sets[%lu]", i, j);
-            for (std::map<size_t, bool>::iterator it = connection_map[i].begin();
-                 it != connection_map[i].end(); it++) {
-              NODELET_DEBUG("%lu -> %lu", (*it).first, j);
-              cloud_sets[j].insert((*it).first);
-            }
-            i_done = true;
-            break;
-          }
-        }
-        // i is not yet included in cloud_sets
-        if (!i_done) {
-          std::set<int> new_set;
-          new_set.insert(i);
-          for (std::map<size_t, bool>::iterator it = connection_map[i].begin();
-               it != connection_map[i].end(); it++) {
-            new_set.insert((*it).first);
-          }
-          cloud_sets.push_back(new_set);
-        }
-      }
-      
-      for (size_t i = 0; i < cloud_sets.size(); i++) {
-        NODELET_DEBUG("%lu cloud", i);
-        PCLIndicesMsg one_indices;
-        one_indices.header = msg->header;
-        for (std::set<int>::iterator it = cloud_sets[i].begin();
-             it != cloud_sets[i].end();
-             it++) {
-          NODELET_DEBUG("%lu includes %d", i, *it);
-          pcl::PointIndices inlier = inlier_indices[*it];
-          // append indices...
-          for (size_t j = 0; j < inlier.indices.size(); j++) {
-            one_indices.indices.push_back(inlier.indices[j]);
-          }
-        }
-        indices.cluster_indices.push_back(one_indices);
+      pclIndicesArrayToClusterPointIndices(output_indices, msg->header,
+                                           indices);
+      for (size_t i = 0; i < output_boundary_clouds.size(); i++) {
+        geometry_msgs::PolygonStamped polygon;
+        polygon.header = msg->header;
+        pointCloudToPolygon(output_boundary_clouds[i], polygon.polygon);
+        polygon_array.polygons.push_back(polygon);
       }
       pub_.publish(indices);
+      polygon_pub_.publish(polygon_array);
+      
+      jsk_pcl_ros::ModelCoefficientsArray coefficients_array;
+      for (size_t i = 0; i < output_coefficients.size(); i++) {
+        PCLModelCoefficientMsg coefficient;
+        coefficient.values = output_coefficients[i].values;
+        coefficient.header = msg->header;
+        coefficients_array.coefficients.push_back(coefficient);
+      }
+      coefficients_pub_.publish(coefficients_array);
     }
     
     ros::Time after_connect_time = ros::Time::now();


### PR DESCRIPTION
- add new message: ModelCoefficientsArray
- publish the boundary points of the result of the clustering (with connecting the planes) as PolygonArray.
  the outputs are reconstructed by Convex Hull.
- publish model coefficients to `~output_coefficients` and `~output_nonconnected_coefficients`

![screenshot from 2014-05-17 14 29 18](https://cloud.githubusercontent.com/assets/40454/3004195/6039fd12-dd84-11e3-9bab-b2380876b786.png)
