### PR TITLE
use enum to select estimation method of NormalEstimationIntegralImage

### DIFF
--- a/jsk_pcl_ros/cfg/NormalEstimationIntegralImage.cfg
+++ b/jsk_pcl_ros/cfg/NormalEstimationIntegralImage.cfg
@@ -15,9 +15,14 @@ from math import pi
 
 gen = ParameterGenerator ()
 
+estimation_method_enum = gen.enum([gen.const("AVERAGE_3D_GRADIENT", int_t, 0, "AVERAGE 3D GRADIENT, no curvature is available"),
+                                   gen.const("COVARIANCE_MATRIX", int_t, 1, "COVARIANCE_MATRIX, curvature is available"),
+                                   gen.const("AVERAGE_DEPTH_CHANGE", int_t, 2, "AVERAGE_DEPTH_CHANGE, no curvature is available")],
+                                   "normal estimation method")
+
 gen.add("max_depth_change_factor", double_t, 0, "max depth change factor", 0.02, 0.0, 1.0)
 gen.add("normal_smoothing_size", double_t, 0, "normal smoothing size parameter", 20.0, 0.0, 100.0)
-gen.add("estimation_method", int_t, 0, "estimation method", 0, 0, 2)
+gen.add("estimation_method", int_t, 0, "estimation method", 1, 0, 2, edit_method = estimation_method_enum)
 gen.add("depth_dependent_smoothing", bool_t, 0, "use depth dependent smoothing", False)
 gen.add("border_policy_ignore", bool_t, 0, "ignore border policy", True)
 exit (gen.generate (PACKAGE, "jsk_pcl_ros", "NormalEstimationIntegralImage"))

--- a/jsk_pcl_ros/cfg/OrganizedMultiPlaneSegmentation.cfg
+++ b/jsk_pcl_ros/cfg/OrganizedMultiPlaneSegmentation.cfg
@@ -16,7 +16,7 @@ from math import pi
 gen = ParameterGenerator ()
 gen.add("min_size", int_t, 0, "the minimum number of the points of each cluster", 2000, 0, 10000)
 gen.add("distance_threshold", double_t, 0, "distance threshold of organized plane segmentation", 0.01, 0, 1.0)
-gen.add("angular_threshold", double_t, 0, "angular threshold of organized plane segmentation", 0.005, 0, 0.1)
+gen.add("angular_threshold", double_t, 0, "angular threshold of organized plane segmentation", 0.05, 0, 0.1)
 gen.add("max_curvature", double_t, 0, "maximum curvature of organized plane segmentation", 0.001, 0, 10.0)
 gen.add("connect_plane_angle_threshold", double_t, 0, "plane angle threshold of connecting the planes", 0.2, 0, pi)
 gen.add("connect_plane_distance_threshold", double_t, 0, "plane distance threshold of connecting the planes", 0.03, 0, 1.0)


### PR DESCRIPTION
- use enum edit to select estimation method of NormalEstimationIntegralImage
- change the default parameters for the method to covariance matrix

![screenshot_from_2014-05-23_21_49_07](https://cloud.githubusercontent.com/assets/40454/3066658/89b09888-e278-11e3-9091-a1a3e9707d61.png)
