### PR TITLE
add new nodelet: BorderEstimator

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -111,6 +111,8 @@ jsk_pcl_nodelet(src/organize_pointcloud_nodelet.cpp
   "jsk_pcl/OrganizePointCloud" "organize_pointcloud")
 jsk_pcl_nodelet(src/polygon_array_wrapper_nodelet.cpp
   "jsk_pcl/PolygonArrayWrapper" "polygon_array_wrapper")
+jsk_pcl_nodelet(src/border_estimator_nodelet.cpp
+  "jsk_pcl/BorderEstimator" "border_estimator")
 
 rosbuild_add_library (jsk_pcl_ros
   ${jsk_pcl_nodelet_sources}

--- a/jsk_pcl_ros/catkin.cmake
+++ b/jsk_pcl_ros/catkin.cmake
@@ -166,6 +166,8 @@ jsk_pcl_nodelet(src/organize_pointcloud_nodelet.cpp
   "jsk_pcl/OrganizePointCloud" "organize_pointcloud")
 jsk_pcl_nodelet(src/polygon_array_wrapper_nodelet.cpp
   "jsk_pcl/PolygonArrayWrapper" "polygon_array_wrapper")
+jsk_pcl_nodelet(src/border_estimator_nodelet.cpp
+  "jsk_pcl/BorderEstimator" "border_estimator")
 
 
 add_library(jsk_pcl_ros SHARED ${jsk_pcl_nodelet_sources}

--- a/jsk_pcl_ros/include/jsk_pcl_ros/border_estimator.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/border_estimator.h
@@ -1,0 +1,77 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+
+#ifndef JSK_PCL_ROS_BORDER_ESTIMATOR_H_
+#define JSK_PCL_ROS_BORDER_ESTIMATOR_H_
+
+#include <pcl_ros/pcl_nodelet.h>
+#include <pcl/range_image/range_image.h>
+#include <pcl/features/range_image_border_extractor.h>
+
+#include <sensor_msgs/PointCloud2.h>
+#include <sensor_msgs/CameraInfo.h>
+#include "jsk_pcl_ros/pcl_conversion_util.h"
+
+#include <message_filters/subscriber.h>
+#include <message_filters/time_synchronizer.h>
+#include <message_filters/synchronizer.h>
+
+namespace jsk_pcl_ros
+{
+  class BorderEstimator: public pcl_ros::PCLNodelet
+  {
+  public:
+    typedef message_filters::sync_policies::ApproximateTime<
+    sensor_msgs::PointCloud2, sensor_msgs::CameraInfo> SyncPolicy;
+
+  protected:
+    virtual void onInit();
+    virtual pcl::PointXYZ convertPoint(const pcl::PointWithRange& input);
+    virtual void estimate(const sensor_msgs::PointCloud2::ConstPtr& msg,
+                          const sensor_msgs::CameraInfo::ConstPtr& caminfo);
+    void publishCloud(ros::Publisher& pub,
+                      const pcl::PointCloud<pcl::PointXYZ>& cloud,
+                      const std_msgs::Header& header);
+    message_filters::Subscriber<sensor_msgs::PointCloud2> sub_point_;
+    message_filters::Subscriber<sensor_msgs::CameraInfo> sub_camera_info_;
+    boost::shared_ptr<message_filters::Synchronizer<SyncPolicy> >sync_;
+    ros::Publisher pub_border_, pub_veil_, pub_shadow_;
+  private:
+    
+  };
+}
+
+#endif

--- a/jsk_pcl_ros/jsk_pcl_nodelets.xml
+++ b/jsk_pcl_ros/jsk_pcl_nodelets.xml
@@ -1,4 +1,10 @@
 <library path="lib/libjsk_pcl_ros">
+  <class name="jsk_pcl/BorderEstimator" type="BorderEstimator"
+         base_class_type="nodelet::Nodelet">
+    <description>
+      border estimator for organized pointcloud
+    </description>
+  </class>
   <class name="jsk_pcl/PolygonArrayWrapper" type="PolygonArrayWrapper"
          base_class_type="nodelet::Nodelet">
     <description>

--- a/jsk_pcl_ros/launch/border_estimate.launch
+++ b/jsk_pcl_ros/launch/border_estimate.launch
@@ -1,0 +1,7 @@
+<launch>
+  <node pkg="jsk_pcl_ros" type="border_estimator" name="border_estimator"
+        output="screen">
+    <remap from="~input" to="/camera/depth_registered/points" />
+    <remap from="~input_camera_info" to="/camera/rgb/camera_info" />
+  </node>
+</launch>

--- a/jsk_pcl_ros/src/border_estimator_nodelet.cpp
+++ b/jsk_pcl_ros/src/border_estimator_nodelet.cpp
@@ -1,0 +1,125 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+#include <pcl/range_image/range_image_planar.h>
+#include "jsk_pcl_ros/border_estimator.h"
+
+namespace jsk_pcl_ros
+{
+  void BorderEstimator::onInit()
+  {
+    PCLNodelet::onInit();
+    pub_border_ = pnh_->advertise<sensor_msgs::PointCloud2>("output_border", 1);
+    pub_veil_ = pnh_->advertise<sensor_msgs::PointCloud2>("output_veil", 1);
+    pub_shadow_ = pnh_->advertise<sensor_msgs::PointCloud2>("output_shadow", 1);
+    sub_point_.subscribe(*pnh_, "input", 1);
+    sub_camera_info_.subscribe(*pnh_, "input_camera_info", 1);
+    sync_ = boost::make_shared<message_filters::Synchronizer<SyncPolicy> >(100);
+    sync_->connectInput(sub_point_, sub_camera_info_);
+    sync_->registerCallback(boost::bind(&BorderEstimator::estimate, this, _1, _2));
+  }
+
+  pcl::PointXYZ BorderEstimator::convertPoint(const pcl::PointWithRange& input)
+  {
+    pcl::PointXYZ output;
+    output.x = input.x;
+    output.y = input.y;
+    output.z = input.z;
+    return output;
+  }
+  
+  void BorderEstimator::publishCloud(
+    ros::Publisher& pub,
+    const pcl::PointCloud<pcl::PointXYZ>& cloud,
+    const std_msgs::Header& header)
+  {
+    sensor_msgs::PointCloud2 ros_msg;
+    pcl::toROSMsg(cloud, ros_msg);
+    ros_msg.header = header;
+    pub.publish(ros_msg);
+  }
+  
+  void BorderEstimator::estimate(
+    const sensor_msgs::PointCloud2::ConstPtr& msg,
+    const sensor_msgs::CameraInfo::ConstPtr& info)
+  {
+    if (msg->height == 1) {
+      NODELET_ERROR("[BorderEstimator::estimate] pointcloud must be organized");
+      return;
+    }
+    pcl::RangeImagePlanar range_image;
+    pcl::PointCloud<pcl::PointXYZ> cloud;
+    pcl::fromROSMsg(*msg, cloud);
+    Eigen::Affine3f dummytrans = Eigen::Affine3f::Identity();
+    float fx = info->P[0];
+    float cx = info->P[2];
+    float tx = info->P[3];
+    float fy = info->P[5];
+    float cy = info->P[6];
+    range_image.createFromPointCloudWithFixedSize (cloud,
+                                                   msg->width,
+                                                   msg->height,
+                                                   cx, cy,
+                                                   fx, fy,
+                                                   dummytrans);
+    range_image.setUnseenToMaxRange();
+    pcl::RangeImageBorderExtractor border_extractor (&range_image);
+    pcl::PointCloud<pcl::BorderDescription> border_descriptions;
+    border_extractor.compute (border_descriptions);
+    pcl::PointCloud<pcl::PointXYZ> border_points, veil_points, shadow_points;
+    for (int y = 0; y < (int)range_image.height; ++y) {
+      for (int x = 0; x < (int)range_image.width; ++x) {
+        if (border_descriptions.points[y*range_image.width + x].traits[pcl::BORDER_TRAIT__OBSTACLE_BORDER]) {
+          border_points.points.push_back (
+            convertPoint(range_image.points[y*range_image.width + x]));
+        }
+        if (border_descriptions.points[y*range_image.width + x].traits[pcl::BORDER_TRAIT__VEIL_POINT]) {
+          veil_points.points.push_back (
+            convertPoint(range_image.points[y*range_image.width + x]));
+        }
+        if (border_descriptions.points[y*range_image.width + x].traits[pcl::BORDER_TRAIT__SHADOW_BORDER]) {
+          shadow_points.points.push_back (
+            convertPoint(range_image.points[y*range_image.width + x]));
+        }
+      }
+    }
+    publishCloud(pub_border_, border_points, msg->header);
+    publishCloud(pub_veil_, veil_points, msg->header);
+    publishCloud(pub_shadow_, shadow_points, msg->header);
+  }
+}
+
+#include <pluginlib/class_list_macros.h>
+typedef jsk_pcl_ros::BorderEstimator BorderEstimator;
+PLUGINLIB_DECLARE_CLASS (jsk_pcl, BorderEstimator, BorderEstimator, nodelet::Nodelet);


### PR DESCRIPTION
add new nodelet to estimate border based on range image.
- white: border
- green: shadow
- red: veil

![screenshot_from_2014-08-26 16 19 24](https://cloud.githubusercontent.com/assets/40454/4041110/40c3c2bc-2cf1-11e4-84da-4d749f4bec82.png)
