### PR TITLE
change color_histogram showing methods with reconfigure

### DIFF
--- a/jsk_pcl_ros/cfg/ColorHistogramMatcher.cfg
+++ b/jsk_pcl_ros/cfg/ColorHistogramMatcher.cfg
@@ -26,4 +26,13 @@ histogram_method_enum = gen.enum([gen.const("HUE", int_t, 0, "use hue"),
                                   "histogram to be used")
 gen.add("histogram_method", int_t, 0, "histogram method", 3, 0, 3, 
         edit_method = histogram_method_enum)
+gen.add("publish_colored_cloud", bool_t, 0, "publish coloerd point cloud that shows coefficience", True)
+gen.add("power", int_t, 0, "with which make coefficience powered", 4, 1, 6);
+gen.add("color_min_coefficient", double_t, 0, "show color from", 0, 0.0, 1.0)
+gen.add("color_max_coefficient", double_t, 0, "show color to", 1.0, 0.0, 1.0)
+show_method_enum = gen.enum([gen.const("blue_to_red", int_t, 0, "simple"),
+                                  gen.const("thermo", int_t, 1,"use thermo"),],
+                                  "show_method to be used")
+gen.add("show_method", int_t, 0, "show method", 0, 0, 1, 
+        edit_method = show_method_enum)
 exit (gen.generate (PACKAGE, "jsk_pcl_ros", "ColorHistogramMatcher"))

--- a/jsk_pcl_ros/include/jsk_pcl_ros/color_histogram_matcher.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/color_histogram_matcher.h
@@ -95,6 +95,11 @@ namespace jsk_pcl_ros
     bool reference_set_;
     double coefficient_thr_;
     int bin_size_;
+    bool publish_colored_cloud_;
+    int power_;
+    double color_min_coefficient_;
+    double color_max_coefficient_;
+    int show_method_;
     // must be exclusive
     ComparePolicy policy_;
   private:


### PR DESCRIPTION
use dynamic reconfigure to change color_histogram degree of similarity's showing method
![config_blue](https://cloud.githubusercontent.com/assets/7259700/4200271/f5907d84-380e-11e4-8794-a97ccfea6225.png)
![config_thermo](https://cloud.githubusercontent.com/assets/7259700/4200278/0a2a5b8e-380f-11e4-8227-0dacfd529f58.png)
this picture shows changing showing method, simple-one and thermo-like-one
