### PR TITLE
add new nodelet to align two pointcloud based on ICP algorithm

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -129,6 +129,8 @@ jsk_pcl_nodelet(src/organized_pass_through_nodelet.cpp
   "jsk_pcl/OrganizedPassThrough" "organized_pass_through")
 jsk_pcl_nodelet(src/plane_reasoner_nodelet.cpp
   "jsk_pcl/PlaneReasoner" "plane_reasoner")
+jsk_pcl_nodelet(src/icp_registration_nodelet.cpp
+  "jsk_pcl/ICPRegistration" "icp_registration")
 rosbuild_add_library (jsk_pcl_ros
   ${jsk_pcl_nodelet_sources}
   src/grid_index.cpp src/grid_map.cpp src/grid_line.cpp src/geo_util.cpp

--- a/jsk_pcl_ros/catkin.cmake
+++ b/jsk_pcl_ros/catkin.cmake
@@ -216,6 +216,8 @@ jsk_pcl_nodelet(src/organized_pass_through_nodelet.cpp
   "jsk_pcl/OrganizedPassThrough" "organized_pass_through")
 jsk_pcl_nodelet(src/plane_reasoner_nodelet.cpp
   "jsk_pcl/PlaneReasoner" "plane_reasoner")
+jsk_pcl_nodelet(src/icp_registration_nodelet.cpp
+  "jsk_pcl/ICPRegistration" "icp_registration")
 
 add_library(jsk_pcl_ros SHARED ${jsk_pcl_nodelet_sources}
   src/grid_index.cpp src/grid_map.cpp src/grid_line.cpp src/geo_util.cpp

--- a/jsk_pcl_ros/include/jsk_pcl_ros/icp_registration.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/icp_registration.h
@@ -1,0 +1,75 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+
+#ifndef JSK_PCL_ROS_ICP_REGISTRATION_H_
+#define JSK_PCL_ROS_ICP_REGISTRATION_H_
+
+#include <pcl_ros/pcl_nodelet.h>
+
+namespace jsk_pcl_ros
+{
+  class ICPRegistration: public pcl_ros::PCLNodelet
+  {
+  public:
+    typedef pcl::PointXYZRGB PointT;
+  protected:
+    ////////////////////////////////////////////////////////
+    // methosd
+    ////////////////////////////////////////////////////////
+    virtual void onInit();
+    virtual void align(const sensor_msgs::PointCloud2::ConstPtr& msg);
+    virtual void referenceCallback(
+      const sensor_msgs::PointCloud2::ConstPtr& msg);
+
+    ////////////////////////////////////////////////////////
+    // ROS variables
+    ////////////////////////////////////////////////////////
+    ros::Subscriber sub_;
+    ros::Subscriber sub_reference_;
+    ros::Publisher pub_result_pose_;
+    ros::Publisher pub_result_cloud_;
+    boost::mutex mutex_;
+
+    ////////////////////////////////////////////////////////
+    // parameters
+    ////////////////////////////////////////////////////////
+    pcl::PointCloud<PointT>::Ptr reference_cloud_;
+  private:
+    
+  };
+}
+
+#endif

--- a/jsk_pcl_ros/include/jsk_pcl_ros/pcl_conversion_util.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/pcl_conversion_util.h
@@ -81,6 +81,18 @@ namespace jsk_pcl_ros
   {
     to[0] = from[0]; to[1] = from[1]; to[2] = from[2];
   }
+
+  template<class FromT, class ToT>
+  void convertMatrix4(const FromT& from,
+                      ToT& to)
+  {
+    for (size_t i = 0; i < 4; i++) {
+      for (size_t j = 0; j < 4; j++) {
+        to(i, j) = from(i, j);
+      }
+    }
+  }
+  
 }
 // extend pcl_conversions package's toPCL and fromPCL functions
 namespace pcl_conversions

--- a/jsk_pcl_ros/jsk_pcl_nodelets.xml
+++ b/jsk_pcl_ros/jsk_pcl_nodelets.xml
@@ -1,4 +1,10 @@
 <library path="lib/libjsk_pcl_ros">
+  <class name="jsk_pcl/ICPRegistration" type="ICPRegistration"
+         base_class_type="nodelet::Nodelet">
+    <description>
+      register pointclouds using ICP algorithm
+    </description>
+  </class>
   <class name="jsk_pcl/PlaneReasoner" type="PlaneReasoner"
          base_class_type="nodelet::Nodelet">
     <description>

--- a/jsk_pcl_ros/launch/organized_multi_plane_segmentation.launch
+++ b/jsk_pcl_ros/launch/organized_multi_plane_segmentation.launch
@@ -3,6 +3,8 @@
   <remap from="/diagnostics_agg" to="/diagnostics_pcl_agg" />
   <arg name="BASE_FRAME_ID" default="odom" />
   <arg name="INPUT" default="/camera/depth_registered/points" />
+  <arg name="ICP_REGISTRATION" default="false" />
+  <arg name="MODEL_FILE" default="$(find jsk_pcl_ros)/hand_drill.pcd" />
   <arg name="LAUNCH_MANAGER" default="true" />
   <arg name="MANAGER" default="manager" />
   <arg name="ESTIMATE_OCCLUSION" default="false" />
@@ -10,6 +12,7 @@
   <arg name="HANDLE_ESTIMATOR" default="false" />
   <arg name="MACHINE" default="localhost"/>
   <arg name="GDB" default="false" />
+  <arg name="SAVE_SELECTED_CLOUD" default="false" />
   <machine name="localhost" address="localhost" />
   <group if="$(arg LAUNCH_MANAGER)">
     <node pkg="nodelet" type="nodelet" name="$(arg MANAGER)"
@@ -259,4 +262,21 @@
   </node>
   <node pkg="rqt_robot_monitor" type="rqt_robot_monitor"
         name="pcl_diagnostics_monitor" />
+  <group if="$(arg SAVE_SELECTED_CLOUD)">
+    <node pkg="nodelet" type="nodelet" name="pcd_saver"
+          args="load pcl/PCDWriter /$(arg MANAGER)">
+      <remap from="~input" to="/selected_pointcloud" />
+    </node>
+  </group>
+  <group if="$(arg ICP_REGISTRATION)">
+    <node pkg="nodelet" type="nodelet" name="icp_registration"
+          args="load jsk_pcl/ICPRegistration /$(arg MANAGER)">
+      <remap from="~input" to="/selected_pointcloud" />
+      <remap from="~input_reference" to="reference_cloud" />
+    </node>
+    <node pkg="pcl_ros" type="pcd_to_pointcloud" name="model_publisher"
+          args="$(arg MODEL_FILE)">
+      <remap from="cloud_pcd" to="reference_cloud" />
+    </node>
+  </group>
 </launch>

--- a/jsk_pcl_ros/src/icp_registration_nodelet.cpp
+++ b/jsk_pcl_ros/src/icp_registration_nodelet.cpp
@@ -1,0 +1,114 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include "jsk_pcl_ros/icp_registration.h"
+#include <pcl/registration/icp.h>
+#include "jsk_pcl_ros/pcl_conversion_util.h"
+#include <eigen_conversions/eigen_msg.h>
+
+namespace jsk_pcl_ros
+{
+  void ICPRegistration::onInit()
+  {
+    PCLNodelet::onInit();
+
+    pub_result_pose_ = pnh_->advertise<geometry_msgs::PoseStamped>(
+      "output_pose", 1);
+    pub_result_cloud_ = pnh_->advertise<sensor_msgs::PointCloud2>(
+      "output", 1);
+    ////////////////////////////////////////////////////////
+    // subscription
+    ////////////////////////////////////////////////////////
+    sub_reference_ = pnh_->subscribe("input_reference", 1,
+                                     &ICPRegistration::referenceCallback,
+                                     this);
+    sub_ = pnh_->subscribe("input", 1,
+                           &ICPRegistration::align,
+                           this);
+  }
+
+  void ICPRegistration::align(const sensor_msgs::PointCloud2::ConstPtr& msg)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+    if (!reference_cloud_) {
+      NODELET_FATAL("no reference is specified");
+      return;
+    }
+    
+    pcl::PointCloud<PointT>::Ptr cloud (new pcl::PointCloud<PointT>);
+    pcl::fromROSMsg(*msg, *cloud);
+    pcl::IterativeClosestPoint<PointT, PointT> icp;
+    // icp.setInputSource(cloud);
+    // icp.setInputTarget(reference_cloud_);
+    icp.setInputSource(reference_cloud_);
+    icp.setInputTarget(cloud);
+    pcl::PointCloud<PointT> final;
+    icp.align(final);
+    NODELET_INFO_STREAM("ICP converged: " << icp.hasConverged());
+    NODELET_INFO_STREAM("ICP score: " << icp.getFitnessScore());
+    
+    Eigen::Matrix4f transformation = icp.getFinalTransformation ();
+    Eigen::Matrix4d transformation_d;
+    convertMatrix4<Eigen::Matrix4f, Eigen::Matrix4d>(
+      transformation, transformation_d);
+    Eigen::Affine3d transform_affine (transformation_d);
+    geometry_msgs::PoseStamped pose;
+    pose.header = msg->header;
+    tf::poseEigenToMsg(transform_affine, pose.pose);
+    pub_result_pose_.publish(pose);
+    // convert Eigen Matrix4f to Matrix4d
+    sensor_msgs::PointCloud2 ros_final;
+    pcl::toROSMsg(final, ros_final);
+    ros_final.header = msg->header;
+    pub_result_cloud_.publish(ros_final);
+  }
+  
+  void ICPRegistration::referenceCallback(
+    const sensor_msgs::PointCloud2::ConstPtr& msg)
+  {
+    
+    pcl::PointCloud<PointT>::Ptr cloud (new pcl::PointCloud<PointT>);
+    pcl::fromROSMsg(*msg, *cloud);
+    {
+      boost::mutex::scoped_lock lock(mutex_);
+      reference_cloud_ = cloud;
+    }
+  }
+  
+}
+
+#include <pluginlib/class_list_macros.h>
+typedef jsk_pcl_ros::ICPRegistration ICPRegistration;
+PLUGINLIB_DECLARE_CLASS (jsk_pcl, ICPRegistration, ICPRegistration, nodelet::Nodelet);


### PR DESCRIPTION
a simple nodelet to align two pointcloud based on ICP.
- example)
  run segmentation to segment the target pointcloud.

reference:
![reference_drill_0](https://cloud.githubusercontent.com/assets/40454/4416439/79c2c0a0-4541-11e4-8c7f-cc4b68b03e9a.png)
![reference_drill1](https://cloud.githubusercontent.com/assets/40454/4416440/79c5f964-4541-11e4-8e16-c3f03bd5c70d.png)

result: (red pointcloud is the result of alignment)
![screenshot from 2014-09-26 14 48 57](https://cloud.githubusercontent.com/assets/40454/4416443/828c6bf0-4541-11e4-992c-b73169d397c8.png)
![screenshot from 2014-09-26 14 50 07](https://cloud.githubusercontent.com/assets/40454/4416445/828f9348-4541-11e4-9fe8-02ba29e224f6.png)
![screenshot from 2014-09-26 14 50 26](https://cloud.githubusercontent.com/assets/40454/4416444/828f3380-4541-11e4-80d2-969b4ba09cc7.png)
![screenshot from 2014-09-26 14 51 19](https://cloud.githubusercontent.com/assets/40454/4416446/82907812-4541-11e4-99e3-63121d734481.png)
