### PR TITLE
[jsk_pcl_ros] Increase initial number of particles to avoid SEGV

### DIFF
--- a/jsk_pcl_ros/cfg/ParticleFilterTracking.cfg
+++ b/jsk_pcl_ros/cfg/ParticleFilterTracking.cfg
@@ -15,7 +15,7 @@ from math import pi
 
 gen = ParameterGenerator ()
 
-gen.add("max_particle_num", int_t, 0, "The maximum number of the particles", 200, 1, 100000)
+gen.add("max_particle_num", int_t, 0, "The maximum number of the particles", 1000, 1, 100000)
 gen.add("iteration_num", int_t, 0, "number of iteratoin", 1, 1, 1000)
 gen.add("resample_likelihood_thr", double_t, 0, "threshold to resample particles", 0, 0, 1.0)
 gen.add("delta", double_t, 0, "delta for KLD sampling", 0.99, 0.0, 1.0)


### PR DESCRIPTION
I don't know why but small number particles may cause SEGV when starting up the program.