### PR TITLE
[jsk_perception] print number of point when encoding sparse image

### DIFF
--- a/jsk_perception/launch/sparse_image_encoder.launch
+++ b/jsk_perception/launch/sparse_image_encoder.launch
@@ -1,7 +1,10 @@
 <launch>
-  <node pkg="jsk_perception" type="sparse_image_encoder" name="sparse_image_encoder">
+  <arg name="print_point_num" default="false" />
+  <node pkg="jsk_perception" type="sparse_image_encoder" name="sparse_image_encoder"
+        output="screen">
     <remap from="image" to="edge/image" />
     <remap from="sparse_image" to="sparse/image" />
     <param name="rate" value="1.0" />
+    <param name="print_point_num" value="$(arg print_point_num)" />
   </node>
 </launch>

--- a/jsk_perception/launch/sparse_image_encoder_sample.launch
+++ b/jsk_perception/launch/sparse_image_encoder_sample.launch
@@ -1,0 +1,8 @@
+<launch>
+  <group ns="/openni/rgb">
+    <include file="$(jsk_perception)/launch/edge_detector.launch" />
+    <include file="$(jsk_perception)/launch/sparse_image_encoder.launch">
+      <arg name="print_point_num" value="true" />
+    </include>
+  </group>
+</launch>

--- a/jsk_perception/src/sparse_image_encoder.cpp
+++ b/jsk_perception/src/sparse_image_encoder.cpp
@@ -25,6 +25,7 @@ class SparseImageEncoder: public nodelet::Nodelet
   ros::NodeHandle _ln;
   int _subscriber_count;
   double _rate;
+  bool _print_point_num;
 
   void imageCallback(const sensor_msgs::ImageConstPtr& msg){
     do_work(msg, msg->header.frame_id);
@@ -56,6 +57,14 @@ class SparseImageEncoder: public nodelet::Nodelet
             else           _spr_img_ptr->data16.push_back( (x << 8)  | y );
           }
         }
+      }
+
+      // print number of point if enabled
+      if (_print_point_num) {
+        int size = 0;
+        if (useData32) size = _spr_img_ptr->data32.size();
+        else size = _spr_img_ptr->data16.size();
+        NODELET_INFO("%d point encoded.", size);
       }
 
       // publish sparse image message
@@ -103,6 +112,7 @@ public:
     _spr_img_pub = _nh.advertise<jsk_recognition_msgs::SparseImage>("sparse_image", 10, connect_cb, disconnect_cb);
     _spr_img_ptr = boost::make_shared<jsk_recognition_msgs::SparseImage>();
     _ln.param("rate", _rate, 3.0);
+    _ln.param("print_point_num", _print_point_num, false);
   } // end of onInit function
 }; // end of SparseImageEncoder class definition
 } // end of jsk_perception namespace


### PR DESCRIPTION
add feature to print point nums when encoding sparse image.

including example launch `jsk_perception/launch/sparse_image_encoder_sample.launch`
