### PR TITLE
Add min indices to grid sampler

### DIFF
--- a/jsk_pcl_ros/cfg/GridSampler.cfg
+++ b/jsk_pcl_ros/cfg/GridSampler.cfg
@@ -15,4 +15,5 @@ from math import pi
 
 gen = ParameterGenerator ()
 gen.add("grid_size", double_t, 0, "grid size", 0.2, 0.0, 2.0)
+gen.add("min_indices", int_t, 0, "the minimum numnber of the indices for each grid", 0, 0, 1000)
 exit (gen.generate (PACKAGE, "jsk_pcl_ros", "GridSampler"))

--- a/jsk_pcl_ros/include/jsk_pcl_ros/grid_sampler.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/grid_sampler.h
@@ -55,6 +55,7 @@ namespace jsk_pcl_ros
     virtual void configCallback(Config &config, uint32_t level);
     boost::mutex mutex_;
     double grid_size_;
+    int min_indices_;
     ros::Subscriber sub_;
     ros::Publisher pub_;
     boost::shared_ptr <dynamic_reconfigure::Server<Config> > srv_;

--- a/jsk_pcl_ros/src/grid_sampler_nodelet.cpp
+++ b/jsk_pcl_ros/src/grid_sampler_nodelet.cpp
@@ -60,6 +60,7 @@ namespace jsk_pcl_ros
     }
     else {
       grid_size_ = config.grid_size;
+      min_indices_ = config.min_indices;
     }
   }
 
@@ -143,13 +144,15 @@ namespace jsk_pcl_ros
              zit != zbins.end();
              zit++) {
           std::vector<size_t> indices = zit->second;
-          PCLIndicesMsg ros_indices;
-          ros_indices.header = msg->header;
           NODELET_DEBUG_STREAM("size: " << indices.size());
-          for (size_t j = 0; j < indices.size(); j++) {
-            ros_indices.indices.push_back(indices[j]);
+          if (indices.size() > min_indices_) {
+            PCLIndicesMsg ros_indices;
+            ros_indices.header = msg->header;
+            for (size_t j = 0; j < indices.size(); j++) {
+              ros_indices.indices.push_back(indices[j]);
+            }
+            output.cluster_indices.push_back(ros_indices);
           }
-          output.cluster_indices.push_back(ros_indices);
         }
       }
     }


### PR DESCRIPTION
The minimum number of the points in the grid.

You can ignore "too far grid" by setting `~min_indices` of GridSampler.
- `~min_indices=0`
  ![screenshot_from_2014-06-28 17 41 11](https://cloud.githubusercontent.com/assets/40454/3420254/387a59ec-fea0-11e3-89a8-e75db7c76ca8.png)
- `~min_indices=69`
  ![screenshot_from_2014-06-28 17 41 28](https://cloud.githubusercontent.com/assets/40454/3420255/387a9e34-fea0-11e3-87bd-6812e0384f51.png)
