### PR TITLE
add new nodelet: SLICSuperPixels, a nodelet to compute superpixels based on SLIC method

### DIFF
--- a/jsk_perception/Makefile.slic
+++ b/jsk_perception/Makefile.slic
@@ -1,0 +1,19 @@
+all: build/SLIC-Superpixels
+
+INSTALL_DIR ?= ${CURDIR}
+GIT_DIR = build/SLIC-Superpixels
+PATCH_DIR = $(CURDIR)
+GIT_URL = https://github.com/PSMM/SLIC-Superpixels.git
+#GIT_REVISION = 315.2.0
+GIT_PATCH   =
+
+MK_DIR       = $(shell rospack find mk)
+NUM_OF_CPUS = $(shell grep -c '^processor' /proc/cpuinfo)
+
+include $(MK_DIR)/git_checkout.mk
+
+clean:
+	-cd $(GIT_DIR) && make clean
+
+download:
+	git clone $(GIT_URL) $(GIT_DIR); (cd ${GIT_DIR}; git checkout $(GIT_REVISION) up; rm -f `rospack find jsk_perception`/installed)

--- a/jsk_perception/catkin.cmake
+++ b/jsk_perception/catkin.cmake
@@ -30,7 +30,14 @@ catkin_package(
   LIBRARIES
 )
 
-include_directories(include ${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+execute_process(
+  COMMAND cmake -E chdir ${CMAKE_CURRENT_BINARY_DIR}
+  make -f ${PROJECT_SOURCE_DIR}/Makefile.slic
+  INSTALL_DIR=${CATKIN_DEVEL_PREFIX}
+  MK_DIR=${mk_PREFIX}/share/mk
+  RESULT_VARIABLE _make_failed)
+
+include_directories(include ${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR}/build/SLIC-Superpixels)
 add_executable(camshiftdemo src/camshiftdemo.cpp)
 add_executable(virtual_camera_mono src/virtual_camera_mono.cpp)
 add_executable(point_pose_extractor src/point_pose_extractor.cpp)
@@ -62,9 +69,11 @@ jsk_perception_nodelet(src/sparse_image_encoder.cpp "jsk_perception/SparseImageE
 jsk_perception_nodelet(src/sparse_image_decoder.cpp "jsk_perception/SparseImageDecoder" "sparse_image_decoder")
 jsk_perception_nodelet(src/color_histogram.cpp "jsk_perception/ColorHistogram" "color_histogram")
 jsk_perception_nodelet(src/hough_circles.cpp "jsk_perception/HoughCircleDetector" "hough_circles")
+jsk_perception_nodelet(src/slic_superpixels.cpp "jsk_perception/SLICSuperPixels" "slic_super_pixels")
 
 # compiling jsk_perception library for nodelet
-add_library(${PROJECT_NAME} SHARED ${jsk_perception_nodelet_sources})
+add_library(${PROJECT_NAME} SHARED ${jsk_perception_nodelet_sources}
+  ${CMAKE_CURRENT_BINARY_DIR}/build/SLIC-Superpixels/slic.cpp)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg ${PROJECT_NAME}_gencpp)
 

--- a/jsk_perception/jsk_perception_nodelets.xml
+++ b/jsk_perception/jsk_perception_nodelets.xml
@@ -1,4 +1,10 @@
 <library path="lib/libjsk_perception">
+  <class name="jsk_perception/SLICSuperPixels" type="SLICSuperPixels"
+         base_class_type="nodelet::Nodelet">
+    <description>
+      compute superpixels
+    </description>
+  </class>
   <class name="jsk_perception/HoughCircleDetector" type="HoughCircleDetector"
          base_class_type="nodelet::Nodelet">
     <description>

--- a/jsk_perception/src/slic_superpixels.cpp
+++ b/jsk_perception/src/slic_superpixels.cpp
@@ -1,0 +1,95 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <ros/ros.h>
+#include <nodelet/nodelet.h>
+#include <sensor_msgs/image_encodings.h>
+#include <cv_bridge/cv_bridge.h>
+#include <image_transport/image_transport.h>
+#include <dynamic_reconfigure/server.h>
+#include <boost/thread.hpp>
+#include <opencv/cv.h>
+#include <opencv/highgui.h>
+#include "slic.h"
+
+namespace jsk_perception
+{
+  class SLICSuperPixels: public nodelet::Nodelet
+  {
+  public:
+    ros::NodeHandle nh_, pnh_;
+    boost::shared_ptr<image_transport::ImageTransport> it_;
+    boost::mutex mutex_;
+    image_transport::Subscriber image_sub_;
+    void imageCallback(const sensor_msgs::Image::ConstPtr& image)
+    {
+      boost::mutex::scoped_lock lock(mutex_);
+      cv_bridge::CvImagePtr cv_ptr;
+      cv_ptr = cv_bridge::toCvCopy(image, sensor_msgs::image_encodings::BGR8);
+      cv::Mat bgr_image = cv_ptr->image;
+
+      IplImage bgr_image_ipl;
+      bgr_image_ipl = bgr_image;
+      IplImage* lab_image = cvCloneImage(&bgr_image_ipl);
+      IplImage* out_image = cvCloneImage(&bgr_image_ipl);
+      // slic
+      cvCvtColor(&bgr_image_ipl, lab_image, CV_BGR2Lab);
+      int w = image->width, h = image->height;
+      int nr_superpixels = 200;
+      int nc = 4;
+      double step = sqrt((w * h) / (double) nr_superpixels);
+      Slic slic;
+      slic.generate_superpixels(lab_image, step, nc);
+      slic.create_connectivity(lab_image);
+      slic.display_contours(out_image, CV_RGB(255,0,0));
+      cvShowImage("result", out_image);
+      cvWaitKey(10);
+    }
+    
+    virtual void onInit()
+    {
+      nh_ = ros::NodeHandle(getNodeHandle(), "image");
+      pnh_ = getPrivateNodeHandle();
+      it_.reset(new image_transport::ImageTransport(nh_));
+      image_sub_ = it_->subscribe("", 1, &SLICSuperPixels::imageCallback, this);
+    }
+  protected:
+  private:
+  };
+}
+
+#include <pluginlib/class_list_macros.h>
+typedef jsk_perception::SLICSuperPixels SLICSuperPixels;
+PLUGINLIB_DECLARE_CLASS (jsk_perception, SLICSuperPixels, SLICSuperPixels, nodelet::Nodelet);


### PR DESCRIPTION
add nodelet to compute slic-superpixels.

it uses the code here: https://github.com/PSMM/SLIC-Superpixels

the code is super experimental, it's only available on catkin and no output is available on ROS.
just showing the image.
no parameters are configurable.

![screenshot from 2014-08-01 20 05 26](https://cloud.githubusercontent.com/assets/40454/3778046/09f7035e-196c-11e4-916e-2a1d3fedbe3d.png)
