### PR TITLE
modified detection-interface.l

### DIFF
--- a/jsk_perception/euslisp/detection_interface.l
+++ b/jsk_perception/euslisp/detection_interface.l
@@ -67,8 +67,8 @@
 (defun start-detection-interface-subscribe (tf-force obj &optional (topic *detection-topic*))
   (ros::ros-info "start subscribe ~A" topic)
   (ros::subscribe topic
-    posedetection_msgs::ObjectDetection
-    #'detection-interface-objectdetection tf-force obj))
+                  posedetection_msgs::ObjectDetection
+                  #'detection-interface-objectdetection tf-force obj))
 (defun stop-detection-interface-subscribe (&optional (topic *detection-topic*))
   (ros::ros-info "stop subscribe ~A" topic)
   (ros::unsubscribe topic))
@@ -94,10 +94,9 @@
            (t (speak-jp (format nil "~aをさがしています" (send target-obj :speak-name)))))
         (speak-jp (format nil "~a を さがして います" (send target-obj :speak-name)))))
     (start-detection-interface-subscribe tf-force target-obj detection-topic)
-    (send *ri* :ros-wait 2.0 :spin-self t
+    (send *ri* :ros-wait 0.0 :spin-self t
           :func-before-throw #'(lambda (sl) (stop-detection-interface-subscribe detection-topic))) ;; attention-check ...
     (send target-obj :stamp (ros::time-now))
-    
     (let* (current-object-coords
            previous-object-coords
            (start-time (ros::time-now)) (detect-object-list))


### PR DESCRIPTION
冷蔵庫デモにかかる時間を短縮するため、認識にかかる時間を短縮する。
go-posなどで動いた後、画像のぶれが止まるのを待つために2s待つ処理が入っていると思われるが、画像が７hz程度で更新されるようになったので、ここを0sにしても問題ないと思われる。
実験を何度も行ってみたが、動作に支障はきたさなかった。
この変更により、check-detectionにかかる時間が平均でおよそ２sとなり、デモ全体として１３s程度の短縮となる。
