### PR TITLE
Add new nodelet 'PlaneReasoner' to segment wall/ground

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -127,6 +127,8 @@ jsk_pcl_nodelet(src/bounding_box_filter_nodelet.cpp
   "jsk_pcl/BoundingBoxFilter" "bounding_box_filter")
 jsk_pcl_nodelet(src/organized_pass_through_nodelet.cpp
   "jsk_pcl/OrganizedPassThrough" "organized_pass_through")
+jsk_pcl_nodelet(src/plane_reasoner_nodelet.cpp
+  "jsk_pcl/PlaneReasoner" "plane_reasoner")
 rosbuild_add_library (jsk_pcl_ros
   ${jsk_pcl_nodelet_sources}
   src/grid_index.cpp src/grid_map.cpp src/grid_line.cpp src/geo_util.cpp

--- a/jsk_pcl_ros/catkin.cmake
+++ b/jsk_pcl_ros/catkin.cmake
@@ -67,6 +67,7 @@ add_service_files(FILES SwitchTopic.srv
 
 # generate the dynamic_reconfigure config file
 generate_dynamic_reconfigure_options(
+  cfg/PlaneReasoner.cfg
   cfg/OrganizedPassThrough.cfg
   cfg/EuclideanClustering.cfg
   cfg/ColorizeDistanceFromPlane.cfg
@@ -213,6 +214,8 @@ jsk_pcl_nodelet(src/bounding_box_filter_nodelet.cpp
   "jsk_pcl/BoundingBoxFilter" "bounding_box_filter")
 jsk_pcl_nodelet(src/organized_pass_through_nodelet.cpp
   "jsk_pcl/OrganizedPassThrough" "organized_pass_through")
+jsk_pcl_nodelet(src/plane_reasoner_nodelet.cpp
+  "jsk_pcl/PlaneReasoner" "plane_reasoner")
 
 add_library(jsk_pcl_ros SHARED ${jsk_pcl_nodelet_sources}
   src/grid_index.cpp src/grid_map.cpp src/grid_line.cpp src/geo_util.cpp

--- a/jsk_pcl_ros/cfg/PlaneReasoner.cfg
+++ b/jsk_pcl_ros/cfg/PlaneReasoner.cfg
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+# set up parameters that we care about
+PACKAGE = 'jsk_pcl_ros'
+
+try:
+    import imp
+    imp.find_module(PACKAGE)
+    from dynamic_reconfigure.parameter_generator_catkin import *;
+except:
+    import roslib; roslib.load_manifest(PACKAGE)
+    from dynamic_reconfigure.parameter_generator import *;
+
+from math import pi
+
+gen = ParameterGenerator ()
+
+gen.add("global_frame_id", str_t, 0, "frame_id of global cooridnates", "odom")
+gen.add("horizontal_angular_threshold", double_t, 0, "Horizontal Angular Threshold",  0.1, 0, 1.57)
+gen.add("vertical_angular_threshold", double_t, 0, "Vertical Angular Threshold",  0.1, 0, 1.57)
+
+
+exit (gen.generate (PACKAGE, "jsk_pcl_ros", "PlaneReasoner"))

--- a/jsk_pcl_ros/include/jsk_pcl_ros/geo_util.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/geo_util.h
@@ -145,6 +145,7 @@ namespace jsk_pcl_ros
     
     virtual double distance(const Plane& another);
     virtual double angle(const Plane& another);
+    virtual double angle(const Eigen::Vector3f& vector);
     virtual void project(const Eigen::Vector3f& p, Eigen::Vector3f& output);
     virtual void project(const Eigen::Vector3d& p, Eigen::Vector3d& output);
     virtual void project(const Eigen::Vector3d& p, Eigen::Vector3f& output);
@@ -159,6 +160,9 @@ namespace jsk_pcl_ros
     double d_;
   private:
   };
+
+  std::vector<Plane::Ptr> convertToPlanes(
+    std::vector<pcl::ModelCoefficients::Ptr>);
 
   class Polygon: public Plane
   {

--- a/jsk_pcl_ros/include/jsk_pcl_ros/plane_reasoner.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/plane_reasoner.h
@@ -1,0 +1,154 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+
+#ifndef JSK_PCL_ROS_PLANE_REASONER_H_
+#define JSK_PCL_ROS_PLANE_REASONER_H_
+
+#include "jsk_pcl_ros/diagnostic_nodelet.h"
+#include "jsk_pcl_ros/ClusterPointIndices.h"
+#include "jsk_pcl_ros/PolygonArray.h"
+#include "jsk_pcl_ros/ModelCoefficientsArray.h"
+
+#include <message_filters/subscriber.h>
+#include <message_filters/time_synchronizer.h>
+#include <message_filters/synchronizer.h>
+#include <tf/transform_listener.h>
+#include <dynamic_reconfigure/server.h>
+#include "jsk_pcl_ros/PlaneReasonerConfig.h"
+
+#include "jsk_pcl_ros/geo_util.h"
+
+namespace jsk_pcl_ros
+{
+  typedef boost::tuple<pcl::PointIndices::Ptr,
+                       pcl::ModelCoefficients::Ptr,
+                       Plane::Ptr,
+                       geometry_msgs::PolygonStamped>
+  PlaneInfoContainer;
+  
+  class PlaneReasoner: public DiagnosticNodelet
+  {
+  public:
+    ////////////////////////////////////////////////////////
+    // typedefs
+    ////////////////////////////////////////////////////////
+    typedef message_filters::sync_policies::ExactTime<
+    sensor_msgs::PointCloud2,
+    ClusterPointIndices,
+    ModelCoefficientsArray,
+    PolygonArray> SyncPolicy;
+    typedef jsk_pcl_ros::PlaneReasonerConfig Config;
+    typedef pcl::PointXYZRGB PointT;
+    
+    
+    PlaneReasoner(): DiagnosticNodelet("PlaneReasoner") { }
+
+  protected:
+    ////////////////////////////////////////////////////////
+    // Methods
+    ////////////////////////////////////////////////////////
+    virtual void onInit();
+    
+    virtual void reason(
+      const sensor_msgs::PointCloud2::ConstPtr& cloud_msg,
+      const ClusterPointIndices::ConstPtr& inliers_msg,
+      const ModelCoefficientsArray::ConstPtr& coefficients_msg,
+      const PolygonArray::ConstPtr& polygons_msg);
+
+    virtual void configCallback (Config &config, uint32_t level);
+
+    virtual void updateDiagnostic(
+      diagnostic_updater::DiagnosticStatusWrapper &stat);
+    
+    virtual std::vector<PlaneInfoContainer>
+    packInfo(std::vector<pcl::PointIndices::Ptr>& inliers,
+             std::vector<pcl::ModelCoefficients::Ptr>& coefficients,
+             std::vector<Plane::Ptr>& planes,
+             std::vector<geometry_msgs::PolygonStamped>& polygons);
+
+    virtual std::vector<PlaneInfoContainer>
+    filterHorizontalPlanes(
+      std::vector<PlaneInfoContainer>& infos);
+    
+    virtual std::vector<PlaneInfoContainer>
+    filterVerticalPlanes(
+      std::vector<PlaneInfoContainer>& infos);
+
+    virtual std::vector<PlaneInfoContainer>
+    filterPlanesAroundAngle(
+      double reference_angle,
+      double thrshold,
+      std::vector<PlaneInfoContainer>& infos);
+
+    virtual void publishPlaneInfo(
+      std::vector<PlaneInfoContainer>& containers,
+      const std_msgs::Header& header,
+      pcl::PointCloud<PointT>::Ptr cloud,
+      ros::Publisher& pub_inlier,
+      ros::Publisher& pub_coefficients,
+      ros::Publisher& pub_polygons);
+    
+    ////////////////////////////////////////////////////////
+    // ROS variables
+    ////////////////////////////////////////////////////////
+    message_filters::Subscriber<sensor_msgs::PointCloud2> sub_input_;
+    message_filters::Subscriber<ClusterPointIndices> sub_inliers_;
+    message_filters::Subscriber<ModelCoefficientsArray> sub_coefficients_;
+    message_filters::Subscriber<PolygonArray> sub_polygons_;
+    boost::shared_ptr<message_filters::Synchronizer<SyncPolicy> >sync_;
+    boost::shared_ptr<dynamic_reconfigure::Server<Config> > srv_;
+    boost::shared_ptr<tf::TransformListener> tf_listener_;
+    ros::Publisher pub_vertical_inliers_;
+    ros::Publisher pub_vertical_coefficients_;
+    ros::Publisher pub_vertical_polygons_;
+    ros::Publisher pub_horizontal_inliers_;
+    ros::Publisher pub_horizontal_coefficients_;
+    ros::Publisher pub_horizontal_polygons_;
+    
+    boost::mutex mutex_;
+    
+    ////////////////////////////////////////////////////////
+    // parameters
+    ////////////////////////////////////////////////////////
+    std::string global_frame_id_;
+    double horizontal_angular_threshold_;
+    double vertical_angular_threshold_;
+  private:
+    
+  };
+}
+
+#endif

--- a/jsk_pcl_ros/jsk_pcl_nodelets.xml
+++ b/jsk_pcl_ros/jsk_pcl_nodelets.xml
@@ -1,4 +1,10 @@
 <library path="lib/libjsk_pcl_ros">
+  <class name="jsk_pcl/PlaneReasoner" type="PlaneReasoner"
+         base_class_type="nodelet::Nodelet">
+    <description>
+      group polygons into several groups like vertical planes, horizontal planes.
+    </description>
+  </class>
   <class name="jsk_pcl/OrganizedPassThrough" type="OrganizedPassThrough"
          base_class_type="nodelet::Nodelet">
     <description>

--- a/jsk_pcl_ros/src/geo_util.cpp
+++ b/jsk_pcl_ros/src/geo_util.cpp
@@ -317,6 +317,23 @@ namespace jsk_pcl_ros
     return fabs(fabs(d_) - fabs(another.d_));
   }
 
+  double Plane::angle(const Eigen::Vector3f& vector)
+  {
+    double dot = normal_.dot(vector);
+    if (dot > 1.0) {
+      dot = 1.0;
+    }
+    else if (dot < -1.0) {
+      dot = -1.0;
+    }
+    double theta = acos(dot);
+    if (theta > M_PI / 2.0) {
+      return M_PI - theta;
+    }
+
+    return acos(dot);
+  }
+  
   double Plane::angle(const Plane& another)
   {
     double dot = normal_.dot(another.normal_);
@@ -415,6 +432,17 @@ namespace jsk_pcl_ros
     }
     return Polygon(skipped_vertices);
   }
+
+  std::vector<Plane::Ptr> convertToPlanes(
+    std::vector<pcl::ModelCoefficients::Ptr> coefficients)
+  {
+    std::vector<Plane::Ptr> ret;
+    for (size_t i = 0; i < coefficients.size(); i++) {
+      ret.push_back(Plane::Ptr (new Plane(coefficients[i]->values)));
+    }
+    return ret;
+  }
+  
   
   Polygon::Polygon(const Vertices& vertices):
     Plane((vertices[1] - vertices[0]).cross(vertices[2] - vertices[0]).normalized(), vertices[0]),

--- a/jsk_pcl_ros/src/organized_pass_through_nodelet.cpp
+++ b/jsk_pcl_ros/src/organized_pass_through_nodelet.cpp
@@ -119,6 +119,7 @@ namespace jsk_pcl_ros
     pcl::toROSMsg(output, ros_output);
     ros_output.header = msg->header;
     pub_.publish(ros_output);
+    diagnostic_updater_->update();
   }
 
   void OrganizedPassThrough::updateDiagnostic(

--- a/jsk_pcl_ros/src/plane_reasoner_nodelet.cpp
+++ b/jsk_pcl_ros/src/plane_reasoner_nodelet.cpp
@@ -1,0 +1,268 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include "jsk_pcl_ros/pcl_conversion_util.h"
+#include "jsk_pcl_ros/plane_reasoner.h"
+#include <tf_conversions/tf_eigen.h>
+
+namespace jsk_pcl_ros
+{
+  void PlaneReasoner::onInit()
+  {
+    ////////////////////////////////////////////////////////
+    // Diagnostics
+    ////////////////////////////////////////////////////////
+    DiagnosticNodelet::onInit();
+    tf_listener_.reset(new tf::TransformListener());
+    
+    ////////////////////////////////////////////////////////
+    // Dynamic Reconfigure
+    ////////////////////////////////////////////////////////
+    srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
+    dynamic_reconfigure::Server<Config>::CallbackType f =
+      boost::bind (
+        &PlaneReasoner::configCallback, this, _1, _2);
+    srv_->setCallback (f);
+
+    ////////////////////////////////////////////////////////
+    // Publishers
+    ////////////////////////////////////////////////////////
+    pub_vertical_inliers_
+      = pnh_->advertise<ClusterPointIndices>("output/vertical/inliers", 1);
+    pub_vertical_coefficients_
+      = pnh_->advertise<ModelCoefficientsArray>("output/vertical/coefficients", 1);
+    pub_vertical_polygons_
+      = pnh_->advertise<PolygonArray>("output/vertical/polygons", 1);
+    pub_horizontal_inliers_
+      = pnh_->advertise<ClusterPointIndices>("output/horizontal/inliers", 1);
+    pub_horizontal_coefficients_
+      = pnh_->advertise<ModelCoefficientsArray>("output/horizontal/coefficients", 1);
+    pub_horizontal_polygons_
+      = pnh_->advertise<PolygonArray>("output/horizontal/polygons", 1);
+    ////////////////////////////////////////////////////////
+    // Subscribers
+    ////////////////////////////////////////////////////////
+    sub_input_.subscribe(*pnh_, "input", 1);
+    sub_inliers_.subscribe(*pnh_, "input_inliers", 1);
+    sub_coefficients_.subscribe(*pnh_, "input_coefficients", 1);
+    sub_polygons_.subscribe(*pnh_, "input_polygons", 1);
+    sync_ = boost::make_shared<message_filters::Synchronizer<SyncPolicy> >(100);
+    sync_->connectInput(sub_input_, sub_inliers_,
+                        sub_coefficients_, sub_polygons_);
+    sync_->registerCallback(boost::bind(&PlaneReasoner::reason,
+                                        this, _1, _2, _3, _4));
+  }
+
+  void PlaneReasoner::configCallback(Config &config, uint32_t level)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+    global_frame_id_ = config.global_frame_id;
+    horizontal_angular_threshold_ = config.horizontal_angular_threshold;
+    vertical_angular_threshold_ = config.vertical_angular_threshold;
+  }
+
+  void PlaneReasoner::updateDiagnostic(
+    diagnostic_updater::DiagnosticStatusWrapper &stat)
+  {
+    if (vital_checker_->isAlive()) {
+      stat.summary(diagnostic_msgs::DiagnosticStatus::OK,
+                   name_ + " running");
+    }
+    else {
+      addDiagnosticErrorSummary(
+        name_, vital_checker_, stat);
+    }
+  }
+
+  void PlaneReasoner::reason(
+      const sensor_msgs::PointCloud2::ConstPtr& cloud_msg,
+      const ClusterPointIndices::ConstPtr& inliers_msg,
+      const ModelCoefficientsArray::ConstPtr& coefficients_msg,
+      const PolygonArray::ConstPtr& polygons_msg)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+    // Check the size of the array messages first
+    if ((inliers_msg->cluster_indices.size()
+         != coefficients_msg->coefficients.size()) ||
+        (inliers_msg->cluster_indices.size()
+         != polygons_msg->polygons.size())) {
+      NODELET_FATAL("the size of inliers, coefficients and polygons are not same");
+      return;
+    }
+    vital_checker_->poke();
+    pcl::PointCloud<PointT>::Ptr input_cloud (new pcl::PointCloud<PointT>);
+    pcl::fromROSMsg(*cloud_msg, *input_cloud);
+    
+    // convert ROS msg to PCL/jsk_pcl messages
+    std::vector<pcl::PointIndices::Ptr> inliers
+      = pcl_conversions::convertToPCLPointIndices(inliers_msg->cluster_indices);
+    std::vector<pcl::ModelCoefficients::Ptr> coefficients
+      = pcl_conversions::convertToPCLModelCoefficients(
+        coefficients_msg->coefficients);
+    std::vector<Plane::Ptr> planes = convertToPlanes(coefficients);
+    std::vector<geometry_msgs::PolygonStamped> polygons = polygons_msg->polygons;
+    std::vector<PlaneInfoContainer> plane_infos
+      = packInfo(inliers, coefficients, planes, polygons);
+    std::vector<PlaneInfoContainer> horizontal_planes
+      = filterHorizontalPlanes(plane_infos);
+    std::vector<PlaneInfoContainer> vertical_planes
+      = filterVerticalPlanes(plane_infos);
+    publishPlaneInfo(vertical_planes,
+                     cloud_msg->header,
+                     input_cloud,
+                     pub_vertical_inliers_,
+                     pub_vertical_coefficients_,
+                     pub_vertical_polygons_);
+    publishPlaneInfo(horizontal_planes,
+                     cloud_msg->header,
+                     input_cloud,
+                     pub_horizontal_inliers_,
+                     pub_horizontal_coefficients_,
+                     pub_horizontal_polygons_);
+  }
+
+  void PlaneReasoner::publishPlaneInfo(
+    std::vector<PlaneInfoContainer>& containers,
+    const std_msgs::Header& header,
+    pcl::PointCloud<PointT>::Ptr cloud,
+    ros::Publisher& pub_inlier,
+    ros::Publisher& pub_coefficients,
+    ros::Publisher& pub_polygons)
+  {
+    std::vector<pcl::PointIndices::Ptr> inliers;
+    std::vector<pcl::ModelCoefficients::Ptr> coefficients;
+    std::vector<geometry_msgs::PolygonStamped> polygons;
+    for (size_t i = 0; i < containers.size(); i++) {
+      inliers.push_back(containers[i].get<0>());
+      coefficients.push_back(containers[i].get<1>());
+      polygons.push_back(containers[i].get<3>());
+    }
+    ClusterPointIndices ros_indices;
+    ModelCoefficientsArray ros_coefficients;
+    PolygonArray ros_polygons;
+    ros_indices.header = header;
+    ros_coefficients.header = header;
+    ros_polygons.header = header;
+    ros_indices.cluster_indices = pcl_conversions::convertToROSPointIndices(
+      inliers, header);
+    ros_coefficients.coefficients
+      = pcl_conversions::convertToROSModelCoefficients(
+        coefficients, header);
+    ros_polygons.polygons = polygons;
+    pub_inlier.publish(ros_indices);
+    pub_coefficients.publish(ros_coefficients);
+    pub_polygons.publish(ros_polygons);
+  }
+  
+  std::vector<PlaneInfoContainer>
+  PlaneReasoner::filterPlanesAroundAngle(
+    double reference_angle,
+    double thrshold,
+    std::vector<PlaneInfoContainer>& infos)
+  {
+    
+    std::vector<PlaneInfoContainer> ret;
+    for (size_t i = 0; i < infos.size(); i++) {
+      PlaneInfoContainer plane_info = infos[i];
+      if (tf_listener_->canTransform(global_frame_id_,
+                                     plane_info.get<3>().header.frame_id,
+                                     plane_info.get<3>().header.stamp)) {
+        tf::StampedTransform transform;
+        tf_listener_->lookupTransform(plane_info.get<3>().header.frame_id, global_frame_id_,
+                                      
+                                      plane_info.get<3>().header.stamp,
+                                      transform);
+        Eigen::Affine3d eigen_transform;
+        tf::transformTFToEigen(transform, eigen_transform);
+        Eigen::Affine3f eigen_transform_3f;
+        Eigen::Vector3d up_d =  (eigen_transform.rotation() * Eigen::Vector3d(0, 0, 1));
+        Eigen::Vector3f up;
+        pointFromVectorToVector<Eigen::Vector3d, Eigen::Vector3f>(up_d, up);
+        Plane::Ptr plane = plane_info.get<2>();
+        double angle = plane->angle(up);
+        // ROS_INFO("axis: [%f, %f, %f]", up[0], up[1], up[2]);
+        // ROS_INFO("plane: [%f, %f, %f, %f]", plane_info.get<1>()->values[0], plane_info.get<1>()->values[1], plane_info.get<1>()->values[2], plane_info.get<1>()->values[3]);
+        // ROS_INFO("angle: %f", angle);
+        if (fabs(angle - reference_angle) < thrshold) {
+          ret.push_back(plane_info);
+        }
+      }
+    }
+    return ret;
+  }
+  
+  std::vector<PlaneInfoContainer>
+  PlaneReasoner::filterHorizontalPlanes(
+    std::vector<PlaneInfoContainer>& infos)
+  {
+    return filterPlanesAroundAngle(
+      0,
+      horizontal_angular_threshold_,
+      infos);
+  }
+  
+  std::vector<PlaneInfoContainer>
+  PlaneReasoner::filterVerticalPlanes(
+    std::vector<PlaneInfoContainer>& infos)
+  {
+    return filterPlanesAroundAngle(
+      M_PI / 2.0,
+      vertical_angular_threshold_,
+      infos);
+  }
+
+  std::vector<PlaneInfoContainer>
+  PlaneReasoner::packInfo(
+    std::vector<pcl::PointIndices::Ptr>& inliers,
+    std::vector<pcl::ModelCoefficients::Ptr>& coefficients,
+    std::vector<Plane::Ptr>& planes,
+    std::vector<geometry_msgs::PolygonStamped>& polygons)
+  {
+    std::vector<PlaneInfoContainer> ret;
+    for (size_t i = 0; i < inliers.size(); i++) {
+      ret.push_back(boost::make_tuple<pcl::PointIndices::Ptr,
+                    pcl::ModelCoefficients::Ptr,
+                    Plane::Ptr>(inliers[i], coefficients[i],
+                                planes[i], polygons[i]));
+    }
+    return ret;
+  }
+
+  
+}
+
+#include <pluginlib/class_list_macros.h>
+typedef jsk_pcl_ros::PlaneReasoner PlaneReasoner;
+PLUGINLIB_DECLARE_CLASS (jsk_pcl, PlaneReasoner, PlaneReasoner, nodelet::Nodelet);


### PR DESCRIPTION
a nodelet which takes list of planes and classifies them into wall and ground.

Red planes are regarded as "ground" and green ones are regarded as "wall".

![screenshot from 2014-09-25 22 43 19](https://cloud.githubusercontent.com/assets/40454/4405327/f933c8b2-44b9-11e4-8bf3-dde6e53bcc10.png)
