### PR TITLE
[jsk_perception] Mask from histogram match in ColorHistogramLabelMatch

### DIFF
--- a/jsk_perception/cfg/ColorHistogramLabelMatch.cfg
+++ b/jsk_perception/cfg/ColorHistogramLabelMatch.cfg
@@ -18,10 +18,18 @@ coef_enum = gen.enum([gen.const("correlancy", int_t, 0, "correlency"),
                       gen.const("EMD_Manhattan", int_t, 4, "EMD (Manhattan)"),
                       gen.const("EMD_Euclid", int_t, 5, "EMD (Euclid)")],
                       "method to compute coefficient between two histograms")
+thr_enum = gen.enum([gen.const("smaller_than", int_t, 0, "smaller than coef_threshold"),
+                     gen.const("greater_than", int_t, 1, "greater than coef_threshold"),
+                     gen.const("otsu", int_t, 2, "Otsu method"),
+                     gen.const("otsu_inv", int_t, 3, "Otsu method inversed")],
+                     "method to compute threshold image")
 gen.add("coefficient_method", int_t, 0, "method to compute coefficient between two histograms",
         0, 0, 5, edit_method = coef_enum)
 gen.add("max_value", double_t, 0, "maximum value of histogram", 255, 0, 1000)
 gen.add("min_value", double_t, 0, "minimum value of histogram", 0, 0, 1000)
-
+gen.add("masked_coefficient", double_t, 0, "value for masked region", 0, 0, 1.0)
+gen.add("threshold_method", int_t, 0, "method to compute threshold image", 0, 0, 3,
+        edit_method = thr_enum)
+gen.add("coef_threshold", double_t, 0, "threshold", 0.8, 0, 1.0)
 
 exit(gen.generate(PACKAGE, "jsk_perception", "ColorHistogramLabelMatch"))

--- a/jsk_perception/include/jsk_perception/color_histogram_label_match.h
+++ b/jsk_perception/include/jsk_perception/color_histogram_label_match.h
@@ -83,9 +83,12 @@ namespace jsk_perception
     virtual double coefficients(const cv::Mat& ref_hist,
                                 const cv::Mat& target_hist);
     virtual void configCallback(Config &config, uint32_t level);
-
+    
     float max_value_;
     float min_value_;
+    float coef_threshold_;
+    float masked_coefficient_;
+    int threshold_method_;
     boost::mutex mutex_;
     boost::shared_ptr<dynamic_reconfigure::Server<Config> > srv_;
     boost::shared_ptr<message_filters::Synchronizer<SyncPolicy> > sync_;
@@ -97,6 +100,8 @@ namespace jsk_perception
     cv::Mat histogram_;
     ros::Publisher pub_debug_;
     ros::Publisher pub_coefficient_image_;
+    ros::Publisher pub_mask_;
+    ros::Publisher pub_result_;
   private:
     
   };


### PR DESCRIPTION
Make (kind of) mask image based on histogram coefficients.

![coef_mask_image](https://cloud.githubusercontent.com/assets/40454/5814898/b49083a0-a0d3-11e4-8f45-5f0014d17302.png)

This picture is based on OTSU's method