### PR TITLE
[jsk_perception] add Simple Fisheye to Panorama

### DIFF
--- a/jsk_perception/CMakeLists.txt
+++ b/jsk_perception/CMakeLists.txt
@@ -86,6 +86,7 @@ jsk_perception_nodelet(src/sparse_image_decoder.cpp "jsk_perception/SparseImageD
 jsk_perception_nodelet(src/color_histogram.cpp "jsk_perception/ColorHistogram" "color_histogram")
 jsk_perception_nodelet(src/background_substraction_nodelet.cpp "jsk_perception/BackgroundSubstraction" "background_substraction")
 jsk_perception_nodelet(src/hough_circles.cpp "jsk_perception/HoughCircleDetector" "hough_circles")
+jsk_perception_nodelet(src/fisheye_to_panorama.cpp "jsk_perception/FisheyeToPanorama" "fisheye_to_panorama")
 jsk_perception_nodelet(src/grabcut_nodelet.cpp "jsk_perception/GrabCut" "grabcut")
 jsk_perception_nodelet(src/slic_superpixels.cpp "jsk_perception/SLICSuperPixels" "slic_super_pixels")
 jsk_perception_nodelet(src/rgb_decomposer.cpp "jsk_perception/RGBDecomposer" "rgb_decomposer")

--- a/jsk_perception/include/jsk_perception/fisheye_to_panorama.h
+++ b/jsk_perception/include/jsk_perception/fisheye_to_panorama.h
@@ -1,0 +1,79 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+
+#ifndef JSK_PERCEPTION_FISHEYE_TO_PANORAMA_H_
+#define JSK_PERCEPTION_FISHEYE_TO_PANORAMA_H_
+
+#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <sensor_msgs/Image.h>
+#include <sensor_msgs/CameraInfo.h>
+
+#include <message_filters/subscriber.h>
+#include <message_filters/synchronizer.h>
+#include <message_filters/sync_policies/approximate_time.h>
+#include <message_filters/pass_through.h>
+#include <dynamic_reconfigure/server.h>
+
+#include <opencv2/opencv.hpp>
+
+namespace jsk_perception
+{
+  class FisheyeToPanorama: public jsk_topic_tools::DiagnosticNodelet
+  {
+  public:
+    typedef message_filters::sync_policies::ApproximateTime<
+      sensor_msgs::Image,         // image
+      sensor_msgs::CameraInfo        // camera info
+      > SyncPolicy;
+
+    FisheyeToPanorama(): DiagnosticNodelet("FisheyeToPanorama") {}
+  protected:
+    virtual void onInit();
+    virtual void subscribe();
+    virtual void unsubscribe();
+    inline double interpolate(double rate, double first, double second){return (1.0 - rate) * first + rate * second;};
+    virtual void rectify(const sensor_msgs::Image::ConstPtr& image_msg);
+    
+    boost::shared_ptr<message_filters::Synchronizer<SyncPolicy> > sync_;
+    ros::Subscriber sub_image_;
+    ros::Publisher pub_undistorted_image_;
+    ros::Publisher pub_undistorted_bilinear_image_;
+  private:
+    
+  };
+}
+
+#endif

--- a/jsk_perception/jsk_perception_nodelets.xml
+++ b/jsk_perception/jsk_perception_nodelets.xml
@@ -142,4 +142,10 @@
       Nodelet to decode from an array of sparse matrix to image.
     </description>
   </class>
+  <class name="jsk_perception/FisheyeToPanorama" type="jsk_perception::FisheyeToPanorama"
+         base_class_type="nodelet::Nodelet">
+    <description>
+      Nodelet to convert fisheye image to panorama.
+    </description>
+  </class>
 </library>

--- a/jsk_perception/launch/fisheye_to_panorama.launch
+++ b/jsk_perception/launch/fisheye_to_panorama.launch
@@ -1,0 +1,16 @@
+<launch>
+  <node type="nm33_node" pkg="opt_camera" name="nm33_camera"/>
+
+  <node type="nodelet" pkg="nodelet" name="fisheye_manager" args="manager"/>
+  <node type="nodelet" pkg="nodelet" name="fisheye_to_panorama"
+	args="load jsk_perception/FisheyeToPanorama fisheye_manager" output="screen">
+    <remap from="~input" to="/camera/omni/image_raw"/>
+    <remap from="~input_camera_info" to="/camera/omni/camera_info"/>
+  </node>
+  <node type="image_view" pkg="image_view" name="fisheye_image_view">
+    <remap from="image" to="/camera/omni/image_raw"/>
+  </node>
+  <node type="image_view" pkg="image_view" name="undistorted_image_view">
+    <remap from="image" to="/fisheye_to_panorama/output_bilinear"/>
+  </node>
+</launch>

--- a/jsk_perception/src/fisheye_to_panorama.cpp
+++ b/jsk_perception/src/fisheye_to_panorama.cpp
@@ -1,0 +1,150 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include "jsk_perception/fisheye_to_panorama.h"
+#include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/Image.h>
+#include <sensor_msgs/image_encodings.h>
+#include <algorithm>
+#include <math.h> 
+
+#define PI 3.141592
+
+namespace jsk_perception
+{
+  void FisheyeToPanorama::onInit()
+  {
+    DiagnosticNodelet::onInit();
+    pub_undistorted_image_ = advertise<sensor_msgs::Image>(
+      *pnh_, "output", 1);
+    pub_undistorted_bilinear_image_ = advertise<sensor_msgs::Image>(
+      *pnh_, "output_bilinear", 1);
+  }
+
+  void FisheyeToPanorama::subscribe()
+  {
+    sub_image_ = pnh_->subscribe("input", 1, &FisheyeToPanorama::rectify, this);
+  }
+  
+  void FisheyeToPanorama::unsubscribe()
+  {
+    sub_image_.shutdown();
+  }
+
+  void FisheyeToPanorama::rectify(const sensor_msgs::Image::ConstPtr& image_msg)
+  {
+    
+    cv::Mat distorted = cv_bridge::toCvCopy(image_msg, sensor_msgs::image_encodings::BGR8)->image;
+    int l = distorted.rows / 2;
+    cv::Mat undistorted(l, l*4, CV_8UC3);
+    cv::Mat undistorted_bilinear(l, l*4, CV_8UC3);
+
+    for(int i = 0; i < undistorted.rows; ++i){
+      for(int j = 0; j < undistorted.cols; ++j){
+	
+	double radius = l - i;
+	double theta = 2.0 * PI * (double)(-j) / (double)(4.0 * l);
+	double fTrueX = radius * cos(theta);
+	double fTrueY = radius * sin(theta);
+
+	int x = (int)round(fTrueX) + l;
+	int y = l - (int)round(fTrueY);
+	if (x >= 0 && x < (2 * l) && y >= 0 && y < (2 * l))
+	  {
+	    for(int c = 0; c < undistorted.channels(); ++c)
+	      undistorted.data[ i * undistorted.step + j * undistorted.elemSize() + c ]
+		= distorted.data[x * distorted.step + y * distorted.elemSize() + c];
+	  }
+
+	fTrueX = fTrueX + (double)l;
+	fTrueY = (double)l - fTrueY;
+
+	int iFloorX = (int)floor(fTrueX);
+	int iFloorY = (int)floor(fTrueY);
+	int iCeilingX = (int)ceil(fTrueX);
+	int iCeilingY = (int)ceil(fTrueY);
+
+	if (iFloorX < 0 || iCeilingX < 0 ||
+	    iFloorX >= (2 * l) || iCeilingX >= (2 * l) ||
+	    iFloorY < 0 || iCeilingY < 0 ||
+	    iFloorY >= (2 * l) || iCeilingY >= (2 * l)) continue;
+
+	double fDeltaX = fTrueX - (double)iFloorX;
+	double fDeltaY = fTrueY - (double)iFloorY;
+
+	cv::Mat clrTopLeft(1,1, CV_8UC3), clrTopRight(1,1, CV_8UC3), clrBottomLeft(1,1, CV_8UC3), clrBottomRight(1,1, CV_8UC3);
+	for(int c = 0; c < undistorted.channels(); ++c){
+	  clrTopLeft.data[ c ] = distorted.data[iFloorX * distorted.step + iFloorY * distorted.elemSize() + c];
+	  clrTopRight.data[ c ] = distorted.data[iCeilingX * distorted.step + iFloorY * distorted.elemSize() + c];
+	  clrBottomLeft.data[ c ] = distorted.data[iFloorX * distorted.step + iCeilingY * distorted.elemSize() + c];
+	  clrBottomRight.data[ c ] = distorted.data[iCeilingX * distorted.step + iCeilingY * distorted.elemSize() + c];
+	}
+
+	double fTop0 = interpolate(fDeltaX, clrTopLeft.data[0], clrTopRight.data[0]);
+	double fTop1 = interpolate(fDeltaX, clrTopLeft.data[1], clrTopRight.data[1]);
+	double fTop2 = interpolate(fDeltaX, clrTopLeft.data[2], clrTopRight.data[2]);
+	double fBottom0 = interpolate(fDeltaX, clrBottomLeft.data[0], clrBottomRight.data[0]);
+	double fBottom1 = interpolate(fDeltaX, clrBottomLeft.data[1], clrBottomRight.data[1]);
+	double fBottom2 = interpolate(fDeltaX, clrBottomLeft.data[2], clrBottomRight.data[2]);
+
+	int i0 = (int)round(interpolate(fDeltaY, fTop0, fBottom0));
+	int i1 = (int)round(interpolate(fDeltaY, fTop1, fBottom1));
+	int i2 = (int)round(interpolate(fDeltaY, fTop2, fBottom2));
+
+	i0 = std::min(255, std::max(i0, 0));
+	i1 = std::min(255, std::max(i1, 0));
+	i2 = std::min(255, std::max(i2, 0));
+	  
+	undistorted_bilinear.data[ i * undistorted_bilinear.step + j * undistorted_bilinear.elemSize() + 0] = i0;
+	undistorted_bilinear.data[ i * undistorted_bilinear.step + j * undistorted_bilinear.elemSize() + 1] = i1;
+	undistorted_bilinear.data[ i * undistorted_bilinear.step + j * undistorted_bilinear.elemSize() + 2] = i2;
+      }
+    }
+
+    pub_undistorted_image_.publish(
+				   cv_bridge::CvImage(
+						      image_msg->header,
+						      image_msg->encoding,
+						      undistorted).toImageMsg());
+    pub_undistorted_bilinear_image_.publish(cv_bridge::CvImage(
+							       image_msg->header,
+							       image_msg->encoding,
+							       undistorted_bilinear).toImageMsg());
+  }
+}
+
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS (jsk_perception::FisheyeToPanorama, nodelet::Nodelet);


### PR DESCRIPTION
For the time being, I added the nodelet which will convert fisheye imageto panorama VERY SIMPLELY
![fisheye_to_panorama](https://cloud.githubusercontent.com/assets/3803922/6996582/23c61a96-dbcb-11e4-985c-f8c802156d05.png)
.
I refer most of all from this page -> http://polymathprogrammer.com/2009/10/15/convert-360-degree-fisheye-image-to-landscape-mode/