### PR TITLE
changet pointcloud_screen_point not to use jsconnection_based_nodelet

### DIFF
--- a/jsk_pcl_ros/include/jsk_pcl_ros/pointcloud_screenpoint.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/pointcloud_screenpoint.h
@@ -53,12 +53,12 @@
 #include "jsk_pcl_ros/TransformScreenpoint.h"
 
 #include <boost/thread/mutex.hpp>
-#include "jsk_pcl_ros/connection_based_nodelet.h"
+
 // F/K/A <ray ocnverter>
 
 namespace jsk_pcl_ros
 {
-  class PointcloudScreenpoint : public ConnectionBasedNodelet
+  class PointcloudScreenpoint : public pcl_ros::PCLNodelet
   {
     typedef message_filters::sync_policies::ApproximateTime< sensor_msgs::PointCloud2,
                                                              geometry_msgs::PolygonStamped > PolygonApproxSyncPolicy;
@@ -95,8 +95,6 @@ namespace jsk_pcl_ros
 #endif
 
     void onInit();
-    void subscribe();
-    void unsubscribe();
     bool screenpoint_cb(jsk_pcl_ros::TransformScreenpoint::Request &req,
                         jsk_pcl_ros::TransformScreenpoint::Response &res);
     void points_cb(const sensor_msgs::PointCloud2ConstPtr &msg);

--- a/jsk_pcl_ros/src/pointcloud_screenpoint_nodelet.cpp
+++ b/jsk_pcl_ros/src/pointcloud_screenpoint_nodelet.cpp
@@ -76,10 +76,7 @@ void jsk_pcl_ros::PointcloudScreenpoint::onInit()
 #endif
   n3d_.setKSearch (k_);
   n3d_.setSearchMethod (normals_tree_);
-}
 
-void jsk_pcl_ros::PointcloudScreenpoint::subscribe()
-{
   points_sub_.subscribe (*pnh_, "points", queue_size_);
 
   if (use_rect) {
@@ -118,22 +115,6 @@ void jsk_pcl_ros::PointcloudScreenpoint::subscribe()
   points_sub_.registerCallback (boost::bind (&PointcloudScreenpoint::points_cb, this, _1));
 }
 
-void jsk_pcl_ros::PointcloudScreenpoint::unsubscribe()
-{
-  points_sub_.unsubscribe();
-
-  if (use_rect) {
-    rect_sub_.unsubscribe();
-  }
-
-  if (use_point) {
-    point_sub_.unsubscribe();
-  }
-
-  if (use_point_array) {
-    point_array_sub_.unsubscribe();
-  }
-}
 
 bool jsk_pcl_ros::PointcloudScreenpoint::checkpoint (pcl::PointCloud< pcl::PointXYZ > &in_pts, int x, int y,
                                                      float &resx, float &resy, float &resz)  {


### PR DESCRIPTION
実行するとサブスクライバが上がってなかったので、直しました。
#435 を受けて、

connection_based_nodeletを使う方針ではなく、PCLNodeletを使うコードに
戻しました。
