### PR TITLE
Add moveit plugin to just filter pointcloud which belongs to robot

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -151,6 +151,7 @@ rosbuild_add_library (jsk_pcl_ros
   src/pcl_conversion_util.cpp src/pcl_util.cpp
   src/diagnostic_nodelet.cpp
   src/connection_based_nodelet.cpp
+  src/pointcloud_moveit_filter.cpp
 )
 rosbuild_add_openmp_flags(jsk_pcl_ros)
 

--- a/jsk_pcl_ros/catkin.cmake
+++ b/jsk_pcl_ros/catkin.cmake
@@ -29,7 +29,7 @@ find_package(catkin REQUIRED COMPONENTS
   eigen_conversions tf_conversions tf2_ros tf
   image_transport nodelet cv_bridge
   ${ML_CLASSIFIERS} sklearn jsk_topic_tools
-  laser_assembler)
+  laser_assembler moveit_ros_perception)
 # only run in hydro
 if(NOT $ENV{ROS_DISTRO} STREQUAL "groovy")
   find_package(PCL REQUIRED)
@@ -250,6 +250,7 @@ add_library(jsk_pcl_ros SHARED ${jsk_pcl_nodelet_sources}
   src/grid_index.cpp src/grid_map.cpp src/grid_line.cpp src/geo_util.cpp
   src/pcl_conversion_util.cpp src/pcl_util.cpp
   src/diagnostic_nodelet.cpp
+  src/pointcloud_moveit_filter.cpp
   src/connection_based_nodelet.cpp)
 target_link_libraries(jsk_pcl_ros ${catkin_LIBRARIES} ${pcl_ros_LIBRARIES} ${OpenCV_LIBRARIES})
 add_dependencies(jsk_pcl_ros ${PROJECT_NAME}_gencpp ${PROJECT_NAME}_gencfg)

--- a/jsk_pcl_ros/include/jsk_pcl_ros/pointcloud_moveit_filter.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/pointcloud_moveit_filter.h
@@ -1,0 +1,180 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+
+#ifndef JSK_PCL_ROS_POINTCLOUD_MOVEIT_FILTER_H_
+#define JSK_PCL_ROS_POINTCLOUD_MOVEIT_FILTER_H_
+
+#include <ros/ros.h>
+#include <tf/tf.h>
+#include <tf/message_filter.h>
+#include <message_filters/subscriber.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <moveit/occupancy_map_monitor/occupancy_map_updater.h>
+#include <moveit/point_containment_filter/shape_mask.h>
+#include <moveit/occupancy_map_monitor/occupancy_map_monitor.h>
+#include <XmlRpcException.h>
+#include <pcl/point_types.h>
+#include <pcl/point_cloud.h>
+#include <pcl_conversions/pcl_conversions.h>
+#include <pcl/filters/extract_indices.h>
+
+namespace jsk_pcl_ros
+{
+  typedef occupancy_map_monitor::ShapeHandle ShapeHandle;
+  typedef occupancy_map_monitor::ShapeTransformCache ShapeTransformCache;
+  class PointCloudMoveitFilter:
+    public occupancy_map_monitor::OccupancyMapUpdater
+  {
+  public:
+    PointCloudMoveitFilter();
+    virtual ~PointCloudMoveitFilter();
+
+    virtual bool setParams(XmlRpc::XmlRpcValue &params);
+    virtual bool initialize();
+    virtual void start();
+    virtual void stop();
+    virtual ShapeHandle excludeShape(const shapes::ShapeConstPtr &shape);
+    virtual void forgetShape(ShapeHandle handle);
+    
+  protected:
+    virtual void stopHelper();
+    virtual bool getShapeTransform(ShapeHandle h,
+                                   Eigen::Affine3d &transform) const;
+    template <typename PointT>
+    void cloudMsgCallback(
+      const sensor_msgs::PointCloud2::ConstPtr &cloud_msg)
+      {
+        if (monitor_->getMapFrame().empty())
+          monitor_->setMapFrame(cloud_msg->header.frame_id);
+        tf::StampedTransform map_H_sensor;
+        if (monitor_->getMapFrame() == cloud_msg->header.frame_id) {
+          map_H_sensor.setIdentity();
+        }
+        else {
+          if (tf_) {
+            try
+            {
+              tf_->lookupTransform(monitor_->getMapFrame(),
+                                   cloud_msg->header.frame_id,
+                                   cloud_msg->header.stamp,
+                                   map_H_sensor);
+            }
+            catch (tf::TransformException& ex)
+            {
+              ROS_ERROR_STREAM("Transform error of sensor data: "
+                               << ex.what() << "; quitting callback");
+              return;
+            }
+          }
+          else {
+            return;
+          }
+        }
+        /* convert cloud message to pcl cloud object */
+        //typename pcl::PointCloud<PointT>::Ptr cloud(pcl::PointCloud<PointT>);
+        typename pcl::PointCloud<PointT>::Ptr cloud;
+        cloud.reset(new pcl::PointCloud<PointT>());
+        pcl::PointCloud<pcl::PointXYZ> xyz_cloud;
+        pcl::fromROSMsg(*cloud_msg, *cloud);
+        pcl::fromROSMsg(*cloud_msg, xyz_cloud);
+        const tf::Vector3 &sensor_origin_tf = map_H_sensor.getOrigin();
+        octomap::point3d sensor_origin(
+          sensor_origin_tf.getX(),
+          sensor_origin_tf.getY(),
+          sensor_origin_tf.getZ());
+        Eigen::Vector3d sensor_origin_eigen(
+          sensor_origin_tf.getX(),
+          sensor_origin_tf.getY(),
+          sensor_origin_tf.getZ());
+        if (!updateTransformCache(cloud_msg->header.frame_id,
+                                  cloud_msg->header.stamp))
+        {
+          ROS_ERROR_THROTTLE(
+            1, "Transform cache was not updated. Self-filtering may fail.");
+          return;
+        }
+        /* mask out points on the robot */
+        shape_mask_->maskContainment(xyz_cloud, sensor_origin_eigen, 0.0,
+                                     max_range_, mask_);
+        typename pcl::PointCloud<PointT>::Ptr
+          filtered_cloud (new pcl::PointCloud<PointT>);
+        pcl::PointIndices::Ptr indices (new pcl::PointIndices);
+        // convert mask into indices
+        for (size_t i = 0; i < mask_.size(); i++) {
+          if (mask_[i] == point_containment_filter::ShapeMask::OUTSIDE) {
+            indices->indices.push_back(i);
+          }
+        }
+        pcl::ExtractIndices<PointT> ex;
+        ex.setInputCloud(cloud);
+        ex.setIndices(indices);
+        ex.setKeepOrganized(keep_organized_);
+        ex.filter(*filtered_cloud);
+        sensor_msgs::PointCloud2 ros_cloud;
+        pcl::toROSMsg(*filtered_cloud, ros_cloud);
+        ros_cloud.header = cloud_msg->header;
+        filtered_cloud_publisher_.publish(ros_cloud);
+      }
+
+    ////////////////////////////////////////////////////////
+    // ROS variables
+    ////////////////////////////////////////////////////////
+    ros::NodeHandle root_nh_;
+    ros::NodeHandle private_nh_;
+    boost::shared_ptr<tf::Transformer> tf_;
+    std::string point_cloud_topic_;
+    double scale_;
+    double padding_;
+    double max_range_;
+    unsigned int point_subsample_;
+    std::string filtered_cloud_topic_;
+    ros::Publisher filtered_cloud_publisher_;
+
+    message_filters::Subscriber<sensor_msgs::PointCloud2> *point_cloud_subscriber_;
+    tf::MessageFilter<sensor_msgs::PointCloud2> *point_cloud_filter_;
+
+    boost::scoped_ptr<point_containment_filter::ShapeMask> shape_mask_;
+    std::vector<int> mask_;
+
+    bool use_color_;
+    bool keep_organized_;
+    
+  private:
+    
+  };
+}
+
+#endif

--- a/jsk_pcl_ros/jsk_pcl_nodelets.xml
+++ b/jsk_pcl_ros/jsk_pcl_nodelets.xml
@@ -1,4 +1,4 @@
-<library path="lib/libjsk_pcl_ros">
+<library path="libjsk_pcl_ros">
   <class name="jsk_pcl/TiltLaserListener" type="jsk_pcl_ros::TiltLaserListener"
          base_class_type="nodelet::Nodelet">
     listen joint state and publish TimeRange to assemble pointcloud
@@ -351,6 +351,12 @@
          base_class_type="nodelet::Nodelet">
     <description>
       jsk_pcl_ros::OrganizePointCloud
+    </description>
+  </class>
+  <class name="jsk_pcl/PointCloudMoveitFilter"
+         type="jsk_pcl_ros::PointCloudMoveitFilter"
+         base_class_type="occupancy_map_monitor::OccupancyMapUpdater">
+    <description>
     </description>
   </class>
 </library>

--- a/jsk_pcl_ros/manifest.xml
+++ b/jsk_pcl_ros/manifest.xml
@@ -30,12 +30,14 @@
   <depend package="cv_bridge" />
   <depend package="jsk_topic_tools" />
   <depend package="roscpp_tutorials" />
+  <depend package="moveit_ros_perception" />
   <rosdep name="boost" />
   <rosdep name="tbb" />
 
   <export>
     <nodelet plugin="${prefix}/jsk_pcl_nodelets.xml" />
     <cpp cflags="-I${prefix}/include" lflags="-Wl,-rpath,${prefix}/lib -L${prefix}/lib -ljsk_pcl_ros" />
+    <moveit_ros_perception plugin="${prefix}/jsk_pcl_nodelets.xml"/>
   </export>
 
   <export>

--- a/jsk_pcl_ros/package.xml
+++ b/jsk_pcl_ros/package.xml
@@ -78,8 +78,13 @@
   <run_depend>python_sklearn</run_depend>
   <build_depend>laser_assembler</build_depend>
   <run_depend>laser_assembler</run_depend>
+  <build_depend>moveit_ros_perception</build_depend>
+  <run_depend>moveit_ros_perception</run_depend>
+  <build_depend>moveit_core</build_depend>
+  <run_depend>moveit_core</run_depend>
   <export>
     <nodelet plugin="${prefix}/jsk_pcl_nodelets.xml"/>
     <cpp lflags="-Wl,-rpath,${prefix}/lib -L${prefix}/lib -ljsk_pcl_ros" cflags="-I${prefix}/include"/>
+    <moveit_ros_perception plugin="${prefix}/jsk_pcl_nodelets.xml"/>
   </export>
 </package>

--- a/jsk_pcl_ros/src/pointcloud_moveit_filter.cpp
+++ b/jsk_pcl_ros/src/pointcloud_moveit_filter.cpp
@@ -1,0 +1,198 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include "jsk_pcl_ros/pointcloud_moveit_filter.h"
+
+namespace jsk_pcl_ros
+{
+  PointCloudMoveitFilter::PointCloudMoveitFilter():
+    OccupancyMapUpdater("PointCloudMoveitFilter"),
+    private_nh_("~"),
+    scale_(1.0),
+    padding_(0.0),
+    max_range_(std::numeric_limits<double>::infinity()),
+    point_subsample_(1),
+    point_cloud_subscriber_(NULL),
+    point_cloud_filter_(NULL),
+    use_color_(false),
+    keep_organized_(false)
+  {
+  }
+
+  PointCloudMoveitFilter::~PointCloudMoveitFilter()
+  {
+  }
+
+  bool PointCloudMoveitFilter::setParams(XmlRpc::XmlRpcValue &params)
+  {
+    try
+    {
+      if (!params.hasMember("point_cloud_topic"))
+        return false;
+      point_cloud_topic_ = static_cast<const std::string&>(params["point_cloud_topic"]);
+      
+      readXmlParam(params, "max_range", &max_range_);
+      readXmlParam(params, "padding_offset", &padding_);
+      readXmlParam(params, "padding_scale", &scale_);
+      readXmlParam(params, "point_subsample", &point_subsample_);
+      if (!params.hasMember("filtered_cloud_topic")) {
+        ROS_ERROR("filtered_cloud_topic is required");
+        return false;
+      }
+      else {
+        filtered_cloud_topic_ = static_cast<const std::string&>(params["filtered_cloud_topic"]);
+      }
+      if (params.hasMember("filtered_cloud_use_color")) {
+        use_color_ = (bool)params["filtered_cloud_use_color"];
+      }
+      if (params.hasMember("filtered_cloud_keep_organized")) {
+        keep_organized_ = (bool)params["filtered_cloud_keep_organized"];
+      }
+    }
+    catch (XmlRpc::XmlRpcException& ex)
+    {
+      ROS_ERROR("XmlRpc Exception: %s", ex.getMessage().c_str());
+      return false;
+    }
+    
+    return true;
+  }
+
+
+  
+  bool PointCloudMoveitFilter::initialize()
+  {
+    tf_ = monitor_->getTFClient();
+    shape_mask_.reset(new point_containment_filter::ShapeMask());
+    shape_mask_->setTransformCallback(
+      boost::bind(&PointCloudMoveitFilter::getShapeTransform, this, _1, _2));
+    filtered_cloud_publisher_ = private_nh_.advertise<sensor_msgs::PointCloud2>(
+      filtered_cloud_topic_, 10, false);
+    return true;
+  }
+
+  bool PointCloudMoveitFilter::getShapeTransform(ShapeHandle h, Eigen::Affine3d &transform) const
+  {
+    ShapeTransformCache::const_iterator it = transform_cache_.find(h);
+    if (it == transform_cache_.end())
+    {
+      ROS_ERROR("Internal error. Shape filter handle %u not found", h);
+      return false;
+    }
+    transform = it->second;
+    return true;
+  }
+
+  ShapeHandle PointCloudMoveitFilter::excludeShape(const shapes::ShapeConstPtr &shape)
+  {
+    ShapeHandle h = 0;
+    if (shape_mask_)
+      h = shape_mask_->addShape(shape, scale_, padding_);
+    else
+      ROS_ERROR("Shape filter not yet initialized!");
+    return h;
+  }
+
+  
+  void PointCloudMoveitFilter::forgetShape(ShapeHandle handle)
+  {
+    if (shape_mask_)
+      shape_mask_->removeShape(handle);
+  }
+
+  
+  void PointCloudMoveitFilter::start()
+  {
+    if (point_cloud_subscriber_)
+      return;
+    /* subscribe to point cloud topic using tf filter*/
+    point_cloud_subscriber_
+      = new message_filters::Subscriber<sensor_msgs::PointCloud2>(
+        root_nh_, point_cloud_topic_, 5);
+    if (tf_ && !monitor_->getMapFrame().empty())
+    {
+      point_cloud_filter_
+        = new tf::MessageFilter<sensor_msgs::PointCloud2>(
+          *point_cloud_subscriber_, *tf_, monitor_->getMapFrame(), 5);
+      if (use_color_) {
+        point_cloud_filter_->registerCallback(
+          boost::bind(
+            &PointCloudMoveitFilter::cloudMsgCallback<pcl::PointXYZRGB>,
+            this, _1));
+      }
+      else {
+        point_cloud_filter_->registerCallback(
+          boost::bind(
+            &PointCloudMoveitFilter::cloudMsgCallback<pcl::PointXYZ>,
+            this, _1));
+      }
+      ROS_INFO("Listening to '%s' using message filter with target frame '%s'",
+               point_cloud_topic_.c_str(),
+               point_cloud_filter_->getTargetFramesString().c_str());
+    }
+    else
+    {
+      if (use_color_) {
+        point_cloud_subscriber_->registerCallback(
+          boost::bind(
+            &PointCloudMoveitFilter::cloudMsgCallback<pcl::PointXYZRGB>,
+            this, _1));
+      }
+      else {
+        point_cloud_subscriber_->registerCallback(
+          boost::bind(&PointCloudMoveitFilter::cloudMsgCallback<pcl::PointXYZ>,
+                      this, _1));
+      }
+      ROS_INFO("Listening to '%s'", point_cloud_topic_.c_str());
+    }
+  }
+
+  void PointCloudMoveitFilter::stopHelper()
+  {
+    delete point_cloud_filter_;
+    delete point_cloud_subscriber_;
+  }
+  
+  void PointCloudMoveitFilter::stop()
+  {
+    stopHelper();
+    point_cloud_filter_ = NULL;
+    point_cloud_subscriber_ = NULL;
+  }
+  
+}
+
+#include <class_loader/class_loader.h>
+CLASS_LOADER_REGISTER_CLASS(jsk_pcl_ros::PointCloudMoveitFilter, occupancy_map_monitor::OccupancyMapUpdater)


### PR DESCRIPTION
I found that moveit occupancy map filter is slow(about 1 fps) because of updating of occupancy map.
I implemented pointcloud filter without occupancy map stuff.

Now you can have realtime(~30fps) filtered pointcloud.
