### PR TITLE
Refine plane connection by ransac pr

### DIFF
--- a/jsk_pcl_ros/cfg/OrganizedMultiPlaneSegmentation.cfg
+++ b/jsk_pcl_ros/cfg/OrganizedMultiPlaneSegmentation.cfg
@@ -30,8 +30,9 @@ gen.add("normal_smoothing_size", double_t, 0, "normal smoothing size parameter",
 gen.add("estimation_method", int_t, 0, "estimation method", 1, 0, 2, edit_method = estimation_method_enum)
 gen.add("depth_dependent_smoothing", bool_t, 0, "use depth dependent smoothing", False)
 gen.add("border_policy_ignore", bool_t, 0, "ignore border policy", True)
+gen.add("ransac_refine_coefficients", bool_t, 0, "refine coefficients by RANSAC", True)
+gen.add("ransac_refine_outlier_distance_threshold", double_t, 0, "distance threshold  for ransac refinement", 0.1, 0.0, 0.3)
 gen.add("publish_normal", bool_t, 0, "publish normal pointcloud", False)
 #gen.add("concave_alpha", double_t, 0, "alpha parameter for concave estimation", 0.1, 0, 1.0)
 
 exit (gen.generate (PACKAGE, "jsk_pcl_ros", "OrganizedMultiPlaneSegmentation"))
-

--- a/jsk_pcl_ros/include/jsk_pcl_ros/geo_util.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/geo_util.h
@@ -187,6 +187,18 @@ namespace jsk_pcl_ros
     virtual ConvexPolygon flipConvex();
     virtual Eigen::Vector3f getCentroid();
     virtual Ptr magnify(const double scale_factor);
+    
+    template<class PointT> void boundariesToPointCloud(
+      pcl::PointCloud<PointT>& output) {
+      output.points.resize(vertices_.size());
+      for (size_t i = 0; i < vertices_.size(); i++) {
+        Eigen::Vector3f v = vertices_[i];
+        PointT p;
+        p.x = v[0]; p.y = v[1]; p.z = v[2];
+        output.points[i] = p;
+      }
+    }
+    
     static ConvexPolygon fromROSMsg(const geometry_msgs::Polygon& polygon);
     bool distanceSmallerThan(
       const Eigen::Vector3f& p, double distance_threshold);
@@ -209,8 +221,8 @@ namespace jsk_pcl_ros
     typedef typename pcl::PointCloud<PointT> POINTCLOUD;
     typename POINTCLOUD::Ptr projected_cloud(new pcl::PointCloud<PointT>);
     // project inliers based on coefficients
-    std::cout << "inliers: " << inliers->indices.size() << std::endl;
-    std::cout << "coefficients: " << *coefficients << std::endl;
+    // std::cout << "inliers: " << inliers->indices.size() << std::endl;
+    // std::cout << "coefficients: " << *coefficients << std::endl;
     pcl::ProjectInliers<PointT> proj;
     proj.setModelType(pcl::SACMODEL_PERPENDICULAR_PLANE);
     proj.setInputCloud(cloud);
@@ -233,8 +245,7 @@ namespace jsk_pcl_ros
           Eigen::Vector3f v = convex_cloud->points[i].getVector3fMap();
           vs.push_back(v);
         }
-        ConvexPolygon::Ptr convex (new ConvexPolygon(vs));
-        return convex;
+        return ConvexPolygon::Ptr(new ConvexPolygon(vs));
       }
       else {
         return ConvexPolygon::Ptr();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/pcl_util.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/pcl_util.h
@@ -94,18 +94,35 @@ namespace jsk_pcl_ros
   //   vertex.
   // 
   //   graph_map := A map representeing edges of the graph.
-  //                The graph is one-directional graph.
+  //                The graph is bidirectional graph.
   //                the key means "from vertex" and the value
   //                means the "to indices" from the key vertex.
   //   from_index := The index to pay attension
   //   to_indices := The "to indices" from from_index
   //   output_set := result
   ////////////////////////////////////////////////////////
-  void buildGroupFromGraphMap(std::map<int, std::vector<int> > graph_map,
+  typedef std::map<int, std::vector<int> > IntegerGraphMap;
+  
+  void buildGroupFromGraphMap(IntegerGraphMap graph_map,
+                              const int from_index,
+                              std::vector<int>& to_indices,
+                              std::set<int>& output_set);
+  void _buildGroupFromGraphMap(IntegerGraphMap graph_map,
                               const int from_index,
                               std::vector<int>& to_indices,
                               std::set<int>& output_set);
   
+  ////////////////////////////////////////////////////////
+  // buildAllGraphSetFromGraphMap
+  //   get all the list of set represented in graph_map
+  ////////////////////////////////////////////////////////
+  void buildAllGroupsSetFromGraphMap(IntegerGraphMap graph_map,
+                                     std::vector<std::set<int> >& output_sets);
+  
+  ////////////////////////////////////////////////////////
+  // addSet<class>(A, B)
+  //   add two set like A = A + B
+  ////////////////////////////////////////////////////////
   template <class T>
   void addSet(std::set<T>& output,
               const std::set<T>& new_set)

--- a/jsk_pcl_ros/src/organized_multi_plane_segmentation_nodelet.cpp
+++ b/jsk_pcl_ros/src/organized_multi_plane_segmentation_nodelet.cpp
@@ -52,6 +52,10 @@
 #include <visualization_msgs/Marker.h>
 #include "jsk_pcl_ros/geo_util.h"
 
+#include <pcl/sample_consensus/method_types.h>
+#include <pcl/sample_consensus/model_types.h>
+#include <pcl/segmentation/sac_segmentation.h>
+#include <pcl/surface/convex_hull.h>
 
 namespace jsk_pcl_ros
 {
@@ -97,6 +101,15 @@ namespace jsk_pcl_ros
     org_coefficients_pub_
       = pnh_->advertise<ModelCoefficientsArray>(
         "output_nonconnected_coefficients", 1);
+    
+    refined_pub_ = pnh_->advertise<ClusterPointIndices>(
+      "output_refined", 1);
+    refined_polygon_pub_
+      = pnh_->advertise<PolygonArray>("output_refined_polygon", 1);
+    refined_coefficients_pub_
+      = pnh_->advertise<ModelCoefficientsArray>(
+        "output_refined_coefficients", 1);
+    
     pub_connection_marker_
       = pnh_->advertise<visualization_msgs::Marker>(
         "debug_connection_map", 1);
@@ -137,6 +150,9 @@ namespace jsk_pcl_ros
     estimation_method_ = config.estimation_method;
     border_policy_ignore_ = config.border_policy_ignore;
     publish_normal_ = config.publish_normal;
+    ransac_refine_coefficients_ = config.ransac_refine_coefficients;
+    ransac_refine_outlier_distance_threshold_
+      = config.ransac_refine_outlier_distance_threshold;
     //concave_alpha_ = config.concave_alpha;
   }
 
@@ -144,7 +160,7 @@ namespace jsk_pcl_ros
     const pcl::PointCloud<PointT>::Ptr& input,
     const std::vector<pcl::ModelCoefficients>& model_coefficients,
     const std::vector<pcl::PointIndices>& boundary_indices,
-    std::vector<std::map<size_t, bool> >& connection_map)
+    IntegerGraphMap& connection_map)
   {
     if (model_coefficients.size() == 0) {
       return;                   // do nothing
@@ -152,8 +168,9 @@ namespace jsk_pcl_ros
     
     pcl::ExtractIndices<PointT> extract;
     extract.setInputCloud(input);
-    connection_map.resize(model_coefficients.size());
     for (size_t i = 0; i < model_coefficients.size() - 1; i++) {
+      // initialize connection_map[i]
+      connection_map[i] = std::vector<int>();
       for (size_t j = i + 1; j < model_coefficients.size(); j++) {
         // check if i and j can be connected
         pcl::ModelCoefficients a_coefficient = model_coefficients[i];
@@ -211,17 +228,17 @@ namespace jsk_pcl_ros
             }
           }
           if (foundp) {
-            // i and j can be connected
-            connection_map[i].insert(std::map<size_t, bool>::value_type(j, true));
+            connection_map[i].push_back(j);
           }
         }
       }
     }
   }
 
-  void OrganizedMultiPlaneSegmentation::pclIndicesArrayToClusterPointIndices(const std::vector<pcl::PointIndices>& inlier_indices,
-                                                                             const std_msgs::Header& header,
-                                                                             jsk_pcl_ros::ClusterPointIndices& output_indices)
+  void OrganizedMultiPlaneSegmentation::pclIndicesArrayToClusterPointIndices(
+    const std::vector<pcl::PointIndices>& inlier_indices,
+    const std_msgs::Header& header,
+    jsk_pcl_ros::ClusterPointIndices& output_indices)
   {
     for (size_t i = 0; i < inlier_indices.size(); i++) {
       pcl::PointIndices inlier = inlier_indices[i];
@@ -232,8 +249,9 @@ namespace jsk_pcl_ros
     }
   }
   
-  void OrganizedMultiPlaneSegmentation::pointCloudToPolygon(const pcl::PointCloud<PointT>& input,
-                                                            geometry_msgs::Polygon& polygon)
+  void OrganizedMultiPlaneSegmentation::pointCloudToPolygon(
+    const pcl::PointCloud<PointT>& input,
+    geometry_msgs::Polygon& polygon)
   {
     for (size_t i = 0; i < input.points.size(); i++) {
       geometry_msgs::Point32 point;
@@ -244,47 +262,27 @@ namespace jsk_pcl_ros
     }
   }
   
-  void OrganizedMultiPlaneSegmentation::buildConnectedPlanes(const pcl::PointCloud<PointT>::Ptr& input,
-                                                             const std_msgs::Header& header,
-                                                             const std::vector<pcl::PointIndices>& inlier_indices,
-                                                             const std::vector<pcl::PointIndices>& boundary_indices,
-                                                             const std::vector<pcl::ModelCoefficients>& model_coefficients,
-                                                             std::vector<std::map<size_t, bool> > connection_map,
-                                                             std::vector<pcl::PointIndices>& output_indices,
-                                                             std::vector<pcl::ModelCoefficients>& output_coefficients,
-                                                             std::vector<pcl::PointCloud<PointT> >& output_boundary_clouds)
+  void OrganizedMultiPlaneSegmentation::buildConnectedPlanes(
+    const pcl::PointCloud<PointT>::Ptr& input,
+    const std_msgs::Header& header,
+    const std::vector<pcl::PointIndices>& inlier_indices,
+    const std::vector<pcl::PointIndices>& boundary_indices,
+    const std::vector<pcl::ModelCoefficients>& model_coefficients,
+    const IntegerGraphMap& connection_map,
+    std::vector<pcl::PointIndices>& output_indices,
+    std::vector<pcl::ModelCoefficients>& output_coefficients,
+    std::vector<pcl::PointCloud<PointT> >& output_boundary_clouds)
   { 
     std::vector<std::set<int> > cloud_sets;
-    for (size_t i = 0; i < connection_map.size(); i++) {
-      bool i_done = false;
-      // check i is included in cloud_sets
-      for (size_t j = 0; j < cloud_sets.size(); j++) {
-        if (cloud_sets[j].find(i) != cloud_sets[j].end()) {
-          // i is included in cloud_sets[j]
-          NODELET_DEBUG("%lu is included in cloud_sets[%lu]", i, j);
-          for (std::map<size_t, bool>::iterator it = connection_map[i].begin();
-               it != connection_map[i].end(); it++) {
-            NODELET_DEBUG("%lu -> %lu", (*it).first, j);
-            cloud_sets[j].insert((*it).first);
-          }
-          i_done = true;
-          break;
-        }
-      }
-      // i is not yet included in cloud_sets
-      if (!i_done) {
-        std::set<int> new_set;
-        new_set.insert(i);
-        for (std::map<size_t, bool>::iterator it = connection_map[i].begin();
-             it != connection_map[i].end(); it++) {
-          new_set.insert((*it).first);
-        }
-        cloud_sets.push_back(new_set);
-      }
-    }
-      
+    buildAllGroupsSetFromGraphMap(connection_map, cloud_sets);
     for (size_t i = 0; i < cloud_sets.size(); i++) {
-      NODELET_DEBUG("%lu cloud", i);
+      //std::cout << i << " cloud set: ";
+      // for (std::set<int>::iterator it = cloud_sets[i].begin();
+      //      it != cloud_sets[i].end();
+      //      ++it) {
+      //   std::cout << *it << ", ";
+      // }
+      // std::cout << std::endl;
       
       pcl::PointIndices one_indices;
       pcl::PointIndices one_boundaries;
@@ -292,23 +290,14 @@ namespace jsk_pcl_ros
       new_coefficients.resize(4, 0);
       for (std::set<int>::iterator it = cloud_sets[i].begin();
            it != cloud_sets[i].end();
-           it++) {
+           ++it) {
         NODELET_DEBUG("%lu includes %d", i, *it);
+        new_coefficients = model_coefficients[*it].values;
         pcl::PointIndices inlier = inlier_indices[*it];
         pcl::PointIndices boundary_inlier = boundary_indices[*it];
         // append indices...
-        for (size_t j = 0; j < inlier.indices.size(); j++) {
-          one_indices.indices.push_back(inlier.indices[j]);
-        }
-        for (size_t j = 0; j < boundary_inlier.indices.size(); j++) {
-          one_boundaries.indices.push_back(boundary_inlier.indices[j]);
-        }
-        for (size_t i = 0; i < 4; i++) { // take summation of coefficients
-          new_coefficients[0] += model_coefficients[*it].values[0];
-          new_coefficients[1] += model_coefficients[*it].values[1];
-          new_coefficients[2] += model_coefficients[*it].values[2];
-          new_coefficients[3] += model_coefficients[*it].values[3];
-        }
+        one_indices = *addIndices(one_indices, inlier);
+        one_boundaries = *addIndices(one_boundaries, boundary_inlier);
       }
       if (one_indices.indices.size() == 0) {
         continue;
@@ -382,9 +371,11 @@ namespace jsk_pcl_ros
   void OrganizedMultiPlaneSegmentation::publishSegmentationInformation(
     const std_msgs::Header& header,
     const pcl::PointCloud<PointT>::Ptr input,
+    ros::Publisher& indices_pub,
+    ros::Publisher& polygon_pub,
+    ros::Publisher& coefficients_pub,
     const std::vector<pcl::PointIndices>& inlier_indices,
-    const std::vector<pcl::PointIndices>& boundary_indices,
-    const PlanarRegionVector& regions,
+    const std::vector<pcl::PointCloud<PointT> >& boundaries,
     const std::vector<pcl::ModelCoefficients>& model_coefficients)
   {
     jsk_pcl_ros::ClusterPointIndices indices;
@@ -397,26 +388,20 @@ namespace jsk_pcl_ros
     ////////////////////////////////////////////////////////
     // publish inliers
     ////////////////////////////////////////////////////////
-    pclIndicesArrayToClusterPointIndices(inlier_indices, header,
-                                         indices);
-    org_pub_.publish(indices);
-
+    pclIndicesArrayToClusterPointIndices(inlier_indices, header, indices);
+    indices_pub.publish(indices);
+    
     ////////////////////////////////////////////////////////
-    // boundaries as polygon and pointcloud
+    // boundaries as polygon
     ////////////////////////////////////////////////////////
-    pcl::ExtractIndices<PointT> extract;
-    extract.setInputCloud(input);
-    for (size_t i = 0; i < regions.size(); i++) {
-      pcl::PointCloud<PointT> boundary_cloud;
-      pcl::PointIndices::Ptr indices_ptr = boost::make_shared<pcl::PointIndices>(boundary_indices[i]);
-      extract.setIndices(indices_ptr);
-      extract.filter(boundary_cloud);
+    for (size_t i = 0; i < boundaries.size(); i++) {
       geometry_msgs::PolygonStamped polygon;
+      pcl::PointCloud<PointT> boundary_cloud = boundaries[i];
       pointCloudToPolygon(boundary_cloud, polygon.polygon);
       polygon.header = header;
       polygon_array.polygons.push_back(polygon);
     }
-    org_polygon_pub_.publish(polygon_array);
+    polygon_pub.publish(polygon_array);
 
     ////////////////////////////////////////////////////////
     // publish coefficients
@@ -427,11 +412,39 @@ namespace jsk_pcl_ros
       coefficient.header = header;
       coefficients_array.coefficients.push_back(coefficient);
     }
-    org_coefficients_pub_.publish(coefficients_array);
+    coefficients_pub.publish(coefficients_array);    
+  }
+  
+  void OrganizedMultiPlaneSegmentation::publishSegmentationInformation(
+    const std_msgs::Header& header,
+    const pcl::PointCloud<PointT>::Ptr input,
+    ros::Publisher& indices_pub,
+    ros::Publisher& polygon_pub,
+    ros::Publisher& coefficients_pub,
+    const std::vector<pcl::PointIndices>& inlier_indices,
+    const std::vector<pcl::PointIndices>& boundary_indices,
+    const std::vector<pcl::ModelCoefficients>& model_coefficients)
+  {
+    // convert boundary_indices into boundary pointcloud
+    std::vector<pcl::PointCloud<PointT> > boundaries;
+    pcl::ExtractIndices<PointT> extract;
+    extract.setInputCloud(input);
+    for (size_t i = 0; i < boundary_indices.size(); i++) {
+      pcl::PointCloud<PointT> boundary_cloud;
+      pcl::PointIndices boundary_one_indices = boundary_indices[i];
+      pcl::PointIndices::Ptr indices_ptr = boost::make_shared<pcl::PointIndices>(boundary_indices[i]);
+      extract.setIndices(indices_ptr);
+      extract.filter(boundary_cloud);
+      boundaries.push_back(boundary_cloud);
+    }
+    
+    publishSegmentationInformation(
+      header, input, indices_pub, polygon_pub, coefficients_pub,
+      inlier_indices, boundaries, model_coefficients);
   }
 
   void OrganizedMultiPlaneSegmentation::publishMarkerOfConnection(
-    const std::vector<std::map<size_t, bool> >& connection_map,
+    IntegerGraphMap connection_map,
     const pcl::PointCloud<PointT>::Ptr cloud,
     const std::vector<pcl::PointIndices>& inliers,
     const std_msgs::Header& header)
@@ -445,6 +458,10 @@ namespace jsk_pcl_ros
     connection_marker.header = header;
     connection_marker.pose.orientation.w = 1.0;
     connection_marker.color = colorCategory20(0);
+    
+    ////////////////////////////////////////////////////////
+    // first, compute centroids for each clusters
+    ////////////////////////////////////////////////////////
     Vertices centroids;
     for (size_t i = 0; i < inliers.size(); i++) {
       pcl::PointIndices::Ptr target_inliers
@@ -460,25 +477,24 @@ namespace jsk_pcl_ros
       centroids.push_back(centroid_3f);
     }
 
-    for (size_t i = 0; i < connection_map.size(); i++) {
+    for (IntegerGraphMap::iterator it = connection_map.begin();
+         it != connection_map.end();
+         ++it) {
       // from = i
-      std::map<size_t, bool> the_connection_map = connection_map[i];
-      int from_index = i;
-      for (std::map<size_t, bool>::iterator it = the_connection_map.begin();
-           it != the_connection_map.end();
-           ++it) {
-        if (it->second) {
-          int to_index = it->first;
-          Eigen::Vector3f from_point = centroids[from_index];
-          Eigen::Vector3f to_point = centroids[to_index];
-          geometry_msgs::Point from_point_ros, to_point_ros;
-          pcl_conversions::fromEigenToMSG(from_point, from_point_ros);
-          pcl_conversions::fromEigenToMSG(to_point, to_point_ros);
-          connection_marker.points.push_back(from_point_ros);
-          connection_marker.points.push_back(to_point_ros);
-          connection_marker.colors.push_back(colorCategory20(i));
-          connection_marker.colors.push_back(colorCategory20(i));
-        }
+      int from_index = it->first;
+      std::vector<int> the_connection_map = connection_map[from_index];
+      for (size_t j = 0; j < the_connection_map.size(); j++) {
+        int to_index = the_connection_map[j];
+        //std::cout << "connection: " << from_index << " --> " << to_index << std::endl;
+        Eigen::Vector3f from_point = centroids[from_index];
+        Eigen::Vector3f to_point = centroids[to_index];
+        geometry_msgs::Point from_point_ros, to_point_ros;
+        pcl_conversions::fromEigenToMSG(from_point, from_point_ros);
+        pcl_conversions::fromEigenToMSG(to_point, to_point_ros);
+        connection_marker.points.push_back(from_point_ros);
+        connection_marker.points.push_back(to_point_ros);
+        connection_marker.colors.push_back(colorCategory20(from_index));
+        connection_marker.colors.push_back(colorCategory20(from_index));
       }
     }
     pub_connection_marker_.publish(connection_marker);
@@ -495,58 +511,109 @@ namespace jsk_pcl_ros
     pcl::PointCloud<pcl::Label>::Ptr labels (new pcl::PointCloud<pcl::Label>());
     std::vector<pcl::PointIndices> label_indices;
     std::vector<pcl::PointIndices> boundary_indices;
+    ////////////////////////////////////////////////////////
+    // segment planes based on pcl's organized multi plane
+    // segmentation.
+    ////////////////////////////////////////////////////////
     segmentOrganizedMultiPlanes(input, normal, regions, model_coefficients,
                                 inlier_indices, labels, label_indices,
                                 boundary_indices);
     original_plane_num_counter_.add(regions.size());
-    publishSegmentationInformation(header, input, inlier_indices,
-                                   boundary_indices, regions,
-                                   model_coefficients);
+    publishSegmentationInformation(
+      header, input,
+      org_pub_, org_polygon_pub_, org_coefficients_pub_,
+      inlier_indices, boundary_indices, model_coefficients);
     
     ////////////////////////////////////////////////////////
     // segmentation by PCL organized multiplane segmentation
     // is not enough. we "connect" planes like graph problem.
     ////////////////////////////////////////////////////////
-    std::vector<std::map<size_t, bool> > connection_map;
+    IntegerGraphMap connection_map;
     connectPlanesMap(input, model_coefficients, boundary_indices, connection_map);
     publishMarkerOfConnection(connection_map, input, inlier_indices, header);
-    
-    {
-      std::vector<pcl::PointIndices> output_indices;
-      std::vector<pcl::ModelCoefficients> output_coefficients;
-      std::vector<pcl::PointCloud<PointT> > output_boundary_clouds;
-    
-      buildConnectedPlanes(input, header,
-                           inlier_indices,
-                           boundary_indices,
-                           model_coefficients,
-                           connection_map,
-                           output_indices, output_coefficients, output_boundary_clouds);
+    std::vector<pcl::PointIndices> output_nonrefined_indices;
+    std::vector<pcl::ModelCoefficients> output_nonrefined_coefficients;
+    std::vector<pcl::PointCloud<PointT> > output_nonrefined_boundary_clouds;
+    buildConnectedPlanes(input, header,
+                         inlier_indices,
+                         boundary_indices,
+                         model_coefficients,
+                         connection_map,
+                         output_nonrefined_indices,
+                         output_nonrefined_coefficients,
+                         output_nonrefined_boundary_clouds);
+    publishSegmentationInformation(
+      header, input,
+      pub_, polygon_pub_, coefficients_pub_,
+      output_nonrefined_indices,
+      output_nonrefined_boundary_clouds,
+      output_nonrefined_coefficients);
+    ////////////////////////////////////////////////////////
+    // refine coefficients based on RANSAC
+    ////////////////////////////////////////////////////////
+    if (ransac_refine_coefficients_) {
+      std::vector<pcl::PointIndices> refined_inliers;
+      std::vector<pcl::ModelCoefficients> refined_coefficients;
+      std::vector<ConvexPolygon::Ptr> refined_convexes;
+      
+      refineBasedOnRANSAC(
+        input, output_nonrefined_indices, output_nonrefined_coefficients,
+        refined_inliers, refined_coefficients, refined_convexes);
+      std::vector<pcl::PointCloud<PointT> > refined_boundary_clouds;
+      for (size_t i = 0; i < refined_convexes.size(); i++) {
+        pcl::PointCloud<PointT> refined_boundary;
+        refined_convexes[i]->boundariesToPointCloud(refined_boundary);
+        refined_boundary_clouds.push_back(refined_boundary);
+      }
+      publishSegmentationInformation(
+      header, input,
+      refined_pub_, refined_polygon_pub_, refined_coefficients_pub_,
+      refined_inliers, refined_boundary_clouds, refined_coefficients);
+    }
+  }
 
-      jsk_pcl_ros::ClusterPointIndices indices;
-      jsk_pcl_ros::PolygonArray polygon_array;
-      indices.header = header;
-      polygon_array.header = header;
-      pclIndicesArrayToClusterPointIndices(output_indices, header,
-                                           indices);
-      connected_plane_num_counter_.add(output_boundary_clouds.size());
-      for (size_t i = 0; i < output_boundary_clouds.size(); i++) {
-        geometry_msgs::PolygonStamped polygon;
-        polygon.header = header;
-        pointCloudToPolygon(output_boundary_clouds[i], polygon.polygon);
-        polygon_array.polygons.push_back(polygon);
-      }
-      pub_.publish(indices);
-      polygon_pub_.publish(polygon_array);
-      jsk_pcl_ros::ModelCoefficientsArray coefficients_array;
-      coefficients_array.header = header;
-      for (size_t i = 0; i < output_coefficients.size(); i++) {
-        PCLModelCoefficientMsg coefficient;
-        coefficient.values = output_coefficients[i].values;
-        coefficient.header = header;
-        coefficients_array.coefficients.push_back(coefficient);
-      }
-      coefficients_pub_.publish(coefficients_array);
+  void OrganizedMultiPlaneSegmentation::refineBasedOnRANSAC(
+    const pcl::PointCloud<PointT>::Ptr input,
+    const std::vector<pcl::PointIndices>& input_indices,
+    const std::vector<pcl::ModelCoefficients>& input_coefficients,
+    std::vector<pcl::PointIndices>& output_indices,
+    std::vector<pcl::ModelCoefficients>& output_coefficients,
+    std::vector<ConvexPolygon::Ptr>& output_convexes)
+  {
+    jsk_topic_tools::ScopedTimer timer
+      = ransac_refinement_time_acc_.scopedTimer();
+    for (size_t i = 0; i < input_indices.size(); i++) {
+      pcl::PointIndices::Ptr input_indices_ptr
+        = boost::make_shared<pcl::PointIndices>(input_indices[i]);
+      Eigen::Vector3f normal(input_coefficients[i].values[0],
+                             input_coefficients[i].values[1],
+                             input_coefficients[i].values[2]);
+      normal.normalize();
+      ////////////////////////////////////////////////////////
+      // run RANSAC
+      ////////////////////////////////////////////////////////
+      pcl::SACSegmentation<PointT> seg;
+      seg.setOptimizeCoefficients (true);
+      seg.setModelType (pcl::SACMODEL_PERPENDICULAR_PLANE);
+      seg.setMethodType (pcl::SAC_RANSAC);
+      seg.setDistanceThreshold (ransac_refine_outlier_distance_threshold_);
+      seg.setInputCloud(input);
+      seg.setIndices(input_indices_ptr);
+      seg.setMaxIterations (10000);
+      seg.setAxis(normal);
+      seg.setEpsAngle(pcl::deg2rad(20.0));
+      pcl::PointIndices::Ptr refined_inliers (new pcl::PointIndices);
+      pcl::ModelCoefficients::Ptr refined_coefficients(new pcl::ModelCoefficients);
+      seg.segment (*refined_inliers, *refined_coefficients);
+      output_indices.push_back(*refined_inliers);
+      output_coefficients.push_back(*refined_coefficients);
+
+      ////////////////////////////////////////////////////////
+      // compute boundaries from convex hull of
+      ////////////////////////////////////////////////////////
+      ConvexPolygon::Ptr convex = convexFromCoefficientsAndInliers<PointT>(
+        input, refined_inliers, refined_coefficients);
+      output_convexes.push_back(convex);
     }
   }
 

--- a/jsk_pcl_ros/src/pcl_util.cpp
+++ b/jsk_pcl_ros/src/pcl_util.cpp
@@ -35,6 +35,7 @@
 
 #include "jsk_pcl_ros/pcl_util.h"
 #include <set>
+#include <algorithm>
 
 namespace jsk_pcl_ros
 {
@@ -236,23 +237,76 @@ namespace jsk_pcl_ros
     return boost::accumulators::variance(acc_);
   }
 
-  void buildGroupFromGraphMap(std::map<int, std::vector<int> > graph_map,
-                              const int from_index,
-                              std::vector<int>& to_indices,
+  void buildGroupFromGraphMap(IntegerGraphMap graph_map,
+                              const int from_index_arg,
+                              std::vector<int>& to_indices_arg,
                               std::set<int>& output_set)
   {
+    // convert graph_map into one-directional representation
+    IntegerGraphMap onedirectional_map(graph_map);
+    for (IntegerGraphMap::iterator it = onedirectional_map.begin();
+         it != onedirectional_map.end();
+         ++it) {
+      int from_index = it->first;
+      std::vector<int> to_indices = it->second;
+      for (size_t i = 0; i < to_indices.size(); i++) {
+        int to_index = to_indices[i];
+        if (onedirectional_map.find(to_index) == onedirectional_map.end()) {
+          // not yet initialized
+          onedirectional_map[to_index] = std::vector<int>(); 
+        }
+        if (std::find(onedirectional_map[to_index].begin(),
+                      onedirectional_map[to_index].end(),
+                      from_index) == onedirectional_map[to_index].end()) {
+          onedirectional_map[to_index].push_back(from_index);
+        }
+      }
+    }
+    _buildGroupFromGraphMap(onedirectional_map,
+                            from_index_arg,
+                            to_indices_arg,
+                            output_set);
+  }
+  
+  void _buildGroupFromGraphMap(IntegerGraphMap graph_map,
+                               const int from_index,
+                               std::vector<int>& to_indices,
+                               std::set<int>& output_set)
+  {    
     output_set.insert(from_index);
     for (size_t i = 0; i < to_indices.size(); i++) {
       int to_index = to_indices[i];
       if (output_set.find(to_index) == output_set.end()) {
         output_set.insert(to_index);
+        //std::cout << "__connection__: " << from_index << " --> " << to_index << std::endl;
         std::vector<int> next_indices = graph_map[to_index];
-        buildGroupFromGraphMap(graph_map,
+        _buildGroupFromGraphMap(graph_map,
                                to_index,
                                next_indices,
                                output_set);
       }
     }
   }
+
+  void buildAllGroupsSetFromGraphMap(IntegerGraphMap graph_map,
+                                     std::vector<std::set<int> >& output_sets)
+  {
+    std::set<int> duplication_check_set;
+    for (IntegerGraphMap::iterator it = graph_map.begin();
+         it != graph_map.end();
+         ++it) {
+      int from_index = it->first;
+      if (duplication_check_set.find(from_index)
+          == duplication_check_set.end()) {
+        std::set<int> new_graph_set;
+        buildGroupFromGraphMap(graph_map, from_index, it->second,
+                               new_graph_set);
+        output_sets.push_back(new_graph_set);
+        // update duplication_check_set
+        addSet<int>(duplication_check_set, new_graph_set);
+      }
+    }
+  }
+  
 }
 


### PR DESCRIPTION
Refine the result of segmentation planes.
Originally, the result of segmentation might be too small, so we need to merge across several small planes.
This patch refines planar coefficients using RANSAC after merging.

Red line is the result before refinement, and blue line is the refined result

![screenshot_from_2014-09-10 15 06 14](https://cloud.githubusercontent.com/assets/40454/4213263/f58c5918-38b1-11e4-8285-aaa999de7f2b.png)
