### PR TITLE
[jsk_perception] Fix ColorHistogram minor bags:

### DIFF
--- a/jsk_perception/src/color_histogram.cpp
+++ b/jsk_perception/src/color_histogram.cpp
@@ -189,7 +189,7 @@ namespace jsk_perception
   {
     cv::Mat hsi_image;
     cv::cvtColor(bgr_image, hsi_image, CV_BGR2HSV);
-      
+    
     float range[] = { 0, 256 } ;
     const float* histRange = { range };
     float h_range[] = { 0, 180 } ;
@@ -198,12 +198,12 @@ namespace jsk_perception
     bool uniform = true; bool accumulate = false;
     std::vector<cv::Mat> hsi_planes;
     split(hsi_image, hsi_planes);
-      
-    cv::calcHist(&hsi_planes[0], 1, 0, cv::Mat(), h_hist, 1, &h_hist_size_,
+    
+    cv::calcHist(&hsi_planes[0], 1, 0, mask, h_hist, 1, &h_hist_size_,
                  &h_histRange, uniform, accumulate);
-    cv::calcHist(&hsi_planes[1], 1, 0, cv::Mat(), s_hist, 1, &s_hist_size_,
+    cv::calcHist(&hsi_planes[1], 1, 0, mask, s_hist, 1, &s_hist_size_,
                  &histRange, uniform, accumulate);
-    cv::calcHist(&hsi_planes[2], 1, 0, cv::Mat(), i_hist, 1, &i_hist_size_,
+    cv::calcHist(&hsi_planes[2], 1, 0, mask, i_hist, 1, &i_hist_size_,
                  &histRange, uniform, accumulate);
       
     jsk_pcl_ros::ColorHistogram h_histogram;
@@ -235,17 +235,19 @@ namespace jsk_perception
       cv_ptr = cv_bridge::toCvCopy(image, sensor_msgs::image_encodings::BGR8);
       geometry_msgs::Point32 point0 = rectangle->polygon.points[0];
       geometry_msgs::Point32 point1 = rectangle->polygon.points[1];
-      int larger_x_index = point0.x > point1.x? 0: 1;
-      int larger_y_index = point0.y > point1.y? 0: 1;
-      int smaller_x_index = point0.x < point1.x? 0: 1;
-      int smaller_y_index = point0.y < point1.y? 0: 1;
-      cv::Rect roi(rectangle->polygon.points[smaller_x_index].x,
-                   rectangle->polygon.points[smaller_y_index].y,
-                   rectangle->polygon.points[larger_x_index].x
-                   - rectangle->polygon.points[smaller_x_index].x,
-                   rectangle->polygon.points[larger_y_index].y
-                   - rectangle->polygon.points[smaller_y_index].y);
-      cv::Mat bgr_image = cv_ptr->image(roi);
+      int min_x = std::max(0.0f, std::min(point0.x, point1.x));
+      int min_y = std::max(0.0f, std::min(point0.y, point1.y));
+      int max_x = std::min(std::max(point0.x, point1.x), (float)image->width);
+      int max_y = std::min(std::max(point0.y, point1.y), (float)image->height);
+      cv::Rect roi(min_x, min_y, max_x - min_x, max_y - min_y);
+      cv::Mat bgr_image, roi_image;
+      roi_image = cv_ptr->image(roi);
+      if (image->encoding == sensor_msgs::image_encodings::RGB8) {
+        cv::cvtColor(roi_image, bgr_image, CV_RGB2BGR);
+      }
+      else {
+        roi_image.copyTo(bgr_image);
+      }
       processBGR(bgr_image, image->header);
       processHSI(bgr_image, image->header);
     }


### PR DESCRIPTION
1. Support rect message out side of image
2. Use mask image in HSV histogram calculation