### PR TITLE
run PCA to compute orientation of bounding box

### DIFF
--- a/jsk_pcl_ros/include/jsk_pcl_ros/cluster_point_indices_decomposer.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/cluster_point_indices_decomposer.h
@@ -91,7 +91,9 @@ namespace jsk_pcl_ros
     virtual void allocatePublishers(size_t num);
     std::vector<std_msgs::ColorRGBA> colors_;
     bool publish_clouds_;
+    bool publish_tf_;
     bool align_boxes_;
+    bool use_pca_;
     
     virtual int findNearestPlane(const Eigen::Vector4f& center,
                                  const jsk_pcl_ros::PolygonArrayConstPtr& planes,

--- a/jsk_pcl_ros/launch/organized_multi_plane_segmentation.launch
+++ b/jsk_pcl_ros/launch/organized_multi_plane_segmentation.launch
@@ -1,4 +1,5 @@
 <launch>
+  <arg name="BASE_FRAME_ID" default="odom" />
   <arg name="INPUT" default="/camera/depth_registered/points" />
   <arg name="LAUNCH_MANAGER" default="true" />
   <arg name="MANAGER" default="manager" />
@@ -89,6 +90,7 @@
            to="/multi_plane_estimate/output_coefficients" />
     <rosparam>
       align_boxes: true
+      use_pca: true
       publish_clouds: false
     </rosparam>
   </node>
@@ -117,15 +119,15 @@
         output="screen" clear_params="true">
     <remap from="~input_polygons" to="/multi_plane_estimate/output_polygon" />
     <remap from="~input_coefficients" to="/multi_plane_estimate/output_coefficients" />
-    <rosparam>
+    <rosparam subst_value="true">
       reference_axis: [0, 0, -1]
-      processing_frame_id: odom
+      processing_frame_id: $(arg BASE_FRAME_ID)
     </rosparam>
   </node>
     <node pkg="nodelet" type="nodelet" name="transform_input"
           args="load jsk_pcl/TfTransformCloud $(arg MANAGER)">
       <remap from="~input" to="input_relay/output" />
-      <param name="target_frame_id" value="odom" />
+      <param name="target_frame_id" value="$(arg BASE_FRAME_ID)" />
     </node>
     <group if="$(arg ESTIMATE_OCCLUSION)">
     <include file="$(find jsk_pcl_ros)/launch/hrp2jsknt_footstep_polygon.launch">
@@ -136,13 +138,13 @@
           args="load jsk_pcl/PolygonArrayTransformer /$(arg MANAGER)">
       <remap from="~input_polygons" to="footstep_polygon_publisher/output_polygons" />
       <remap from="~input_coefficients" to="footstep_polygon_publisher/output_coefficients" />
-      <param name="frame_id" value="odom" />
+      <param name="frame_id" value="$(arg BASE_FRAME_ID)" />
     </node>
     <node pkg="nodelet" type="nodelet" name="estimated_plane_respected_to_odom"
           args="load jsk_pcl/PolygonArrayTransformer /$(arg MANAGER)">
       <remap from="~input_polygons" to="multi_plane_estimate/output_polygon" />
       <remap from="~input_coefficients" to="multi_plane_estimate/output_coefficients" />
-      <param name="frame_id" value="odom" />
+      <param name="frame_id" value="$(arg BASE_FRAME_ID)" />
     </node>
 
     <node pkg="nodelet" type="nodelet" name="polygon_estimator"


### PR DESCRIPTION
run PCA to compute X and Y axis of bounding box. Z axis is estimated from
the normal of the nearest plane.
You can toggle this function via `~use_pca` parameter. (default to False)
- before (X and Y are parallel to sensor coordinates)
  ![screenshot_from_2014-06-20 23 51 23](https://cloud.githubusercontent.com/assets/40454/3341661/842f6c40-f88a-11e3-8543-5424f826c508.png)
- after
  ![screenshot_from_2014-06-22 11 47 04](https://cloud.githubusercontent.com/assets/40454/3350512/b1ab27b2-f9b7-11e3-846f-25fc9281d42f.png)
