### PR TITLE
Publish PosedCameraInfo from IntermittentImageAnnotator

### DIFF
--- a/jsk_pcl_ros/README.md
+++ b/jsk_pcl_ros/README.md
@@ -86,6 +86,9 @@ Represent range of time.
 
   Direction of ROI as `PoseStamped`. z-axis directs the center of ROI.
 
+* `~output/roi` (`jsk_pcl_ros/PosedCameraInfo`)
+
+  Publish ROI of specified region as `PosedCameraInfo`.
 #### Parameters
 * `~fixed_frame_id` (`String`, default: `odom`)
 

--- a/jsk_pcl_ros/catkin.cmake
+++ b/jsk_pcl_ros/catkin.cmake
@@ -56,6 +56,7 @@ add_message_files(FILES PointsArray.msg ClusterPointIndices.msg Int32Stamped.msg
   SparseOccupancyGridArray.msg
   DepthErrorResult.msg
   ParallelEdge.msg ParallelEdgeArray.msg
+  PosedCameraInfo.msg
   ICPResult.msg)
 
 add_service_files(FILES SwitchTopic.srv

--- a/jsk_pcl_ros/include/jsk_pcl_ros/intermittent_image_annotator.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/intermittent_image_annotator.h
@@ -48,6 +48,8 @@
 #include <boost/circular_buffer.hpp>
 #include <Eigen/Geometry>
 #include <geometry_msgs/PolygonStamped.h>
+#include <jsk_pcl_ros/PosedCameraInfo.h>
+
 namespace jsk_pcl_ros
 {
   class SnapshotInformation
@@ -108,6 +110,7 @@ namespace jsk_pcl_ros
     ros::ServiceServer clear_service_;
     ros::ServiceServer request_service_;
     ros::Publisher pub_pose_;
+    ros::Publisher pub_roi_;
     sensor_msgs::Image::ConstPtr latest_image_msg_;
     sensor_msgs::CameraInfo::ConstPtr latest_camera_info_msg_;
     

--- a/jsk_pcl_ros/msg/PosedCameraInfo.msg
+++ b/jsk_pcl_ros/msg/PosedCameraInfo.msg
@@ -1,0 +1,3 @@
+Header header
+sensor_msgs/CameraInfo camera_info
+geometry_msgs/Pose offset


### PR DESCRIPTION
1) add new message `PosedCameraInfo` to represent camera info with offset
2) publish specified ROI as `PosedCameraInfo` from IntermittentImageAnnotator
