### PR TITLE
add two nodelets (DelayPointCloud and DepthImageError) to jsk_pcl_ros and publish u/v coordinates of the checkerboard from checkerboard_detector.

### DIFF
--- a/checkerboard_detector/src/objectdetection_tf_publisher.py
+++ b/checkerboard_detector/src/objectdetection_tf_publisher.py
@@ -14,6 +14,7 @@ def callback(msg):
 if __name__== '__main__':
     global object_messages
     object_messages = None
+    frame_id = rospy.get_param("~frame_id", "object")
     rospy.init_node('objectdetection_tf_publisher', anonymous=True)
     subscriber = rospy.Subscriber("ObjectDetection", ObjectDetection, callback)
     r = rospy.Rate(100)
@@ -28,8 +29,8 @@ if __name__== '__main__':
                                   detected_object.pose.orientation.y,
                                   detected_object.pose.orientation.z,
                                   detected_object.pose.orientation.w),
-                                 rospy.Time.now(),
-                                 "/object",
+                                 object_messages.header.stamp,
+                                 frame_id,
                                  object_messages.header.frame_id)
         r.sleep()
 

--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -106,7 +106,10 @@ jsk_pcl_nodelet(src/grid_sampler_nodelet.cpp
   "jsk_pcl/GridSampler" "grid_sampler")
 jsk_pcl_nodelet(src/handle_estimator_nodelet.cpp
   "jsk_pcl/HandleEstimator" "handle_estimator")
-
+jsk_pcl_nodelet(src/delay_pointcloud_nodelet.cpp
+  "jsk_pcl/DelayPointCloud" "delay_pointcloud")
+jsk_pcl_nodelet(src/depth_image_error_nodelet.cpp
+  "jsk_pcl/DepthImageError" "depth_image_error")
 rosbuild_add_library (jsk_pcl_ros
   ${jsk_pcl_nodelet_sources}
   src/grid_index.cpp src/grid_map.cpp src/grid_line.cpp src/geo_util.cpp

--- a/jsk_pcl_ros/catkin.cmake
+++ b/jsk_pcl_ros/catkin.cmake
@@ -159,6 +159,10 @@ jsk_pcl_nodelet(src/grid_sampler_nodelet.cpp
   "jsk_pcl/GridSampler" "grid_sampler")
 jsk_pcl_nodelet(src/handle_estimator_nodelet.cpp
   "jsk_pcl/HandleEstimator" "handle_estimator")
+jsk_pcl_nodelet(src/delay_pointcloud_nodelet.cpp
+  "jsk_pcl/DelayPointCloud" "delay_pointcloud")
+jsk_pcl_nodelet(src/depth_image_error_nodelet.cpp
+  "jsk_pcl/DepthImageError" "depth_image_error")
 
 add_library(jsk_pcl_ros SHARED ${jsk_pcl_nodelet_sources}
   src/grid_index.cpp src/grid_map.cpp src/grid_line.cpp src/geo_util.cpp

--- a/jsk_pcl_ros/include/jsk_pcl_ros/delay_pointcloud.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/delay_pointcloud.h
@@ -1,0 +1,65 @@
+// -*- mode: C++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#ifndef JSK_PCL_ROS_DELAY_POINTCLOUD_H_
+#define JSK_PCL_ROS_DELAY_POINTCLOUD_H_
+
+#include <pcl_ros/pcl_nodelet.h>
+#include <sensor_msgs/PointCloud.h>
+
+namespace jsk_pcl_ros
+{
+
+  class DelayPointCloud: public pcl_ros::PCLNodelet
+  {
+    
+  public:
+    
+  protected:
+    virtual void onInit();
+    virtual void delay(const sensor_msgs::PointCloud2::ConstPtr& msg);
+
+    double sleep_time_;
+    ros::Subscriber sub_;
+    ros::Publisher pub_;
+  private:
+
+  };
+
+}
+
+
+#endif
+

--- a/jsk_pcl_ros/include/jsk_pcl_ros/depth_image_error.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/depth_image_error.h
@@ -1,0 +1,70 @@
+// -*- mode: C++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+
+#ifndef JSK_PCL_ROS_DEPTH_IMAGE_ERROR_H_
+#define JSK_PCL_ROS_DEPTH_IMAGE_ERROR_H_
+
+#include <pcl_ros/pcl_nodelet.h>
+#include <sensor_msgs/Image.h>
+#include <geometry_msgs/PointStamped.h>
+
+#include <message_filters/subscriber.h>
+#include <message_filters/time_synchronizer.h>
+#include <message_filters/synchronizer.h>
+#include <message_filters/sync_policies/approximate_time.h>
+
+namespace jsk_pcl_ros
+{
+  class DepthImageError: public pcl_ros::PCLNodelet
+  {
+  public:
+    typedef message_filters::sync_policies::ApproximateTime<
+    sensor_msgs::Image,
+    geometry_msgs::PointStamped
+     > SyncPolicy;
+    
+  protected:
+    virtual void onInit();
+    virtual void calcError(const sensor_msgs::Image::ConstPtr& depth_image,
+                           const geometry_msgs::PointStamped::ConstPtr& uv_point);
+    message_filters::Subscriber<sensor_msgs::Image> sub_image_;
+    message_filters::Subscriber<geometry_msgs::PointStamped> sub_point_;
+    boost::shared_ptr<message_filters::Synchronizer<SyncPolicy> >sync_;
+  private:
+  };
+}
+
+#endif

--- a/jsk_pcl_ros/jsk_pcl_nodelets.xml
+++ b/jsk_pcl_ros/jsk_pcl_nodelets.xml
@@ -1,4 +1,16 @@
 <library path="lib/libjsk_pcl_ros">
+
+  <class name="jsk_pcl/DepthImageError" type="DepthImageError"
+         base_class_type="nodelet::Nodelet">
+    <description>compute error of depth image</description>
+  </class>
+
+
+  <class name="jsk_pcl/DelayPointCloud" type="DelayPointCloud"
+         base_class_type="nodelet::Nodelet">
+    <description>delay pointcloud messages</description>
+  </class>
+
   <class name="jsk_pcl/PolygonAppender" type="PolygonAppender"
          base_class_type="nodelet::Nodelet">
     <description>append jsk_pcl_ros/PolygonArray </description>

--- a/jsk_pcl_ros/launch/depth_error.launch
+++ b/jsk_pcl_ros/launch/depth_error.launch
@@ -1,0 +1,46 @@
+<launch>
+  <arg name="POINTCLOUD_INPUT" default="/camera_remote/depth_registered/points"/>
+  <arg name="IMAGE_TOPIC"
+       default="/camera_remote/rgb/image_rect_color" />
+  <arg name="DEPTH_IMAGE" default="/camera_remote/depth/image_rect" />
+  <arg name="CAMERA_INFO_TOPIC" default="/camera_remote/rgb/camera_info" />
+  <arg name="CLIP_SIZE" default="0.2" />
+  compute the pose of the checker board from RGB image.
+  <group ns="checkerdetector" clear_params="true">
+    <param name="display" type="int" value="1"/>
+    <!--param name="frame_id" type="string" value="stereo_link"/-->
+    <param name="rect0_size_x" type="double" value="0.03"/>
+    <param name="rect0_size_y" type="double" value="0.03"/>
+    <param name="grid0_size_x" type="int" value="5"/>
+    <param name="grid0_size_y" type="int" value="4"/>
+    <param name="type0" type="string" value="data/ricebox.kinbody.xml"/>
+    
+    publish the pose of the checker board to ObjectDetection with
+    the message type of ObjectDetection
+    <node pkg="checkerboard_detector" name="checkerboard_detector"
+          type="checkerboard_detector" respawn="false"
+          output="log">
+      <remap from="image" to="$(arg IMAGE_TOPIC)" />
+      <remap from="camera_info" to="$(arg CAMERA_INFO_TOPIC)" />
+    </node>
+    
+    conevrt ObjectDetection to tf frame.
+    <node pkg="checkerboard_detector" name="objectdetection_to_tf"
+          type="objectdetection_tf_publisher.py">
+      <param name="frame_id" value="checkerboard" />
+    </node>
+  </group>
+
+  PointCloud Processing.
+  <node pkg="nodelet" type="nodelet" args="manager"
+        output="screen"
+        name="pcl_manager" />
+  <node pkg="nodelet" type="nodelet"
+        name="depth_image_error"
+        output="screen"
+        args="load jsk_pcl/DepthImageError pcl_manager">
+    <remap from="~image" to="$(arg DEPTH_IMAGE)" />
+    <remap from="~point" to="/checkerdetector/corner_point" />
+  </node>
+
+</launch>

--- a/jsk_pcl_ros/src/delay_pointcloud_nodelet.cpp
+++ b/jsk_pcl_ros/src/delay_pointcloud_nodelet.cpp
@@ -1,0 +1,59 @@
+// -*- mode: C++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include "jsk_pcl_ros/delay_pointcloud.h"
+#include <pluginlib/class_list_macros.h>
+
+namespace jsk_pcl_ros
+{
+  void DelayPointCloud::onInit()
+  {
+    PCLNodelet::onInit();
+    pnh_->param("sleep_time", sleep_time_, 1.0);
+    sub_ = pnh_->subscribe("input", 1, &DelayPointCloud::delay, this);
+    pub_ = pnh_->advertise<sensor_msgs::PointCloud2>("output", 1);
+  }
+
+  void DelayPointCloud::delay(const sensor_msgs::PointCloud2::ConstPtr& msg)
+  {
+    ros::Duration(sleep_time_).sleep();
+    pub_.publish(msg);
+  }
+
+
+}
+
+typedef jsk_pcl_ros::DelayPointCloud DelayPointCloud;
+PLUGINLIB_DECLARE_CLASS (jsk_pcl, DelayPointCloud, DelayPointCloud, nodelet::Nodelet);

--- a/jsk_pcl_ros/src/depth_image_error_nodelet.cpp
+++ b/jsk_pcl_ros/src/depth_image_error_nodelet.cpp
@@ -1,0 +1,70 @@
+// -*- mode: C++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include "jsk_pcl_ros/depth_image_error.h"
+#include <pluginlib/class_list_macros.h>
+#include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
+
+namespace jsk_pcl_ros
+{
+  void DepthImageError::onInit()
+  {
+    PCLNodelet::onInit();
+    sub_image_.subscribe(*pnh_, "image", 1);
+    sub_point_.subscribe(*pnh_, "point", 1);
+    sync_ = boost::make_shared<message_filters::Synchronizer<SyncPolicy> >(1000);
+    sync_->connectInput(sub_image_, sub_point_);
+    sync_->registerCallback(boost::bind(&DepthImageError::calcError,
+                                        this, _1, _2));
+  }
+
+  void DepthImageError::calcError(const sensor_msgs::Image::ConstPtr& depth_image,
+                                  const geometry_msgs::PointStamped::ConstPtr& uv_point)
+  {
+    NODELET_INFO("calcError is called");
+    cv_bridge::CvImagePtr cv_ptr;
+    cv_ptr = cv_bridge::toCvCopy(depth_image, sensor_msgs::image_encodings::TYPE_32FC1);
+    cv::Mat cv_depth_image = cv_ptr->image;
+    NODELET_INFO("(u, v) = (%f, %f)", uv_point->point.x, uv_point->point.y);
+    NODELET_INFO("(z, d) = (%f, %f)", uv_point->point.z, 
+                 cv_depth_image.at<float>((int)uv_point->point.x,
+                                          (int)uv_point->point.y));
+  }
+
+}
+
+typedef jsk_pcl_ros::DepthImageError DepthImageError;
+PLUGINLIB_DECLARE_CLASS (jsk_pcl, DepthImageError, DepthImageError, nodelet::Nodelet);


### PR DESCRIPTION
- DepthImageError is just a skelton yet.
- DelayPointCloud re-publishes pointcloud with specified delay time.
- publish u/v coordinates from checkerboard_detector.
- frame_id broadcasted from objectdetection_tf_publisher.py is configurable
