### PR TITLE
[jsk_pcl_ros] Cache result o nearest-negihbor search

### DIFF
--- a/jsk_pcl_ros/README.md
+++ b/jsk_pcl_ros/README.md
@@ -1009,6 +1009,20 @@ This nodelet tracks the target pointcloud.
 
   If this parameter is true, do not publish tf frame.
 
+* `~enable_cache` (Boolean, default: `false`)
+
+  Enable caching of nearest-neighbor search
+
+* `~cache_size_x` (Double, default: `0.01`)
+* `~cache_size_y` (Double, default: `0.01`)
+* `~cache_size_z` (Double, default: `0.01`)
+
+  Resolution of cache voxel grid.
+
+* `~max_distance` (Double, default: `1.0`)
+
+  Maximum distance between points to take into account when computing likelihood
+
 #### Sample
 
 run the below command.

--- a/jsk_pcl_ros/launch/particle_filter_localization.launch
+++ b/jsk_pcl_ros/launch/particle_filter_localization.launch
@@ -15,7 +15,7 @@
         args="standalone pcl/VoxelGrid">
     <remap from="~input" to="full_laser_cloud_from_root/output" />
     <rosparam>
-      leaf_size: 0.02
+      leaf_size: 0.01
       filter_limit_min: -1000
       filter_limit_max: 1000
     </rosparam>
@@ -42,7 +42,8 @@
       not_use_reference_centroid: true
       use_hsv: false
       reversed: true
-      particle_num: 400
+      particle_num: 1000
+      max_distance: 1.0
     </rosparam>
   </node>
 </launch>


### PR DESCRIPTION
Exprimental implementation to cache result of ANN search.

mutex lock is too heavy, so we need to implement lock-free map like [Michaels Hash Map]( http://www.research.ibm.com/people/m/michael/spaa-2002.pdf)