### PR TITLE
fix for indigo

### DIFF
--- a/jsk_pcl_ros/catkin.cmake
+++ b/jsk_pcl_ros/catkin.cmake
@@ -23,6 +23,13 @@ else()
   set(ML_CLASSIFIERS ml_classifiers) ## hydro and later
 endif()
 
+find_package(PkgConfig)
+pkg_check_modules(yaml_cpp yaml-cpp REQUIRED)
+IF(${yaml_cpp_VERSION} VERSION_LESS "0.5.0")
+## indigo yaml-cpp : 0.5.0 /  hydro yaml-cpp : 0.3.0
+  add_definitions("-DUSE_OLD_YAML")
+ENDIF()
+
 find_package(catkin REQUIRED COMPONENTS
   dynamic_reconfigure pcl_ros nodelet message_generation genmsg
   ${PCL_MSGS} sensor_msgs geometry_msgs

--- a/jsk_pcl_ros/include/jsk_pcl_ros/particle_filter_tracking.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/particle_filter_tracking.h
@@ -189,7 +189,7 @@ namespace pcl
       void computeTransformedPointCloudWithoutNormal
       (const StateT& hypothesis, PointCloudIn &cloud)
         {
-          const Eigen::Affine3f trans = toEigenMatrix (hypothesis);
+          const Eigen::Affine3f trans = this->toEigenMatrix (hypothesis);
           // destructively assigns to cloud
           pcl::transformPointCloud<PointInT> (*input_, cloud, trans);
         }
@@ -222,7 +222,7 @@ namespace pcl
             Eigen::Affine3f inverse_trans = trans.inverse();
             inverse_particle = StateT::toState(inverse_trans);
             IndicesPtr indices (new std::vector<int>);
-            computeTransformedPointCloudWithNormal (inverse_particle, *indices, *transed_input_vector_[i]);
+            this->computeTransformedPointCloudWithNormal (inverse_particle, *indices, *transed_input_vector_[i]);
             coherence_->compute (transed_input_vector_[i], indices, particles_->points[i].weight);
           }
         }
@@ -313,7 +313,7 @@ namespace pcl
             Eigen::Affine3f trans = particles_->points[i].toEigenMatrix();
             Eigen::Affine3f inverse_trans = trans.inverse();
             inverse_particle = StateT::toState(inverse_trans);
-            computeTransformedPointCloudWithoutNormal (inverse_particle, *transed_input_vector_[i]);
+            this->computeTransformedPointCloudWithoutNormal (inverse_particle, *transed_input_vector_[i]);
             //computeTransformedPointCloudWithoutNormal (particles_->points[i], *transed_input_vector_[i]);
             IndicesPtr indices;
             coherence_->compute (transed_input_vector_[i], indices, particles_->points[i].weight);
@@ -333,7 +333,7 @@ namespace pcl
             Eigen::Affine3f inverse_trans = trans.inverse();
             inverse_particle = StateT::toState(inverse_trans);
             IndicesPtr indices (new std::vector<int>);
-            computeTransformedPointCloudWithNormal (inverse_particle, *indices, *transed_input_vector_[i]);
+            this->computeTransformedPointCloudWithNormal (inverse_particle, *indices, *transed_input_vector_[i]);
             coherence_->compute (transed_input_vector_[i], indices, particles_->points[i].weight);
           }
         }

--- a/jsk_pcl_ros/package.xml
+++ b/jsk_pcl_ros/package.xml
@@ -16,7 +16,7 @@
   <!-- <build_depend>pcl</build_depend> -->
   <build_depend>pcl_ros</build_depend>
   <build_depend>pcl_msgs</build_depend>
-  <build_depend>opencv2</build_depend>
+  <build_depend>cv_bridge</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
@@ -53,7 +53,7 @@
   <run_depend>pcl_conversions</run_depend>
   <run_depend>pcl_ros</run_depend>
   <run_depend>pcl_msgs</run_depend>
-  <run_depend>opencv2</run_depend>
+  <run_depend>cv_bridge</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>

--- a/jsk_pcl_ros/src/linemod_nodelet.cpp
+++ b/jsk_pcl_ros/src/linemod_nodelet.cpp
@@ -553,10 +553,11 @@ namespace jsk_pcl_ros
     pcl::PCDReader reader;
     reader.read(template_file_ + ".pcd", *template_cloud_);
     const std::string pose_yaml = template_file_ + "_poses.yaml";
+   YAML::Node doc;
+#ifdef USE_OLD_YAML
     std::ifstream pose_fin;
     pose_fin.open(pose_yaml.c_str(), std::ifstream::in);
     YAML::Parser parser(pose_fin);
-    YAML::Node doc;
     while (parser.GetNextDocument(doc)) {
       const YAML::Node& template_pose_yaml = doc["template_poses"];
       for (size_t i = 0; i < template_pose_yaml.size(); i++) {
@@ -576,6 +577,11 @@ namespace jsk_pcl_ros
       }
     }
     pose_fin.close();
+#else
+     // yaml-cpp is greater than 0.5.0
+     doc = YAML::LoadFile(pose_yaml);
+#endif
+
     
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =

--- a/jsk_pcl_ros/src/pcl_util.cpp
+++ b/jsk_pcl_ros/src/pcl_util.cpp
@@ -45,8 +45,13 @@ namespace jsk_pcl_ros
   Eigen::Affine3f affineFromYAMLNode(const YAML::Node& pose)
   {
     float x, y, z, rx, ry, rz, rw;
+#ifdef USE_OLD_YAML
     pose[0] >> x; pose[1] >> y; pose[2] >> z;
     pose[3] >> rx; pose[4] >> ry; pose[5] >> rz; pose[6] >> rw;
+#else
+    x = pose[0].as<float>(); y = pose[1].as<float>(); z = pose[2].as<float>();
+    rx= pose[3].as<float>(); ry= pose[4].as<float>(); rz= pose[5].as<float>(); rw = pose[6].as<float>();
+#endif
     Eigen::Vector3f p(x, y, z);
     Eigen::Quaternionf q(rw, rx, ry, rz);
     Eigen::Affine3f trans = Eigen::Translation3f(p) * Eigen::AngleAxisf(q);

--- a/resized_image_transport/package.xml
+++ b/resized_image_transport/package.xml
@@ -13,7 +13,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>opencv2</build_depend>
+  <build_depend>cv_bridge</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>image_transport</build_depend>
@@ -21,7 +21,7 @@
   <build_depend>message_generation</build_depend>
   <build_depend>driver_base</build_depend>
 
-  <run_depend>opencv2</run_depend>
+  <run_depend>cv_bridge</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>image_transport</run_depend>
@@ -32,7 +32,7 @@
   <build_depend>jsk_topic_tools</build_depend>
   <run_depend>jsk_topic_tools</run_depend>
 
-  <!-- <test_depend>opencv2</test_depend> -->
+  <!-- <test_depend>cv_bridge</test_depend> -->
   <!-- <test_depend>cv_bridge</test_depend> -->
   <!-- <test_depend>sensor_msgs</test_depend> -->
   <!-- <test_depend>image_transport</test_depend> -->


### PR DESCRIPTION
- support both yaml 0.3.0(hydro) and yaml 0.5.0(indigo), not sure if this really works, but should be ok, I had same strategy for https://github.com/jsk-ros-pkg/jsk_model_tools/blob/1c1472f373288226abb74e3f2a9806c981f1e483/euscollada/src/collada2eus.cpp
- use this to call methods, I need this to compile on indigo, but not sure if   this really works, please check if this is correct @YuOhara, @garaemon 
- depending on cv_bridge is recommended, see  http://wiki.ros.org/indigo/Migration#OpenCV