### PR TITLE
[jsk_pcl_ros] Use triangle decomposition to check inside

### DIFF
--- a/jsk_pcl_ros/include/jsk_pcl_ros/geo_util.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/geo_util.h
@@ -188,6 +188,7 @@ namespace jsk_pcl_ros
       size_t index,
       const Eigen::Vector3f& direction);
     virtual PtrPair separatePolygon(size_t index);
+    virtual bool isInside(const Eigen::Vector3f& p);
     size_t previousIndex(size_t i);
     size_t nextIndex(size_t i);
     static Polygon fromROSMsg(const geometry_msgs::Polygon& polygon);
@@ -230,7 +231,6 @@ namespace jsk_pcl_ros
     virtual void projectOnPlane(const Eigen::Vector3f& p, Eigen::Vector3f& output);
     virtual bool isProjectableInside(const Eigen::Vector3f& p);
     // p should be a point on the plane
-    virtual bool isInside(const Eigen::Vector3f& p);
     virtual ConvexPolygon flipConvex();
     virtual Eigen::Vector3f getCentroid();
     virtual Ptr magnify(const double scale_factor);

--- a/jsk_pcl_ros/launch/snapit.launch
+++ b/jsk_pcl_ros/launch/snapit.launch
@@ -20,5 +20,11 @@
         args="0 0 1 0 0.2 0 odom2 odom 10">
   </node>
   <node pkg="jsk_pcl_ros" type="snapit_sample_pose_publisher.py"
-        name="snapit_sample_pose_publisher" />
+        name="snapit_sample_pose_publisher" if="false"/>
+  <node pkg="jsk_interactive_marker" type="marker_6dof" name="marker">
+    <rosparam>
+      frame_id: odom
+    </rosparam>
+    <remap from="~pose" to="snapit/input/convex_align" />
+  </node>
 </launch>


### PR DESCRIPTION
- Use triangle decomposition to check if a point is inside or not of polygon.
- Update snapit sample to use jsk_interactive_marker

![snapit](https://cloud.githubusercontent.com/assets/40454/5587643/2f66fd8e-9134-11e4-9435-f7b5b28f474d.png)
