### PR TITLE
[jsk_pcl_ros] Add magnify parameter to MultiPlaneExtraction

### DIFF
--- a/jsk_pcl_ros/README.md
+++ b/jsk_pcl_ros/README.md
@@ -808,6 +808,9 @@ Extract the points above the planes between `~min_height` and `~max_height`.
    You can disable this parameter to filter pointcloud which is not the same pointcloud
    to segment planes
 
+* `~magnify` (Double, default: `0.0`)
+
+  Magnify planes by this parameter. The unit is m.
 ### jsk\_pcl/RegionGrowingMultiplePlaneSegmentation
 ![jsk_pcl/RegionGrowingMultiplePlaneSegmentation](images/region_growing_multiple_plane_segmentation.png).
 

--- a/jsk_pcl_ros/cfg/MultiPlaneExtraction.cfg
+++ b/jsk_pcl_ros/cfg/MultiPlaneExtraction.cfg
@@ -17,5 +17,5 @@ gen = ParameterGenerator ()
 
 gen.add("min_height", double_t, 0, "the minimum height of the prism craeted by the planes", 0.0, -5.0, 5.0)
 gen.add("max_height", double_t, 0, "the minimum height of the prism craeted by the planes", 0.5, -5.0, 5.0)
-
+gen.add("maginify", double_t, 0, "maginify polygon region (m)", 0.0, 0.0, 1.0)
 exit (gen.generate (PACKAGE, "jsk_pcl_ros", "MultiPlaneExtraction"))

--- a/jsk_pcl_ros/include/jsk_pcl_ros/multi_plane_extraction.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/multi_plane_extraction.h
@@ -118,6 +118,7 @@ namespace jsk_pcl_ros
     int maximum_queue_size_;
     double min_height_, max_height_;
     bool use_indices_;
+    double maginify_;
   private:
     
     

--- a/jsk_pcl_ros/src/multi_plane_extraction_nodelet.cpp
+++ b/jsk_pcl_ros/src/multi_plane_extraction_nodelet.cpp
@@ -107,6 +107,7 @@ namespace jsk_pcl_ros
     boost::mutex::scoped_lock lock(mutex_);
     min_height_ = config.min_height;
     max_height_ = config.max_height;
+    maginify_ = config.maginify;
   }
 
   void MultiPlaneExtraction::updateDiagnostic(
@@ -176,12 +177,29 @@ namespace jsk_pcl_ros
       pcl::ExtractPolygonalPrismData<pcl::PointXYZRGB> prism_extract;
       pcl::PointCloud<pcl::PointXYZRGB>::Ptr hull_cloud(new pcl::PointCloud<pcl::PointXYZRGB>());
       geometry_msgs::Polygon the_polygon = polygons->polygons[plane_i].polygon;
+      if (the_polygon.points.size() <= 2) {
+        NODELET_WARN("too small polygon");
+        continue;
+      }
+      // compute centroid first
+      Eigen::Vector3f centroid(0, 0, 0);
       for (size_t i = 0; i < the_polygon.points.size(); i++) {
         pcl::PointXYZRGB p;
         pointFromXYZToXYZ<geometry_msgs::Point32, pcl::PointXYZRGB>(
           the_polygon.points[i], p);
+        centroid = centroid + p.getVector3fMap();
+      }
+      centroid = centroid / the_polygon.points.size();
+      
+      for (size_t i = 0; i < the_polygon.points.size(); i++) {
+        pcl::PointXYZRGB p;
+        pointFromXYZToXYZ<geometry_msgs::Point32, pcl::PointXYZRGB>(
+          the_polygon.points[i], p);
+        Eigen::Vector3f dir = (p.getVector3fMap() - centroid).normalized();
+        p.getVector3fMap() = dir * maginify_ + p.getVector3fMap();
         hull_cloud->points.push_back(p);
       }
+      
       pcl::PointXYZRGB p_last;
         pointFromXYZToXYZ<geometry_msgs::Point32, pcl::PointXYZRGB>(
           the_polygon.points[0], p_last);


### PR DESCRIPTION
Add maginify parameter to remove points on the edge of polygons.
![multi_plane_extraction_maginify](https://cloud.githubusercontent.com/assets/40454/5871052/e24df6e4-a31a-11e4-8700-c7a94d1e3e07.png)
