### PR TITLE
fixed bug in icp

### DIFF
--- a/jsk_pcl_ros/src/icp_registration_nodelet.cpp
+++ b/jsk_pcl_ros/src/icp_registration_nodelet.cpp
@@ -281,7 +281,9 @@ namespace jsk_pcl_ros
     result.header = ros_result_pose.header;
     result.pose = ros_result_pose.pose;
     result.score = min_score;
-    result.name = "" + max_index;
+    std::stringstream ss;
+    ss << max_index;
+    result.name = ss.str();
     return result;
   }
   


### PR DESCRIPTION
#386 のコミットでできてしまったbugです。

複数の物体をtemplateにしてICPをしたときに、
どの物体が当てはまったかの結果が正しく返っていなかったので、修正しました。
