### PR TITLE
add param to set angle-divide-param for organized multi plange

### DIFF
--- a/jsk_pcl_ros/include/jsk_pcl_ros/handle_estimator.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/handle_estimator.h
@@ -96,6 +96,7 @@ namespace jsk_pcl_ros
     boost::shared_ptr<tf::TransformListener> tf_listener_;
     double gripper_size_;
     double approach_offset_;
+    int angle_divide_num_;
     boost::circular_buffer<boost::tuple<geometry_msgs::PoseArray, geometry_msgs::PoseArray> > output_buf;
   private:
   };

--- a/jsk_pcl_ros/launch/organized_multi_plane_segmentation.launch
+++ b/jsk_pcl_ros/launch/organized_multi_plane_segmentation.launch
@@ -243,6 +243,7 @@
     <remap from="~input_box" to="/bounding_box_marker/selected_box" />
     <rosparam>
       approach_offset: 0.1
+      angle_divide_num: 6
     </rosparam>
   </node>
     <group if="$(arg ESTIMATE_OCCLUSION)">

--- a/jsk_pcl_ros/src/handle_estimator_nodelet.cpp
+++ b/jsk_pcl_ros/src/handle_estimator_nodelet.cpp
@@ -50,6 +50,7 @@ namespace jsk_pcl_ros
     //tf_listener_.reset(new tf::TransformListener());
     pnh_->param("gripper_size", gripper_size_, 0.08); // defaults to pr2 gripper size
     pnh_->param("approach_offset", approach_offset_, 0.1); // default to 10 cm
+    pnh_->param("angle_divide_num", angle_divide_num_, 6); // even will be better
     pub_ = advertise<geometry_msgs::PoseArray>(*pnh_, "output", 1);
     pub_best_ = advertise<geometry_msgs::PoseStamped>(*pnh_, "output_best", 1);
     pub_selected_ = advertise<geometry_msgs::PoseStamped>(*pnh_, "output_selected", 1);
@@ -168,8 +169,8 @@ namespace jsk_pcl_ros
     const double angle_margin = 0.2;
     const double start_angle = M_PI / 2.0 + angle_margin;
     const double end_angle = M_PI + M_PI / 2.0 - angle_margin;
-    for (size_t i = 0; i < 5; i++) {
-      const double theta = (end_angle - start_angle) / 5.0 * i + start_angle;
+    for (size_t i = 0; i < angle_divide_num_; i++) {
+      const double theta = (end_angle - start_angle) / angle_divide_num_ * i + start_angle;
       Eigen::Vector3d offset_vec = Eigen::Vector3d(cos(theta), sin(theta), 0);
       Eigen::Vector3d pre_approach_pos
         = (center_refined * (approach_offset_ * offset_vec));
@@ -217,8 +218,8 @@ namespace jsk_pcl_ros
     const double start_angle = angle_margin;
     const double end_angle = M_PI - angle_margin;
     
-    for (size_t i = 0; i <= 5; i++) { // 5 samples
-      const double theta = (end_angle - start_angle) / 5.0 * i + start_angle;
+    for (size_t i = 0; i <= angle_divide_num_; i++) { // angle_divide_num samples
+      const double theta = (end_angle - start_angle) / angle_divide_num_ * i + start_angle;
       // x-z plane
       Eigen::Vector3d offset_vec;
       if (y_longest) {


### PR DESCRIPTION
To get vertical arrow, I think we should set the divide param to even value.

![divide_angle](https://cloud.githubusercontent.com/assets/3803922/5224498/c6df9ddc-7718-11e4-8dfe-686cd6ae7986.png)
