### PR TITLE
SelectedClusterPublisher: a nodelet to publith the points inside of the selected box

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -88,7 +88,8 @@ jsk_pcl_nodelet(src/normal_estimation_integral_image_nodelet.cpp
 #  "jsk_pcl/OrganizedMultiPlaneSegmentation" "organized_multi_plane_segmentation")
 jsk_pcl_nodelet(src/multi_plane_extraction_nodelet.cpp
   "jsk_pcl/MultiPlaneExtraction" "multi_plane_extraction")
-
+jsk_pcl_nodelet(src/selected_cluster_publisher_nodelet.cpp
+  "jsk_pcl/SelectedClusterPublisher" "selected_cluster_publisher")
 rosbuild_add_library (jsk_pcl_ros
   ${jsk_pcl_nodelet_sources}
 #  ${pcl_ros_PACKAGE_PATH}/src/pcl_ros/features/feature.cpp

--- a/jsk_pcl_ros/catkin.cmake
+++ b/jsk_pcl_ros/catkin.cmake
@@ -112,6 +112,9 @@ jsk_pcl_nodelet(src/organized_multi_plane_segmentation_nodelet.cpp
 jsk_pcl_nodelet(src/multi_plane_extraction_nodelet.cpp
   "jsk_pcl/MultiPlaneExtraction" "multi_plane_extraction")
 
+jsk_pcl_nodelet(src/selected_cluster_publisher_nodelet.cpp
+  "jsk_pcl/SelectedClusterPublisher" "selected_cluster_publisher")
+
 add_library(jsk_pcl_ros SHARED ${jsk_pcl_nodelet_sources})
 target_link_libraries(jsk_pcl_ros ${catkin_LIBRARIES} ${pcl_ros_LIBRARIES} ${OpenCV_LIBRARIES})
 add_dependencies(jsk_pcl_ros ${PROJECT_NAME}_gencpp ${PROJECT_NAME}_gencfg)

--- a/jsk_pcl_ros/include/jsk_pcl_ros/selected_cluster_publisher.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/selected_cluster_publisher.h
@@ -1,0 +1,69 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Ryohei Ueda and JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#ifndef JSK_PCL_ROS_SELECTED_CLUSTER_PUBLISHER_H_
+#define JSK_PCL_ROS_SELECTED_CLUSTER_PUBLISHER_H_
+
+#include <pcl_ros/pcl_nodelet.h>
+#include <pcl_ros/point_cloud.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <jsk_pcl_ros/Int32Stamped.h>
+#include <jsk_pcl_ros/ClusterPointIndices.h>
+#include <message_filters/time_synchronizer.h>
+#include <message_filters/synchronizer.h>
+
+namespace jsk_pcl_ros
+{
+  class SelectedClusterPublisher: public pcl_ros::PCLNodelet
+  {
+  public:
+    typedef message_filters::sync_policies::ExactTime<sensor_msgs::PointCloud2, jsk_pcl_ros::ClusterPointIndices, jsk_pcl_ros::Int32Stamped> SyncPolicy;
+  protected:
+    ros::Publisher pub_;
+    message_filters::Subscriber<sensor_msgs::PointCloud2> sub_input_;
+    message_filters::Subscriber<jsk_pcl_ros::ClusterPointIndices> sub_indices_;
+    message_filters::Subscriber<jsk_pcl_ros::Int32Stamped> sub_index_;
+    boost::shared_ptr<message_filters::Synchronizer<SyncPolicy> >sync_;
+
+    virtual void extract(const sensor_msgs::PointCloud2::ConstPtr& input,
+                         const jsk_pcl_ros::ClusterPointIndices::ConstPtr& indices,
+                         const jsk_pcl_ros::Int32Stamped::ConstPtr& index);
+  private:
+    virtual void onInit();
+  };
+  
+}
+
+#endif

--- a/jsk_pcl_ros/jsk_pcl_nodelets.xml
+++ b/jsk_pcl_ros/jsk_pcl_nodelets.xml
@@ -2,7 +2,12 @@
 
   <class name="jsk_pcl/NormalEstimationIntegralImage" type="NormalEstimationIntegralImage"
          base_class_type="nodelet::Nodelet">
-    <description>estimates normals based on integral image1</description>
+    <description>estimates normals based on integral image</description>
+  </class>
+
+  <class name="jsk_pcl/SelectedClusterPublisher" type="SelectedClusterPublisher"
+         base_class_type="nodelet::Nodelet">
+    <description>publish the points of the clusters according to the selected index</description>
   </class>
 
 

--- a/jsk_pcl_ros/launch/organized_multi_plane_segmentation.launch
+++ b/jsk_pcl_ros/launch/organized_multi_plane_segmentation.launch
@@ -111,18 +111,19 @@
       publish_clouds: false
     </rosparam>
   </node>
+  <node pkg="jsk_interactive_marker"
+        type="bounding_box_marker"
+        name="bounding_box_marker"
+        output="screen"
+        >
+    <remap from="~bounding_box_array" to="cluster_decomposer_final/boxes" />
+  </node>
   <node pkg="nodelet" type="nodelet"
-        name="cluster_decomposer_final2"
-        args="load jsk_pcl/ClusterPointIndicesDecomposer /$(arg MANAGER)"
+        name="selected_cloud"
+        args="load jsk_pcl/SelectedClusterPublisher /$(arg MANAGER)"
         output="screen" clear_params="true">
     <remap from="~input" to="/plane_extraction/output" />
-    <remap from="~target" to="/euclidean_clustering/output" />
-    <remap from="~align_planes" to="/multi_plane_estimate/output_polygon" />
-    <remap from="~align_planes_coefficients"
-           to="/multi_plane_estimate/output_coefficients" />
-    <rosparam>
-      align_boxes: false
-      publish_clouds: false
-    </rosparam>
+    <remap from="~indices" to="/euclidean_clustering/output" />
+    <remap from="~selected_index" to="/bounding_box_marker/selected_index" />
   </node>
 </launch>

--- a/jsk_pcl_ros/src/selected_cluster_publisher_nodelet.cpp
+++ b/jsk_pcl_ros/src/selected_cluster_publisher_nodelet.cpp
@@ -1,0 +1,88 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Ryohei Ueda and JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include "jsk_pcl_ros/selected_cluster_publisher.h"
+#include <pluginlib/class_list_macros.h>
+#include <pcl/filters/extract_indices.h>
+
+#if ROS_VERSION_MINIMUM(1, 10, 0)
+// hydro and later
+typedef pcl_msgs::PointIndices PCLIndicesMsg;
+typedef pcl_msgs::ModelCoefficients PCLModelCoefficientMsg;
+#else
+// groovy
+typedef pcl::PointIndices PCLIndicesMsg;
+typedef pcl::ModelCoefficients PCLModelCoefficientMsg;
+#endif
+
+
+namespace jsk_pcl_ros
+{
+  void SelectedClusterPublisher::onInit()
+  {
+    PCLNodelet::onInit();
+    pub_ = pnh_->advertise<pcl::PointCloud<pcl::PointXYZRGBNormal> >("output", 1);
+    sync_ = boost::make_shared<message_filters::Synchronizer<SyncPolicy> >(300); // 100 is enough?
+    sub_input_.subscribe(*pnh_, "input", 1);
+    sub_indices_.subscribe(*pnh_, "indices", 1);
+    sub_index_.subscribe(*pnh_, "selected_index", 1);
+    sync_->connectInput(sub_input_, sub_indices_, sub_index_);
+    sync_->registerCallback(boost::bind(&SelectedClusterPublisher::extract, this, _1, _2, _3));
+  }
+
+  void SelectedClusterPublisher::extract(const sensor_msgs::PointCloud2::ConstPtr& input,
+                                         const jsk_pcl_ros::ClusterPointIndices::ConstPtr& indices,
+                                         const jsk_pcl_ros::Int32Stamped::ConstPtr& index)
+  {
+    if (indices->cluster_indices.size() <= index->data) {
+      NODELET_ERROR("the selected index %d is out of clusters array %lu",
+                    index->data,
+                    indices->cluster_indices.size());
+      return;
+    }
+    pcl::PointCloud<pcl::PointXYZRGBNormal>::Ptr input_cloud (new pcl::PointCloud<pcl::PointXYZRGBNormal>());
+    pcl::fromROSMsg(*input, *input_cloud);
+    pcl::ExtractIndices<pcl::PointXYZRGBNormal> extract;
+    pcl::PointIndices::Ptr pcl_indices (new pcl::PointIndices);
+    pcl_indices->indices = indices->cluster_indices[index->data].indices;
+    extract.setInputCloud(input_cloud);
+    extract.setIndices(pcl_indices);
+    pcl::PointCloud<pcl::PointXYZRGBNormal>::Ptr extracted_cloud(new pcl::PointCloud<pcl::PointXYZRGBNormal>());
+    extract.filter(*extracted_cloud);
+    pub_.publish(extracted_cloud);
+  }
+}
+
+typedef jsk_pcl_ros::SelectedClusterPublisher SelectedClusterPublisher;
+PLUGINLIB_DECLARE_CLASS (jsk_pcl, SelectedClusterPublisher, SelectedClusterPublisher, nodelet::Nodelet);


### PR DESCRIPTION
add new nodelet `jsk_pcl/SelectedClusterPublisher` to publish the points of the cluster specified by `jsk_pcl_ros/Int32Stamped`.

this nodelet is supposed to be used with `jsk_interactive_marker/bounding_box_marker`.
see https://github.com/jsk-ros-pkg/jsk_visualization/pull/72

Red points are the pointclouds selected via `jsk_interactive_marker/bounding_box_marker`

![screenshot_from_2014-05-27 19 39 29](https://cloud.githubusercontent.com/assets/40454/3090356/4301b974-e58b-11e3-89b1-1349b5df6d88.png)
![screenshot_from_2014-05-27 19 39 33](https://cloud.githubusercontent.com/assets/40454/3090357/4301c48c-e58b-11e3-9450-6d8c049d0aa9.png)

`.
