### PR TITLE
Support ciecle and acircle pattern

### DIFF
--- a/checkerboard_detector/checkerboard_detector.launch
+++ b/checkerboard_detector/checkerboard_detector.launch
@@ -5,9 +5,17 @@
     <!--param name="frame_id" type="string" value="stereo_link"/-->
     <param name="rect0_size_x" type="double" value="0.35"/>
     <param name="rect0_size_y" type="double" value="0.35"/>
+    <!-- <param name="rect0_size_x" type="double" value="0.02"/> -->
+    <!-- <param name="rect0_size_y" type="double" value="0.02"/> -->
+    <!-- <param name="grid0_size_x" type="int" value="10"/> -->
+    <!-- <param name="grid0_size_y" type="int" value="12"/> -->
     <param name="grid0_size_x" type="int" value="4"/>
     <param name="grid0_size_y" type="int" value="6"/>
     <param name="type0" type="string" value="data/ricebox.kinbody.xml"/>
+    <param name="board_type" value="chess" />
+    <!-- <param name="board_type" value="acircle" /> -->
+    <!-- <param name="grid0_size_x" type="int" value="4"/> -->
+    <!-- <param name="grid0_size_y" type="int" value="7"/> -->
 
     <node pkg="checkerboard_detector" name="checkerboard_detector" type="checkerboard_detector" respawn="false" output="screen">
       <remap from="camera_info" to="/wide_stereo/left/camera_info"/>


### PR DESCRIPTION
Supporting two new types of checker board in checkerboard_detector.
1. circle grid
2. asymmetrical circle grid

And don't use cvFindExtrinsicCameraParams2, use solvePnP because it's not recommended now (we should rewrite this code with c++)

![screenshot from 2014-12-17 12 17 24](https://cloud.githubusercontent.com/assets/40454/5466141/0606f4c8-85e8-11e4-8ee9-4e1c648b0737.png)
![screenshot from 2014-12-17 12 21 59](https://cloud.githubusercontent.com/assets/40454/5466142/06079de2-85e8-11e4-93a3-da2a89715b1f.png)
