### PR TITLE
Use Eigen::Vector3f in geo_util

### DIFF
--- a/jsk_pcl_ros/include/jsk_pcl_ros/geo_util.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/geo_util.h
@@ -48,19 +48,24 @@
 
 namespace jsk_pcl_ros
 {
+  void convertEigenVector(const Eigen::Vector3f& input,
+                          Eigen::Vector3d& output);
+  void convertEigenVector(const Eigen::Vector3d& input,
+                          Eigen::Vector3f& output);
+  
   // (infinite) line
   class Line
   {
   public:
     typedef boost::shared_ptr<Line> Ptr;
-    Line(const Eigen::Vector3d& direction, const Eigen::Vector3d& origin);
-    virtual void getDirection(Eigen::Vector3d& output);
-    virtual double distanceToPoint(const Eigen::Vector3d& from);
-    virtual double distanceToPoint(const Eigen::Vector3d& from, Eigen::Vector3d& foot);
-    virtual void foot(const Eigen::Vector3d& point, Eigen::Vector3d& output);
+    Line(const Eigen::Vector3f& direction, const Eigen::Vector3f& origin);
+    virtual void getDirection(Eigen::Vector3f& output);
+    virtual double distanceToPoint(const Eigen::Vector3f& from);
+    virtual double distanceToPoint(const Eigen::Vector3f& from, Eigen::Vector3f& foot);
+    virtual void foot(const Eigen::Vector3f& point, Eigen::Vector3f& output);
   protected:
-    Eigen::Vector3d direction_;
-    Eigen::Vector3d origin_;
+    Eigen::Vector3f direction_;
+    Eigen::Vector3f origin_;
   private:
   };
 
@@ -68,11 +73,11 @@ namespace jsk_pcl_ros
   {
   public:
     typedef boost::shared_ptr<Segment> Ptr;
-    Segment(const Eigen::Vector3d& from, const Eigen::Vector3d to);
-    virtual void foot(const Eigen::Vector3d& point, Eigen::Vector3d& output);
-    virtual double dividingRatio(const Eigen::Vector3d& point);
+    Segment(const Eigen::Vector3f& from, const Eigen::Vector3f to);
+    virtual void foot(const Eigen::Vector3f& point, Eigen::Vector3f& output);
+    virtual double dividingRatio(const Eigen::Vector3f& point);
   protected:
-    Eigen::Vector3d from_, to_;
+    Eigen::Vector3f from_, to_;
   private:
   };
 
@@ -81,28 +86,31 @@ namespace jsk_pcl_ros
   public:
     typedef boost::shared_ptr<Plane> Ptr;
     Plane(const std::vector<float>& coefficients);
-    Plane(Eigen::Vector3d normal, double d);
-    Plane(Eigen::Vector3d normal, Eigen::Vector3d p);
+    Plane(Eigen::Vector3f normal, double d);
+    Plane(Eigen::Vector3f normal, Eigen::Vector3f p);
     virtual ~Plane();
     virtual Plane flip();
     
     virtual bool isSameDirection(const Plane& another);
-    virtual bool isSameDirection(const Eigen::Vector3d& another_normal);
+    virtual bool isSameDirection(const Eigen::Vector3f& another_normal);
     virtual double signedDistanceToPoint(const Eigen::Vector4f p);
     virtual double distanceToPoint(const Eigen::Vector4f p);
-    virtual double signedDistanceToPoint(const Eigen::Vector3d p);
-    virtual double distanceToPoint(const Eigen::Vector3d p);
+    virtual double signedDistanceToPoint(const Eigen::Vector3f p);
+    virtual double distanceToPoint(const Eigen::Vector3f p);
     
     virtual double distance(const Plane& another);
     virtual double angle(const Plane& another);
+    virtual void project(const Eigen::Vector3f& p, Eigen::Vector3f& output);
     virtual void project(const Eigen::Vector3d& p, Eigen::Vector3d& output);
-    virtual Eigen::Vector3d getNormal();
+    virtual void project(const Eigen::Vector3d& p, Eigen::Vector3f& output);
+    virtual void project(const Eigen::Vector3f& p, Eigen::Vector3d& output);
+    virtual Eigen::Vector3f getNormal();
     virtual Plane transform(const Eigen::Affine3d& transform);
     virtual void toCoefficients(std::vector<float>& output);
     virtual std::vector<float> toCoefficients();
     virtual double getD();
   protected:
-    Eigen::Vector3d normal_;
+    Eigen::Vector3f normal_;
     double d_;
   private:
   };
@@ -111,22 +119,25 @@ namespace jsk_pcl_ros
   {
   public:
     typedef boost::shared_ptr<ConvexPolygon> Ptr;
-    typedef Eigen::Vector3d Vertex;
+    typedef Eigen::Vector3f Vertex;
             
-    typedef std::vector<Eigen::Vector3d,
-                        Eigen::aligned_allocator<Eigen::Vector3d> > Vertices;
+    typedef std::vector<Eigen::Vector3f,
+                        Eigen::aligned_allocator<Eigen::Vector3f> > Vertices;
     // vertices should be CW
     ConvexPolygon(const Vertices& vertices);
     ConvexPolygon(const Vertices& vertices,
                   const std::vector<float>& coefficients);
     
     //virtual Polygon flip();
+    virtual void project(const Eigen::Vector3f& p, Eigen::Vector3f& output);
     virtual void project(const Eigen::Vector3d& p, Eigen::Vector3d& output);
-    virtual void projectOnPlane(const Eigen::Vector3d& p, Eigen::Vector3d& output);
+    virtual void project(const Eigen::Vector3d& p, Eigen::Vector3f& output);
+    virtual void project(const Eigen::Vector3f& p, Eigen::Vector3d& output);
+    virtual void projectOnPlane(const Eigen::Vector3f& p, Eigen::Vector3f& output);
     // p should be a point on the plane
-    virtual bool isInside(const Eigen::Vector3d& p);
+    virtual bool isInside(const Eigen::Vector3f& p);
     virtual ConvexPolygon flipConvex();
-    virtual Eigen::Vector3d getCentroid();
+    virtual Eigen::Vector3f getCentroid();
     static ConvexPolygon fromROSMsg(const geometry_msgs::Polygon& polygon);
   protected:
     Vertices vertices_;

--- a/jsk_pcl_ros/include/jsk_pcl_ros/grid_map.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/grid_map.h
@@ -80,6 +80,7 @@ namespace jsk_pcl_ros
     virtual void fillRegion(const Eigen::Vector3f& start, std::vector<GridIndex::Ptr>& output);
     virtual void fillRegion(const GridIndex::Ptr start, std::vector<GridIndex::Ptr>& output);
     // toMsg does not fill header, be carefull
+    virtual void originPose(Eigen::Affine3f& output);
     virtual void originPose(Eigen::Affine3d& output);
     virtual void toMsg(SparseOccupancyGrid& grid);
     virtual Plane toPlane();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/pcl_conversion_util.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/pcl_conversion_util.h
@@ -66,6 +66,8 @@ namespace pcl_conversions
                geometry_msgs::Point32& msg);
   void fromMSGToEigen(const geometry_msgs::Point32& msg,
                       Eigen::Vector3d& p);
+  void fromMSGToEigen(const geometry_msgs::Point32& msg,
+                      Eigen::Vector3f& p);
   void fromPCLToEigen(const pcl::PointXYZRGB& p,
                       Eigen::Vector3d& output);
 }

--- a/jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
+++ b/jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
@@ -120,9 +120,9 @@ namespace jsk_pcl_ros
     int nearest_index = -1;
     for (size_t i = 0; i < coefficients->coefficients.size(); i++) {
       geometry_msgs::PolygonStamped polygon_msg = planes->polygons[i];
-      std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > vertices;
+      ConvexPolygon::Vertices vertices;
       for (size_t j = 0; j < polygon_msg.polygon.points.size(); j++) {
-        Eigen::Vector3d v;
+        ConvexPolygon::Vertex v;
         v[0] = polygon_msg.polygon.points[j].x;
         v[1] = polygon_msg.polygon.points[j].y;
         v[2] = polygon_msg.polygon.points[j].z;

--- a/jsk_pcl_ros/src/environment_plane_modeling_nodelet.cpp
+++ b/jsk_pcl_ros/src/environment_plane_modeling_nodelet.cpp
@@ -432,8 +432,7 @@ namespace jsk_pcl_ros
         //double alpha = normal.dot(centroid_eigen) - d;
         double alpha = normal.dot(centroid_eigen);
         centroid_projected = centroid_eigen - alpha * normal;
-        Eigen::Vector3d centroid_projected_d (centroid_projected[0], centroid_projected[1], centroid_projected[2]);
-        if (convex_polygon_model.isInside(centroid_projected_d)) {
+        if (convex_polygon_model.isInside(centroid_projected)) {
           grid->fillRegion(centroid_projected, filled_indices);
           
           NODELET_INFO("%lu static polygon merged into %d env polygon and %lu points is required to fill",
@@ -607,14 +606,13 @@ namespace jsk_pcl_ros
   {
     ConvexPolygon::Vertices vertices;
     for (size_t i = 0; i < polygon.points.size(); i++) {
-      Eigen::Vector3d v(polygon.points[i].x,
-                        polygon.points[i].y,
-                        polygon.points[i].z);
+      ConvexPolygon::Vertex v;
+      pcl_conversions::fromMSGToEigen(polygon.points[i], v);
       vertices.push_back(v);
     }
     //Plane new_grid_map(coefficients);
     ConvexPolygon new_grid_map(vertices, coefficients);
-    Eigen::Vector3d c = new_grid_map.getCentroid();
+    Eigen::Vector3f c = new_grid_map.getCentroid();
     int min_index = -1;
     double min_distance = DBL_MAX;
     for (size_t i = 0; i < grid_maps_.size(); i++) {
@@ -785,15 +783,13 @@ namespace jsk_pcl_ros
     Plane::Ptr grid_plane = grid->toPlanePtr();
     for (size_t i = 0; i < sampled_point_cloud->points.size(); i++) {
       PointT p = sampled_point_cloud->points[i];
-      Eigen::Vector3d p_eigen;
-      pcl_conversions::fromPCLToEigen(p, p_eigen);
+      Eigen::Vector3f p_eigen = p.getVector3fMap();
       double d = grid_plane->distanceToPoint(p_eigen);
       if (d < resolution_size_) {
         //NODELET_INFO_STREAM("distance: " << d);
-        Eigen::Vector3d p_eigen_projected;
+        Eigen::Vector3f p_eigen_projected;
         grid_plane->project(p_eigen, p_eigen_projected);
-        Eigen::Vector3f p_eigen_projected_f(p_eigen_projected[0], p_eigen_projected[1], p_eigen_projected[2]);
-        if (!grid->isBinsOccupied(p_eigen_projected_f)) {
+        if (!grid->isBinsOccupied(p_eigen_projected)) {
           return false;            // near enough!! hopefully...
         }
       }

--- a/jsk_pcl_ros/src/grid_map.cpp
+++ b/jsk_pcl_ros/src/grid_map.cpp
@@ -350,13 +350,24 @@ namespace jsk_pcl_ros
     }
   }
 
+  void GridMap::originPose(Eigen::Affine3f& output)
+  {
+    Eigen::Matrix3f rot_mat;
+    rot_mat.col(0) = Eigen::Vector3f(ex_[0], ex_[1], ex_[2]);
+    rot_mat.col(1) = Eigen::Vector3f(ey_[0], ey_[1], ey_[2]);
+    rot_mat.col(2) = Eigen::Vector3f(normal_[0], normal_[1], normal_[2]);
+    output = Eigen::Translation3f(O_) * Eigen::Quaternionf(rot_mat);
+  }
+  
   void GridMap::originPose(Eigen::Affine3d& output)
   {
     Eigen::Matrix3d rot_mat;
     rot_mat.col(0) = Eigen::Vector3d(ex_[0], ex_[1], ex_[2]);
     rot_mat.col(1) = Eigen::Vector3d(ey_[0], ey_[1], ey_[2]);
     rot_mat.col(2) = Eigen::Vector3d(normal_[0], normal_[1], normal_[2]);
-    output = Eigen::Translation3d(Eigen::Vector3d(O_[0], O_[1], O_[2]))
+    output = Eigen::Translation3d(Eigen::Vector3d(O_[0],
+                                                  O_[1],
+                                                  O_[2]))
       * Eigen::Quaterniond(rot_mat);
   }
   
@@ -364,9 +375,10 @@ namespace jsk_pcl_ros
   {
     grid.resolution = resolution_;
     // compute origin POSE from O and normal_, d_
-    Eigen::Affine3d plane_pose;
+    Eigen::Affine3f plane_pose;
     originPose(plane_pose);
-    tf::poseEigenToMsg(plane_pose, grid.origin_pose);
+    
+    //tf::poseEigenToMsg(plane_pose, grid.origin_pose);
     for (ColumnIterator it = data_.begin();
          it != data_.end();
          it++) {
@@ -388,12 +400,12 @@ namespace jsk_pcl_ros
 
   Plane GridMap::toPlane()
   {
-    return Plane(Eigen::Vector3d(normal_[0], normal_[1], normal_[2]), d_);
+    return Plane(normal_, d_);
   }
 
   Plane::Ptr GridMap::toPlanePtr()
   {
-    Plane::Ptr ret (new Plane(Eigen::Vector3d(normal_[0], normal_[1], normal_[2]), d_));
+    Plane::Ptr ret (new Plane(normal_, d_));
     return ret;
   }
 

--- a/jsk_pcl_ros/src/handle_estimator_nodelet.cpp
+++ b/jsk_pcl_ros/src/handle_estimator_nodelet.cpp
@@ -140,7 +140,7 @@ namespace jsk_pcl_ros
     Eigen::Affine3d center;
     tf::poseMsgToEigen(box_msg->pose, center);
     Eigen::Vector3d z = center.rotation().col(2);
-    Plane p(z, 0);
+    Plane p(Eigen::Vector3f(z[0], z[1], z[2]), 0);
     Eigen::Vector3d ray = center.translation().normalized();
     Eigen::Vector3d ray_projected;
     p.project(ray, ray_projected);

--- a/jsk_pcl_ros/src/organized_multi_plane_segmentation_nodelet.cpp
+++ b/jsk_pcl_ros/src/organized_multi_plane_segmentation_nodelet.cpp
@@ -44,18 +44,8 @@
 #include <pcl/filters/project_inliers.h>
 #include <pcl/features/integral_image_normal.h>
 
+#include "jsk_pcl_ros/pcl_conversion_util.h"
 #include <pluginlib/class_list_macros.h>
-
-#if ROS_VERSION_MINIMUM(1, 10, 0)
-// hydro and later
-typedef pcl_msgs::PointIndices PCLIndicesMsg;
-typedef pcl_msgs::ModelCoefficients PCLModelCoefficientMsg;
-#else
-// groovy
-typedef pcl::PointIndices PCLIndicesMsg;
-typedef pcl::ModelCoefficients PCLModelCoefficientMsg;
-#endif
-
 
 namespace jsk_pcl_ros
 {

--- a/jsk_pcl_ros/src/pcl_conversion_util.cpp
+++ b/jsk_pcl_ros/src/pcl_conversion_util.cpp
@@ -79,6 +79,14 @@ namespace pcl_conversions
     p[2] = msg.z;
   }
 
+  void fromMSGToEigen(const geometry_msgs::Point32& msg,
+                      Eigen::Vector3f& p)
+  {
+    p[0] = msg.x;
+    p[1] = msg.y;
+    p[2] = msg.z;
+  }
+
   void fromPCLToEigen(const pcl::PointXYZRGB& p,
                       Eigen::Vector3d& output)
   {


### PR DESCRIPTION
use Eigen::Vector3f as a default type in geo_util, because PCL uses the type as default.
