### PR TITLE
add organized_pc_to_point_indics

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -275,6 +275,8 @@ jsk_pcl_nodelet(src/point_indices_to_mask_image_nodelet.cpp
   "jsk_pcl/PointIndicesToMaskImage" "point_indices_to_mask_image")
 jsk_pcl_nodelet(src/mask_image_to_point_indices_nodelet.cpp
   "jsk_pcl/MaskImageToPointIndices" "mask_image_to_point_indices")
+jsk_pcl_nodelet(src/organized_pointcloud_to_point_indices_nodelet.cpp
+  "jsk_pcl/OrganizedPointCloudToPointIndices" "organized_pointcloud_to_point_indices")
 jsk_pcl_nodelet(src/hinted_handle_estimator_nodelet.cpp
   "jsk_pcl/HintedHandleEstimator" "hinted_handle_estimator")
 jsk_pcl_nodelet(src/capture_stereo_synchronizer_nodelet.cpp

--- a/jsk_pcl_ros/README.md
+++ b/jsk_pcl_ros/README.md
@@ -917,6 +917,20 @@ organized pointcloud.
 
   Output indices converted from the mask image.
 
+### jsk\_pcl/OrganizedPointCloudToPointIndices
+A nodelet to convert organized PointCloud (`sensor_msgs::PointCloud2`) to `pcl_msgs/PointIndices` for
+organized pointcloud.
+
+#### Subscribing Topic
+* `~input` (`sensor_msgs/PointCloud2`)
+
+  Input organized pointcloud.
+
+#### Publishing Topic
+* `~output` (`pcl_msgs/PointIndices`)
+
+  Output indices converted from the organized pointcloud.
+
 ### jsk\_pcl/PointIndicesToMaskImage
 #### What Is This
 ![](images/point_indices_to_mask_image.png)

--- a/jsk_pcl_ros/include/jsk_pcl_ros/organized_pointcloud_to_point_indices.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/organized_pointcloud_to_point_indices.h
@@ -1,0 +1,72 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+
+#ifndef JSK_PCL_ROS_ORGANIZED_POINTCLOUD_TO_POINT_INDICES_H_
+#define JSK_PCL_ROS_ORGANIZED_POINTCLOUD_TO_POINT_INDICES_H_
+
+#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <sensor_msgs/PointCloud2.h>
+#include "jsk_pcl_ros/pcl_conversion_util.h"
+
+namespace jsk_pcl_ros
+{
+  class OrganizedPointCloudToPointIndices: public jsk_topic_tools::DiagnosticNodelet
+  {
+  public:
+    OrganizedPointCloudToPointIndices(): DiagnosticNodelet("OrganizedPointCloudToPointIndices") { }
+  protected:
+    ////////////////////////////////////////////////////////
+    // methods
+    ////////////////////////////////////////////////////////
+    virtual void onInit();
+    virtual void subscribe();
+    virtual void unsubscribe();
+    virtual void updateDiagnostic(
+      diagnostic_updater::DiagnosticStatusWrapper &stat);
+    virtual void indices(
+      const sensor_msgs::PointCloud2::ConstPtr& point_msg);
+
+    ////////////////////////////////////////////////////////
+    // ROS variables
+    ////////////////////////////////////////////////////////
+    ros::Subscriber sub_;
+    ros::Publisher pub_;
+  private:
+
+  };
+}
+
+#endif

--- a/jsk_pcl_ros/jsk_pcl_nodelets.xml
+++ b/jsk_pcl_ros/jsk_pcl_nodelets.xml
@@ -94,6 +94,10 @@
          type="jsk_pcl_ros::MaskImageToPointIndices"
          base_class_type="nodelet::Nodelet">
   </class>
+  <class name="jsk_pcl/OrganizedPointCloudToPointIndices"
+         type="jsk_pcl_ros::OrganizedPointCloudToPointIndices"
+         base_class_type="nodelet::Nodelet">
+  </class>
   <class name="jsk_pcl/IncrementalModelRegistration"
          type="jsk_pcl_ros::IncrementalModelRegistration"
          base_class_type="nodelet::Nodelet">

--- a/jsk_pcl_ros/src/organized_pointcloud_to_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros/src/organized_pointcloud_to_point_indices_nodelet.cpp
@@ -1,0 +1,93 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+#define BOOST_PARAMETER_MAX_ARITY 7
+#include "jsk_pcl_ros/organized_pointcloud_to_point_indices.h"
+#include "jsk_pcl_ros/pcl_conversion_util.h"
+#include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
+
+namespace jsk_pcl_ros
+{
+  void OrganizedPointCloudToPointIndices::onInit()
+  {
+    DiagnosticNodelet::onInit();
+    pub_ = advertise<PCLIndicesMsg>(*pnh_, "output", 1);
+  }
+
+  void OrganizedPointCloudToPointIndices::subscribe()
+  {
+    sub_ = pnh_->subscribe("input", 1,
+                           &OrganizedPointCloudToPointIndices::indices,
+                           this);
+  }
+
+  void OrganizedPointCloudToPointIndices::unsubscribe()
+  {
+    sub_.shutdown();
+  }
+
+  void OrganizedPointCloudToPointIndices::updateDiagnostic(
+    diagnostic_updater::DiagnosticStatusWrapper &stat)
+  {
+    if (vital_checker_->isAlive()) {
+      stat.summary(diagnostic_msgs::DiagnosticStatus::OK,
+                   "OrganizedPointCloudToPointIndices running");
+    }
+    else {
+      jsk_topic_tools::addDiagnosticErrorSummary(
+        "OrganizedPointCloudToPointIndices", vital_checker_, stat);
+    }
+  }
+
+  void OrganizedPointCloudToPointIndices::indices(
+    const sensor_msgs::PointCloud2::ConstPtr& point_msg)
+  {
+    pcl::PointCloud<pcl::PointXYZ>::Ptr pc(new pcl::PointCloud<pcl::PointXYZ>);
+    pcl::fromROSMsg(*point_msg, *pc);
+    if(pc->isOrganized()){
+      PCLIndicesMsg indices_msg;
+      indices_msg.header = point_msg->header;
+      for (size_t i = 0; i < pc->points.size(); i++)
+        if (!isnan(pc->points[i].x) && !isnan(pc->points[i].y) && !isnan(pc->points[i].z))
+          indices_msg.indices.push_back(i);
+      pub_.publish(indices_msg);
+    }else{
+      ROS_ERROR("Input Pointcloud is not organized");
+    }
+  }
+}
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS (jsk_pcl_ros::OrganizedPointCloudToPointIndices, nodelet::Nodelet);


### PR DESCRIPTION
Thanks to #762, I added nodelet which will publsh indices.
 In addition, I added launch file which will publish pass_throughed image as below.
![organized_pointcloud](https://cloud.githubusercontent.com/assets/3803922/6574218/0bf55f68-c766-11e4-9dc4-495ca7ef4960.png)
