### PR TITLE
added some more parameters for detection

### DIFF
--- a/jsk_perception/cfg/ColorHistogramSlidingMatcher.cfg
+++ b/jsk_perception/cfg/ColorHistogramSlidingMatcher.cfg
@@ -11,10 +11,11 @@ except:
 
 gen = ParameterGenerator()
 
-gen.add("standard_width", int_t, 0, "width of sliding_window",  12, 4, 40)
-gen.add("standard_height", int_t, 0, "height of sliding_window", 12, 4, 40)
+gen.add("standard_width", int_t, 0, "width of standard_sliding_window",  12, 4, 40)
+gen.add("standard_height", int_t, 0, "height of standard_sliding_window", 12, 4, 40)
 gen.add("coefficient_threshold", double_t, 0, "the threshold to which color_window expands",  0.5, 0, 1.0)
 gen.add("coefficient_threshold_for_best_window", double_t, 0, "the threshold which the best matching window must have",  0.67, 0, 1.0)
+gen.add("sliding_factor", double_t, 0, "the sliding length, if it becomes smaller then examines image more closely",  1.0, 0, 5.0)
 box_calc_method_enum = gen.enum([gen.const("best_window", int_t, 0, "pub best_sliding_window"),
                                    gen.const("expand_best_window", int_t, 1, "expand the best window to big one"),
                                    gen.const("remove_window", int_t, 2, "not consider matched window")], "final window estimation method") 

--- a/jsk_perception/src/color_histogram_sliding_matcher.cpp
+++ b/jsk_perception/src/color_histogram_sliding_matcher.cpp
@@ -46,6 +46,7 @@ class MatcherNode
   int best_window_estimation_method;
   double coefficient_thre;
   double coefficient_thre_for_best_window;
+  double sliding_factor;
   bool show_result_;
   double template_width;
   double template_height;
@@ -122,6 +123,7 @@ public:
     local_nh.param("best_window_estimation_method", best_window_estimation_method, 1);
     local_nh.param("coefficient_threshold", coefficient_thre, 0.5);
     local_nh.param("coefficient_threshold_for_best_window", coefficient_thre_for_best_window, 0.67);
+    local_nh.param("sliding_factor", sliding_factor, 1.0);
     local_nh.param("show_result", show_result_, true);
     local_nh.param("object_width", template_width, 0.06);
     local_nh.param("object_height", template_height, 0.0739);
@@ -248,7 +250,8 @@ public:
       // for(float scale=1; scale<image.cols/32; scale*=1.2){
       std::vector<box> boxes;
       for(float scale=image.cols/32; scale > 1; scale/=1.2){
-	int dot = (int)(scale*2);
+	int dot = (int)(scale*2*sliding_factor);
+	if(dot<1) dot = 1;
 	int width_d = (int)(scale*standard_width);
 	int height_d = (int)(scale*standard_height);
 	for(size_t i=0, image_rows=image.rows; i+height_d < image_rows; i+=dot){
@@ -275,6 +278,7 @@ public:
 	  }
 	}
       }
+      ROS_INFO("max_coefficient:%f", max_coe);
       if(boxes.size() == 0 || max_coe < coefficient_thre_for_best_window){
 	ROS_INFO("no objects found");
 	if(show_result_){
@@ -391,6 +395,7 @@ public:
     standard_height = config.standard_height;
     standard_width = config.standard_width;
     coefficient_thre = config.coefficient_threshold;
+    sliding_factor = config.sliding_factor;
     coefficient_thre_for_best_window = config.coefficient_threshold_for_best_window;
     best_window_estimation_method = config.best_window_estimation_method;
     if(level==1){ // size changed


### PR DESCRIPTION
sliding_windowの、ウィンドウがスライドしていくときのスライド幅の基準の値を固定していたのですが、
変更可能にしました。
計算時間は長くなりますが、スライド幅を小さくすれば、より細かく物体を探索します。
