### PR TITLE
add none result publisher when reference is empty

### DIFF
--- a/jsk_pcl_ros/src/icp_registration_nodelet.cpp
+++ b/jsk_pcl_ros/src/icp_registration_nodelet.cpp
@@ -261,6 +261,12 @@ namespace jsk_pcl_ros
     boost::mutex::scoped_lock lock(mutex_);
     if (reference_cloud_list_.size() == 0) {
       NODELET_FATAL("no reference is specified");
+      jsk_pcl_ros::ICPResult result;
+      result.name = std::string("NONE");
+      result.score = 0.0;
+      result.header = box_msg->header;
+      result.pose = box_msg->pose;
+      pub_icp_result.publish(result);
       return;
     }
     try


### PR DESCRIPTION
ICPでリファレンスが空っぽの時にも結果を出すようにしました。(boundingboxとセットの時のみ)
中身は、
* 名前 -> NONE
* ポーズ -> bounding_boxのpose
* score -> 0

になります。
