### PR TITLE
[jsk_pcl_ros] Optimized HintedStickFinder

### DIFF
--- a/jsk_pcl_ros/README.md
+++ b/jsk_pcl_ros/README.md
@@ -210,9 +210,17 @@ Detect a stick from pointcloud and line in 2-D image as hiint.
 
   Minimum number of inliers in cylinder fitting.
 
-*`~eps_2d_angle` (Double, default: `0.1`)
+* `~eps_2d_angle` (Double, default: `0.1`)
 
   Threshold between hint line and detected stick. This evaluation is done in 2-D coordinate system.
+
+* `~not_synchronize` (Boolean, default: `False`)
+
+  Do not synchronize `~input`, `~input/camera_info` and `~input/hint/line` if this parameter is `True`.
+  `~input/camera_info` and `~input/hint/line` are stored in nodelet and latest of the messages are used for new `~input` pointcloud.
+* `~use_normal` (Boolean, default: `False`)
+
+  Do not run normal estimation inside of the nodelet and use normal fields of `~input` are used.
 
 ### jsk\_pcl/RGBColorFilter
 Filter pointcloud based on RGB range.

--- a/jsk_pcl_ros/include/jsk_pcl_ros/hinted_stick_finder.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/hinted_stick_finder.h
@@ -71,12 +71,33 @@ namespace jsk_pcl_ros
     virtual void subscribe();
     virtual void unsubscribe();
     virtual void configCallback(Config &config, uint32_t level);
-    
+
+    /** @brief
+     * Synchronized message callback
+     */
     virtual void detect(
       const geometry_msgs::PolygonStamped::ConstPtr& polygon_msg,
       const sensor_msgs::CameraInfo::ConstPtr& camera_info_msg,
       const sensor_msgs::PointCloud2::ConstPtr& cloud_msg);
 
+    /** @brief
+     * Non synchronized message callback for ~input pointcloud.
+     */
+    virtual void cloudCallback(
+      const sensor_msgs::PointCloud2::ConstPtr& cloud_msg);
+
+    /** @brief
+     * Non synchronized message callback for ~input/hint/line
+     */
+    virtual void hintCallback(
+      const geometry_msgs::PolygonStamped::ConstPtr& hint_msg);
+
+    /** @brief
+     * Non synchronized message callback for ~input/camera_info
+     */
+    virtual void infoCallback(
+      const sensor_msgs::CameraInfo::ConstPtr& info_msg);
+    
     virtual ConvexPolygon::Ptr polygonFromLine(
       const geometry_msgs::PolygonStamped::ConstPtr& polygon_msg,
       const image_geometry::PinholeCameraModel& model,
@@ -126,6 +147,10 @@ namespace jsk_pcl_ros
     ros::Publisher pub_cylinder_pose_;
     ros::Publisher pub_inliers_;
     ros::Publisher pub_coefficients_;
+    // params from continuous_mode
+    ros::Subscriber sub_no_sync_cloud_;
+    ros::Subscriber sub_no_sync_camera_info_;
+    ros::Subscriber sub_no_sync_polygon_;
     boost::shared_ptr <dynamic_reconfigure::Server<Config> > srv_;
     
     double max_radius_;
@@ -138,6 +163,21 @@ namespace jsk_pcl_ros
     int cylinder_fitting_trial_;
     int min_inliers_;
     double eps_2d_angle_;
+    
+    /** @brief
+     *  True if use ~input has normal fields.
+     */
+    bool use_normal_;
+
+    /** @brief
+     *  Run in continuous mode. continuous mode means this nodelet does not synchronize
+     *  hint and input messages but keep processing with old hint information.
+     */
+    bool not_synchronize_;
+    
+    sensor_msgs::CameraInfo::ConstPtr latest_camera_info_;
+    geometry_msgs::PolygonStamped::ConstPtr latest_hint_;
+    
   private:
     
   };

--- a/jsk_pcl_ros/src/hinted_stick_finder_nodelet.cpp
+++ b/jsk_pcl_ros/src/hinted_stick_finder_nodelet.cpp
@@ -53,7 +53,9 @@ namespace jsk_pcl_ros
     typename dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&HintedStickFinder::configCallback, this, _1, _2);
     srv_->setCallback (f);
-
+    pnh_->param("use_normal", use_normal_, false);
+    pnh_->param("not_synchronize", not_synchronize_, false);
+    
     pub_line_filtered_indices_ = advertise<PCLIndicesMsg>(
       *pnh_, "debug/line_filtered_indices", 1);
     pub_line_filtered_normal_ = advertise<sensor_msgs::PointCloud2>(
@@ -70,20 +72,68 @@ namespace jsk_pcl_ros
 
   void HintedStickFinder::subscribe()
   {
-    sub_polygon_.subscribe(*pnh_, "input/hint/line", 1);
-    sub_info_.subscribe(*pnh_, "input/camera_info", 1);
-    sub_cloud_.subscribe(*pnh_, "input", 1);
-    sync_ = boost::make_shared<message_filters::Synchronizer<ASyncPolicy> >(100);
-    sync_->connectInput(sub_polygon_, sub_info_, sub_cloud_);
-    sync_->registerCallback(boost::bind(&HintedStickFinder::detect, this,
-                                        _1, _2, _3));
+    if (!not_synchronize_) {
+      sub_polygon_.subscribe(*pnh_, "input/hint/line", 1);
+      sub_info_.subscribe(*pnh_, "input/camera_info", 1);
+      sub_cloud_.subscribe(*pnh_, "input", 1);
+      sync_ = boost::make_shared<message_filters::Synchronizer<ASyncPolicy> >(100);
+      sync_->connectInput(sub_polygon_, sub_info_, sub_cloud_);
+      sync_->registerCallback(boost::bind(&HintedStickFinder::detect, this,
+                                          _1, _2, _3));
+    }
+    else {
+      sub_no_sync_cloud_ = pnh_->subscribe(
+        "input", 1, &HintedStickFinder::cloudCallback, this);
+      sub_no_sync_camera_info_ = pnh_->subscribe(
+        "input/camera_info", 1, &HintedStickFinder::infoCallback, this);
+      sub_no_sync_polygon_ = pnh_->subscribe(
+        "input/hint/line", 1, &HintedStickFinder::hintCallback, this);
+    }
   }
 
+
+  void HintedStickFinder::cloudCallback(
+      const sensor_msgs::PointCloud2::ConstPtr& cloud_msg)
+  {
+    {
+      boost::mutex::scoped_lock lock(mutex_);
+      if (!latest_hint_ || !latest_camera_info_) {
+        // not yet ready
+        NODELET_WARN_THROTTLE(1, "~input/hint/lline or ~input/camera_info is not ready");
+        return;
+      }
+    }
+    detect(latest_hint_, latest_camera_info_, cloud_msg);
+  }
+
+
+  void HintedStickFinder::hintCallback(
+    const geometry_msgs::PolygonStamped::ConstPtr& hint_msg)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+    latest_hint_ = hint_msg;
+  }
+
+  void HintedStickFinder::infoCallback(
+    const sensor_msgs::CameraInfo::ConstPtr& info_msg)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+    latest_camera_info_ = info_msg;
+  }
+  
+  
   void HintedStickFinder::unsubscribe()
   {
-    sub_polygon_.unsubscribe();
-    sub_info_.unsubscribe();
-    sub_cloud_.unsubscribe();
+    if (!not_synchronize_) {
+      sub_polygon_.unsubscribe();
+      sub_info_.unsubscribe();
+      sub_cloud_.unsubscribe();
+    }
+    else {
+      sub_no_sync_cloud_.shutdown();
+      sub_no_sync_camera_info_.shutdown();
+      sub_no_sync_polygon_.shutdown();
+    }
   }
 
   void HintedStickFinder::detect(
@@ -92,6 +142,8 @@ namespace jsk_pcl_ros
     const sensor_msgs::PointCloud2::ConstPtr& cloud_msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+    NODELET_WARN("starting detection");
+    ros::Time start_time = ros::Time::now();
     image_geometry::PinholeCameraModel model;
     model.fromCameraInfo(camera_info_msg);
     pcl::PointCloud<pcl::PointXYZ>::Ptr cloud
@@ -108,8 +160,27 @@ namespace jsk_pcl_ros
       (new pcl::PointCloud<pcl::Normal>);
     pcl::PointCloud<pcl::PointXYZ>::Ptr normals_cloud
       (new pcl::PointCloud<pcl::PointXYZ>);
-    normalEstimate(cloud, candidate_indices, *normals, *normals_cloud);
+    if (!use_normal_) {
+      normalEstimate(cloud, candidate_indices, *normals, *normals_cloud);
+    }
+    else {
+      // we don't need to compute normal
+      pcl::PointCloud<pcl::Normal>::Ptr all_normals
+        (new pcl::PointCloud<pcl::Normal>);
+      pcl::fromROSMsg(*cloud_msg, *all_normals);
+      pcl::ExtractIndices<pcl::PointXYZ> xyz_extract;
+      xyz_extract.setInputCloud(cloud);
+      xyz_extract.setIndices(candidate_indices);
+      xyz_extract.filter(*normals_cloud);
+      
+      pcl::ExtractIndices<pcl::Normal> normal_extract;
+      normal_extract.setInputCloud(all_normals);
+      normal_extract.setIndices(candidate_indices);
+      normal_extract.filter(*normals);
+    }
     fittingCylinder(normals_cloud, normals, a, b);
+    ros::Time end_time = ros::Time::now();
+    NODELET_WARN("detection time: %f", (end_time - start_time).toSec());
   }
 
   void HintedStickFinder::normalEstimate(


### PR DESCRIPTION
1. Use input pointcloud with normal not to run normal estimation in
HintedStickFinder
2. Add ~not_synchronize parameter to keep processing without more hint