### PR TITLE
Fix joint state static filter

### DIFF
--- a/jsk_pcl_ros/config/pr2_sensor_joint.yaml
+++ b/jsk_pcl_ros/config/pr2_sensor_joint.yaml
@@ -1,0 +1,1 @@
+joint_names: ["head_tilt_joint", "head_pan_joint", "torso_lift_joint"]

--- a/jsk_pcl_ros/launch/organized_multi_plane_segmentation.launch
+++ b/jsk_pcl_ros/launch/organized_multi_plane_segmentation.launch
@@ -3,7 +3,9 @@
   <remap from="/diagnostics_agg" to="/diagnostics_pcl_agg" />
   <arg name="BASE_FRAME_ID" default="odom" />
   <arg name="RUN_SELF_FILTER" default="false"/>
-  <arg name="SELF_FILTER_PARAM" value="$(find jsk_pr2_startup)/jsk_pr2_sensors/tilt_self_filter.yaml" />
+  <arg name="SELF_FILTER_PARAM" default="$(find jsk_pr2_startup)/jsk_pr2_sensors/tilt_self_filter.yaml" />
+  <arg name="JOINT_STATIC_FILTER" default="false" />
+  <arg name="FILTER_JOINT_PARAM" value="$(find jsk_pcl_ros)/config/pr2_sensor_joint.yaml" />
   <arg name="INPUT" default="/camera/depth_registered/points" />
   <arg name="ICP_REGISTRATION" default="false" />
   <arg name="MODEL_FILE" default="$(find jsk_pcl_ros)/models/hand_drill_kinect.pcd" />
@@ -48,7 +50,19 @@
         args="load jsk_topic_tools/Relay $(arg MANAGER)">
     <remap from="~input" to="$(arg INPUT)" unless="$(arg RUN_SELF_FILTER)" />
     <remap from="~input" to="openni_cloud_self_filter/cloud_out" if="$(arg RUN_SELF_FILTER)" />
+    <remap from="~output" to="~raw_output" if="$(arg JOINT_STATIC_FILTER)" />
   </node>
+  
+  <node pkg="nodelet" type="nodelet" name="joint_static_filter"
+        if="$(arg JOINT_STATIC_FILTER)"
+        machine="$(arg MACHINE)"
+        args="load jsk_pcl/JointStateStaticFilter /$(arg MANAGER)">
+    <remap from="~input_joint_state" to="/joint_states" />
+    <remap from="~input" to="input_relay/raw_output"/>
+    <remap from="~output" to="input_relay/output" />
+    <rosparam command="load" file="$(arg FILTER_JOINT_PARAM)" />
+  </node>
+  
   <node pkg="nodelet" type="nodelet" name="multi_plane_estimate"
         machine="$(arg MACHINE)"
         args="load jsk_pcl/OrganizedMultiPlaneSegmentation $(arg MANAGER)"

--- a/jsk_pcl_ros/src/joint_state_static_filter_nodelet.cpp
+++ b/jsk_pcl_ros/src/joint_state_static_filter_nodelet.cpp
@@ -66,6 +66,7 @@ namespace jsk_pcl_ros
     const sensor_msgs::PointCloud2::ConstPtr& msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+    NODELET_DEBUG("Pointcloud Callback");
     vital_checker_->poke();
     if (isStatic(msg->header.stamp)) {
       ROS_DEBUG("static");
@@ -105,16 +106,16 @@ namespace jsk_pcl_ros
   {
     double min_diff = DBL_MAX;
     bool min_value = false;
-    
     for (boost::circular_buffer<StampedBool>::iterator it = buf_.begin();
          it != buf_.end();
          ++it) {
-      double diff = (it->get<0>() - stamp).toSec();
+      double diff = fabs((it->get<0>() - stamp).toSec());
       if (diff < min_diff) {
         min_value = it->get<1>();
         min_diff = diff;
       }
     }
+    NODELET_DEBUG("min_diff: %f", min_diff);
     return min_value;
   }
   
@@ -122,6 +123,7 @@ namespace jsk_pcl_ros
     const sensor_msgs::JointState::ConstPtr& msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+    NODELET_DEBUG("jointCallback");
     // filter out joints based on joint names
     std::vector<double> joints = filterJointState(msg);
     if (joints.size() == 0) {


### PR DESCRIPTION
Fix JointStateStaticFilter to use absolute difference when calculating nearest timestamp of divergence of joint states.
And add JointStateStaticFilter to organized_multi_plane_segmentation.launch if JOINT_STATIC_FILTER:=true
