### PR TITLE
add nodelet to publish static jsk_pcl_ros/PolygonArray with timestamp synchronized with the pointclouds

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -92,6 +92,8 @@ jsk_pcl_nodelet(src/selected_cluster_publisher_nodelet.cpp
   "jsk_pcl/SelectedClusterPublisher" "selected_cluster_publisher")
 jsk_pcl_nodelet(src/plane_rejector_nodelet.cpp
   "jsk_pcl/PlaneRejector" "plane_rejector")
+jsk_pcl_nodelet(src/static_polygon_array_publisher_nodelet.cpp
+  "jsk_pcl/StaticPolygonArrayPublisher" "static_polygon_array_publisher")
 rosbuild_add_library (jsk_pcl_ros
   ${jsk_pcl_nodelet_sources}
 #  ${pcl_ros_PACKAGE_PATH}/src/pcl_ros/features/feature.cpp

--- a/jsk_pcl_ros/catkin.cmake
+++ b/jsk_pcl_ros/catkin.cmake
@@ -115,6 +115,8 @@ jsk_pcl_nodelet(src/selected_cluster_publisher_nodelet.cpp
   "jsk_pcl/SelectedClusterPublisher" "selected_cluster_publisher")
 jsk_pcl_nodelet(src/plane_rejector_nodelet.cpp
   "jsk_pcl/PlaneRejector" "plane_rejector")
+jsk_pcl_nodelet(src/static_polygon_array_publisher_nodelet.cpp
+  "jsk_pcl/StaticPolygonArrayPublisher" "static_polygon_array_publisher")
 
 add_library(jsk_pcl_ros SHARED ${jsk_pcl_nodelet_sources})
 target_link_libraries(jsk_pcl_ros ${catkin_LIBRARIES} ${pcl_ros_LIBRARIES} ${OpenCV_LIBRARIES})

--- a/jsk_pcl_ros/include/jsk_pcl_ros/static_polygon_array_publisher.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/static_polygon_array_publisher.h
@@ -1,0 +1,91 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#ifndef JSK_PCL_ROS_STATIC_POLYGON_ARRAY_PUBLISHER_H_
+#define JSK_PCL_ROS_STATIC_POLYGON_ARRAY_PUBLISHER_H_
+
+#include <ros/ros.h>
+#include <ros/names.h>
+#include <sensor_msgs/PointCloud2.h>
+
+#include <pcl_ros/pcl_nodelet.h>
+#include <jsk_pcl_ros/PolygonArray.h>
+#include <jsk_pcl_ros/ModelCoefficientsArray.h>
+
+#include <nodelet/nodelet.h>
+#include <topic_tools/shape_shifter.h>
+
+#if ROS_VERSION_MINIMUM(1, 10, 0)
+// hydro and later
+typedef pcl_msgs::PointIndices PCLIndicesMsg;
+typedef pcl_msgs::ModelCoefficients PCLModelCoefficientMsg;
+#else
+// groovy
+typedef pcl::PointIndices PCLIndicesMsg;
+typedef pcl::ModelCoefficients PCLModelCoefficientMsg;
+#endif
+
+
+namespace jsk_pcl_ros
+{
+
+  class StaticPolygonArrayPublisher: public pcl_ros::PCLNodelet
+  {
+  public:
+  protected:
+    ros::Publisher polygon_pub_, coefficients_pub_;
+    ros::Subscriber sub_;
+    jsk_pcl_ros::PolygonArray polygons_;
+    jsk_pcl_ros::ModelCoefficientsArray coefficients_;
+    ros::Timer periodic_timer_;
+    bool use_periodic_;
+    bool use_message_;
+    double periodic_rate_;      // in Hz
+    std::vector<std::string> frame_ids_;
+    ros::Timer timer_;
+    virtual void onInit();
+    virtual void inputCallback(const sensor_msgs::PointCloud2::ConstPtr& msg);
+    virtual void timerCallback(const ros::TimerEvent& event);
+    virtual void publishPolygon(const ros::Time& stamp);
+    virtual bool readPolygonArray(const std::string& param);
+    virtual bool readFrameIds(const std::string& param);
+    virtual double getXMLDoubleValue(XmlRpc::XmlRpcValue val);
+    virtual PCLModelCoefficientMsg polygonToModelCoefficients(const geometry_msgs::PolygonStamped& polygon);
+  private:
+  };
+
+}
+
+#endif

--- a/jsk_pcl_ros/jsk_pcl_nodelets.xml
+++ b/jsk_pcl_ros/jsk_pcl_nodelets.xml
@@ -1,4 +1,9 @@
 <library path="lib/libjsk_pcl_ros">
+  <class name="jsk_pcl/StaticPolygonArrayPublisher" type="StaticPolygonArrayPublisher"
+         base_class_type="nodelet::Nodelet">
+    <description>publish some static polygons as jsk_pcl_ros/PolygonArray message</description>
+  </class>
+
   <class name="jsk_pcl/PlaneRejector" type="PlaneRejector"
          base_class_type="nodelet::Nodelet">
     <description>rejects the planes which does not satisfy the parameters</description>

--- a/jsk_pcl_ros/launch/hrp2jsknt_footstep_polygon.launch
+++ b/jsk_pcl_ros/launch/hrp2jsknt_footstep_polygon.launch
@@ -1,0 +1,18 @@
+<launch>
+  <arg name="LAUNCH_MANAGER" default="true" />
+  <arg name="MANAGER" default="manager" />
+  <node pkg="nodelet" type="nodelet" name="$(arg MANAGER)"
+        args="manager"
+        if="$(arg LAUNCH_MANAGER)"
+        alaunch-prefix="xterm -e gdb --args"
+        output="screen"/>
+  <node pkg="nodelet" type="nodelet" name="footstep_polygon_publisher"
+        clear_params="true"
+        args="load jsk_pcl/StaticPolygonArrayPublisher /$(arg MANAGER)">
+    <rosparam>
+      use_periodic: true
+      frame_ids: [RLEG_LINK5, LLEG_LINK5]
+      polygon_array: [[[0.178558, -0.077564, -0.10611],[-0.082795, -0.077564, -0.10611],[-0.082795, 0.057564, -0.10611], [0.178558, 0.057564, -0.10611]],[[0.178558, 0.077564, -0.10611],[-0.082795, 0.077564, -0.10611],[-0.082795, -0.057564, -0.10611], [0.178558, -0.057564, -0.10611]]]
+    </rosparam>
+  </node>
+</launch>

--- a/jsk_pcl_ros/src/static_polygon_array_publisher_nodelet.cpp
+++ b/jsk_pcl_ros/src/static_polygon_array_publisher_nodelet.cpp
@@ -1,0 +1,250 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <jsk_pcl_ros/static_polygon_array_publisher.h>
+#include <pluginlib/class_list_macros.h>
+
+namespace jsk_pcl_ros
+{
+
+  void StaticPolygonArrayPublisher::onInit()
+  {
+    PCLNodelet::onInit();
+
+    if(!pnh_->getParam("use_periodic", use_periodic_)) {
+      use_periodic_ = false;
+    }
+    if (!pnh_->getParam("use_message", use_message_)) {
+      use_message_ = false;
+    }
+
+    if (!pnh_->getParam("periodic_rate", periodic_rate_)) {
+      periodic_rate_ = 10.0;    // 10fps
+    }
+    
+    bool frame_id_read_p = readFrameIds("frame_ids");
+    if (!frame_id_read_p) {
+      NODELET_FATAL("failed to read frame_ids from ~frame_ids");
+      return;
+    }
+    
+    bool polygon_read_p = readPolygonArray("polygon_array");
+    if (!polygon_read_p) {
+      NODELET_FATAL("failed to read polygons from ~polygon_array");
+      return;
+    }
+
+    if (frame_ids_.size() != polygons_.polygons.size()) {
+      NODELET_FATAL("the size of frame_ids(%lu) does not match the size of polygons(%lu)",
+                    frame_ids_.size(), polygons_.polygons.size());
+      return;
+    }
+    else {
+      for (size_t i = 0; i < frame_ids_.size(); i++) {
+        polygons_.polygons[i].header.frame_id = frame_ids_[i];
+        coefficients_.coefficients[i].header.frame_id = frame_ids_[i];
+      }
+    }
+    
+    if (!use_periodic_ && !use_message_) {
+      NODELET_FATAL("~use_preiodic nor ~use_message is not true");
+      return;
+    }
+
+    polygon_pub_ = pnh_->advertise<jsk_pcl_ros::PolygonArray>("output_polygons", 1);
+    coefficients_pub_ = pnh_->advertise<jsk_pcl_ros::ModelCoefficientsArray>("output_coefficients", 1);
+    polygons_.header.frame_id = frame_ids_[0];
+    coefficients_.header.frame_id = frame_ids_[0];
+    if (use_periodic_) {
+      timer_ = pnh_->createTimer(ros::Duration(1.0 / periodic_rate_), &StaticPolygonArrayPublisher::timerCallback, this);
+    }
+    if (use_message_) {
+      sub_ = pnh_->subscribe("input", 1, &StaticPolygonArrayPublisher::inputCallback, this);
+    }
+  }
+
+  PCLModelCoefficientMsg StaticPolygonArrayPublisher::polygonToModelCoefficients(const geometry_msgs::PolygonStamped& polygon)
+  {
+    Eigen::Vector3d A, B, C;
+    A[0] = polygon.polygon.points[0].x;
+    A[1] = polygon.polygon.points[0].y;
+    A[2] = polygon.polygon.points[0].z;
+    B[0] = polygon.polygon.points[1].x;
+    B[1] = polygon.polygon.points[1].y;
+    B[2] = polygon.polygon.points[1].z;
+    C[0] = polygon.polygon.points[2].x;
+    C[1] = polygon.polygon.points[2].y;
+    C[2] = polygon.polygon.points[2].z;
+    Eigen::Vector3d n = (B - A).cross(C - A).normalized();
+    double a = n[0];
+    double b = n[1];
+    double c = n[2];
+    double d = a * A[0] + b * A[1] + c * A[2];
+    PCLModelCoefficientMsg coefficient;
+    coefficient.header = polygon.header;
+    coefficient.values.push_back(a);
+    coefficient.values.push_back(b);
+    coefficient.values.push_back(c);
+    coefficient.values.push_back(d);
+    return coefficient;
+  }
+
+  bool StaticPolygonArrayPublisher::readFrameIds(const std::string& param_name)
+  {
+    if (pnh_->hasParam(param_name)) {
+      XmlRpc::XmlRpcValue v;
+      pnh_->param(param_name, v, v);
+      if (v.getType() == XmlRpc::XmlRpcValue::TypeArray) {
+        for (size_t i = 0; i < v.size(); i++) {
+          if (v[i].getType() == XmlRpc::XmlRpcValue::TypeString) {
+            frame_ids_.push_back((std::string)v[i]);
+          }
+          else {
+            NODELET_FATAL("%s[%lu] is not string", param_name.c_str(), i);
+            return false;
+          }
+        }
+      }
+      else {
+        NODELET_FATAL("%s is not array", param_name.c_str());
+        return false;
+      }
+    }
+    else {
+      NODELET_FATAL("no %s is available", param_name.c_str());
+      return false;
+    }
+
+  }
+  
+  /*
+    parameter format is:
+    polygon_array: [[[0, 0, 0], [0, 0, 1], [1, 0, 0]], ...]
+   */
+  bool StaticPolygonArrayPublisher::readPolygonArray(const std::string& param_name)
+  {
+    if (pnh_->hasParam(param_name)) {
+      XmlRpc::XmlRpcValue v;
+      pnh_->param(param_name, v, v);
+      if (v.getType() == XmlRpc::XmlRpcValue::TypeArray) {
+        for (size_t toplevel_i = 0; toplevel_i < v.size(); toplevel_i++) { // polygons
+          XmlRpc::XmlRpcValue polygon_v = v[toplevel_i];
+          geometry_msgs::PolygonStamped polygon;
+          if (polygon_v.getType() == XmlRpc::XmlRpcValue::TypeArray &&
+              polygon_v.size() >= 3) {
+            for (size_t secondlevel_i = 0; secondlevel_i < polygon_v.size(); secondlevel_i++) { // each polygon, vertices
+              XmlRpc::XmlRpcValue vertex_v = polygon_v[secondlevel_i];
+              if (vertex_v.getType() == XmlRpc::XmlRpcValue::TypeArray &&
+                  vertex_v.size() == 3 ) { // vertex_v := [x, y, z]
+                double x = getXMLDoubleValue(vertex_v[0]);
+                double y = getXMLDoubleValue(vertex_v[1]);
+                double z = getXMLDoubleValue(vertex_v[2]);
+                geometry_msgs::Point32 point;
+                point.x = x;
+                point.y = y;
+                point.z = z;
+                polygon.polygon.points.push_back(point);
+              }
+              else {
+                NODELET_FATAL("%s[%lu][%lu] is not array or the length is not 3",
+                              param_name.c_str(), toplevel_i, secondlevel_i);
+                return false;
+              }
+            }
+            polygons_.polygons.push_back(polygon);
+            // estimate model coefficients
+            coefficients_.coefficients.push_back(polygonToModelCoefficients(polygon));
+          }
+          else {
+            NODELET_FATAL("%s[%lu] is not array or not enough points", param_name.c_str(), toplevel_i);
+            return false;
+          }
+        }
+        return true;
+      }
+      else {
+        NODELET_FATAL("%s is not array", param_name.c_str());
+        return false;
+      }
+    }
+    else {
+      NODELET_FATAL("no %s is available on parameter server", param_name.c_str());
+      return false;
+    }
+    return true;
+  }
+  
+  double StaticPolygonArrayPublisher::getXMLDoubleValue(XmlRpc::XmlRpcValue val) {
+    switch(val.getType()) {
+    case XmlRpc::XmlRpcValue::TypeInt:
+      return (double)((int)val);
+    case XmlRpc::XmlRpcValue::TypeDouble:
+      return (double)val;
+    default:
+      return 0;
+    }
+  }
+
+  
+  void StaticPolygonArrayPublisher::inputCallback(const sensor_msgs::PointCloud2::ConstPtr& msg)
+  {
+    publishPolygon(msg->header.stamp);
+  }
+  
+  void StaticPolygonArrayPublisher::timerCallback(const ros::TimerEvent& event)
+  {
+    publishPolygon(event.current_expected);
+  }
+  
+  void StaticPolygonArrayPublisher::publishPolygon(const ros::Time& stamp)
+  {
+    polygons_.header.stamp = stamp;
+    for (size_t i = 0; i < polygons_.polygons.size(); i++) {
+      polygons_.polygons[i].header.stamp = stamp;
+    }
+    
+    coefficients_.header.stamp = stamp;
+    for (size_t i = 0; i < coefficients_.coefficients.size(); i++) {
+      coefficients_.coefficients[i].header.stamp = stamp;
+    }
+    
+    polygon_pub_.publish(polygons_);
+    coefficients_pub_.publish(coefficients_);
+  }
+
+}
+
+typedef jsk_pcl_ros::StaticPolygonArrayPublisher StaticPolygonArrayPublisher;
+PLUGINLIB_DECLARE_CLASS (jsk_pcl, StaticPolygonArrayPublisher, StaticPolygonArrayPublisher, nodelet::Nodelet);
+


### PR DESCRIPTION
add new nodeelt StaticPolygonArrayPublisher to publish the static jsk_pcl_ros/PolygonArray with the timestamp synchronized with the pointcloud.

It must be important to estimate "Ground".

![screenshot_from_2014-06-02 20 48 25](https://cloud.githubusercontent.com/assets/40454/3146744/7f0ff69a-ea4c-11e3-8a30-fe8da1760814.png)
![screenshot_from_2014-06-02 20 48 56](https://cloud.githubusercontent.com/assets/40454/3146753/84807122-ea4c-11e3-942a-aa95d13b2b07.png)
