### PR TITLE
[jsk_pcl_ros] Optimize GridPlane::fillCellsFromPointCloud 

### DIFF
--- a/jsk_pcl_ros/cfg/EnvironmentPlaneModeling.cfg
+++ b/jsk_pcl_ros/cfg/EnvironmentPlaneModeling.cfg
@@ -16,5 +16,7 @@ from math import pi
 gen = ParameterGenerator ()
 gen.add("magnify_distance", double_t, 0, "Lenght to magnify convex polygons", 0.2, 0.0, 1.0)
 gen.add("distance_threshold", double_t, 0, "Allowed distance threshold from plane to points", 0.01, 0.0, 1.0)
+gen.add("resolution", double_t, 0, "Resolution of grid", 0.005, 0.001, 0.1)
+
 
 exit (gen.generate (PACKAGE, "jsk_pcl_ros", "EnvironmentPlaneModeling"))

--- a/jsk_pcl_ros/include/jsk_pcl_ros/environment_plane_modeling.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/environment_plane_modeling.h
@@ -183,6 +183,7 @@ namespace jsk_pcl_ros
     
     double magnify_distance_;
     double distance_threshold_;
+    double resolution_;
   private:
   };
 }

--- a/jsk_pcl_ros/include/jsk_pcl_ros/environment_plane_modeling.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/environment_plane_modeling.h
@@ -163,7 +163,7 @@ namespace jsk_pcl_ros
      * make GridPlane from ConvexPolygon and PointCloud
      */
     virtual std::vector<GridPlane::Ptr> buildGridPlanes(
-      const pcl::PointCloud<pcl::PointNormal>& cloud,
+      const pcl::PointCloud<pcl::PointNormal>::Ptr& cloud,
       std::vector<ConvexPolygon::Ptr> convexes);
     
     boost::mutex mutex_;

--- a/jsk_pcl_ros/include/jsk_pcl_ros/geo_util.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/geo_util.h
@@ -133,6 +133,7 @@ namespace jsk_pcl_ros
   public:
     typedef boost::shared_ptr<Plane> Ptr;
     Plane(const std::vector<float>& coefficients);
+    Plane(const boost::array<float, 4>& coefficients);
     Plane(Eigen::Vector3f normal, double d);
     Plane(Eigen::Vector3f normal, Eigen::Vector3f p);
     virtual ~Plane();
@@ -159,8 +160,10 @@ namespace jsk_pcl_ros
     virtual double getD();
     virtual Eigen::Affine3f coordinates();
   protected:
+    virtual void initializeCoordinates();
     Eigen::Vector3f normal_;
     double d_;
+    Eigen::Affine3f plane_coordinates_;
   private:
   };
 
@@ -292,20 +295,65 @@ namespace jsk_pcl_ros
     }
   }
 
+  /**
+   * @brief
+   * Grid based representation of planar region.
+   *
+   * Each cell represents a square region as belows:
+   *        +--------+
+   *        |        |
+   *        |   +    |
+   *        |        |
+   *        +--------+
+   *
+   * The width and height of the cell is equivalent to resolution_,
+   * and the value of cells_ represents a center point.
+   * (i, j) means rectanglar region of (x, y) which satisfies followings:
+   * i * resolution - 0.5 * resolution < x <= i * resolution + 0.5 * resolution
+   * j * resolution - 0.5 * resolution < y <= j * resolution + 0.5 * resolution
+   * 
+   *
+   */
   class GridPlane
   {
   public:
     typedef boost::shared_ptr<GridPlane> Ptr;
-    GridPlane(ConvexPolygon::Ptr plane);
+    typedef boost::tuple<int, int> IndexPair;
+    GridPlane(ConvexPolygon::Ptr plane, const double resolution);
     virtual ~GridPlane();
     virtual void fillCellsFromPointCloud(
       const pcl::PointCloud<pcl::PointNormal>& cloud,
       double distance_threshold);
     virtual double getResolution() { return resolution_; }
     virtual jsk_recognition_msgs::SimpleOccupancyGrid toROSMsg();
+    
+    /**
+     * @brief
+     * Project 3-D point to GridPlane::IndexPair.
+     * p should be represented in local coordinates.
+     */
+    virtual IndexPair projectLocalPointAsIndexPair(const Eigen::Vector3f& p);
+
+    /**
+     * @brief
+     * Unproject GridPlane::IndexPair to 3-D local point.
+     */
+    virtual Eigen::Vector3f unprojectIndexPairAsLocalPoint(const IndexPair& pair);
+
+    /**
+     * @brief
+     * Unproject GridPlane::IndexPair to 3-D global point.
+     */
+    virtual Eigen::Vector3f unprojectIndexPairAsGlobalPoint(const IndexPair& pair);
+
+    /**
+     * @brief
+     * Add IndexPair to this instance.
+     */
+    virtual void addIndexPair(IndexPair pair);
   protected:
     ConvexPolygon::Ptr convex_;
-    Vertices cells_;
+    std::set<IndexPair> cells_;
     double resolution_;
   private:
     

--- a/jsk_pcl_ros/include/jsk_pcl_ros/geo_util.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/geo_util.h
@@ -322,7 +322,7 @@ namespace jsk_pcl_ros
     GridPlane(ConvexPolygon::Ptr plane, const double resolution);
     virtual ~GridPlane();
     virtual void fillCellsFromPointCloud(
-      const pcl::PointCloud<pcl::PointNormal>& cloud,
+      const pcl::PointCloud<pcl::PointNormal>::Ptr& cloud,
       double distance_threshold);
     virtual double getResolution() { return resolution_; }
     virtual jsk_recognition_msgs::SimpleOccupancyGrid toROSMsg();

--- a/jsk_pcl_ros/src/environment_plane_modeling_nodelet.cpp
+++ b/jsk_pcl_ros/src/environment_plane_modeling_nodelet.cpp
@@ -161,7 +161,7 @@ namespace jsk_pcl_ros
     publishConvexPolygons(debug_magnified_polygons_, cloud_msg->header, magnified_convexes);
 
     // build GridMaps
-    std::vector<GridPlane::Ptr> grid_planes = buildGridPlanes(*cloud, magnified_convexes);
+    std::vector<GridPlane::Ptr> grid_planes = buildGridPlanes(cloud, magnified_convexes);
 
     publishGridMaps(pub_grid_map_, cloud_msg->header, grid_planes);
   }
@@ -183,7 +183,7 @@ namespace jsk_pcl_ros
   
   
   std::vector<GridPlane::Ptr> EnvironmentPlaneModeling::buildGridPlanes(
-    const pcl::PointCloud<pcl::PointNormal>& cloud,
+    const pcl::PointCloud<pcl::PointNormal>::Ptr& cloud,
     std::vector<ConvexPolygon::Ptr> convexes)
   {
     std::vector<GridPlane::Ptr> ret(convexes.size());

--- a/jsk_pcl_ros/src/environment_plane_modeling_nodelet.cpp
+++ b/jsk_pcl_ros/src/environment_plane_modeling_nodelet.cpp
@@ -83,6 +83,7 @@ namespace jsk_pcl_ros
     boost::mutex::scoped_lock lock(mutex_);
     magnify_distance_ = config.magnify_distance;
     distance_threshold_ = config.distance_threshold;
+    resolution_ = config.resolution;
   }
 
   void EnvironmentPlaneModeling::printInputData(
@@ -191,7 +192,7 @@ namespace jsk_pcl_ros
 #pragma omp parallel for
 #endif
     for (size_t i = 0; i < convexes.size(); i++) {
-      GridPlane::Ptr grid(new GridPlane(convexes[i]));
+      GridPlane::Ptr grid(new GridPlane(convexes[i], resolution_));
       grid->fillCellsFromPointCloud(cloud, distance_threshold_);
       ret[i] = grid;
     }


### PR DESCRIPTION
Optimize GridPlane::fillCellsFromPointCloud by using pcl::ExtractPolygonalPrismData and now it's much much faster than before