### PR TITLE
[jsk_pcl_ros] Add geometry_msgs/PolygonStamped input for TorusFinder

### DIFF
--- a/jsk_pcl_ros/README.md
+++ b/jsk_pcl_ros/README.md
@@ -530,6 +530,9 @@ Find a torus out of pointcloud based on RANSAC with 3-D circle model.
 * `~input` (`sensor_msgs/PointCloud`)
 
   Input pointcloud. You may need to choose good candidates of pointcloud.
+* `~input/polygon` (`geometry_msgs/PolygonStampedd`)
+
+  Input polygon. You can use `geometry_msgs/PolygonStampedd` instead of `sensor_msgs/PointCloud`
 
 #### Publishing Topic
 

--- a/jsk_pcl_ros/include/jsk_pcl_ros/torus_finder.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/torus_finder.h
@@ -45,6 +45,7 @@
 #include <dynamic_reconfigure/server.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <Eigen/Core>
+#include <geometry_msgs/PolygonStamped.h>
 
 namespace jsk_pcl_ros
 {
@@ -58,6 +59,7 @@ namespace jsk_pcl_ros
     virtual void subscribe();
     virtual void unsubscribe();
     virtual void segment(const sensor_msgs::PointCloud2::ConstPtr& cloud_msg);
+    virtual void segmentFromPoints(const geometry_msgs::PolygonStamped::ConstPtr& polygon_msg);
     virtual void configCallback(Config &config, uint32_t level);
     
     ////////////////////////////////////////////////////////
@@ -65,6 +67,7 @@ namespace jsk_pcl_ros
     ////////////////////////////////////////////////////////
     boost::shared_ptr <dynamic_reconfigure::Server<Config> > srv_;
     ros::Subscriber sub_;
+    ros::Subscriber sub_points_;
     ros::Publisher pub_torus_;
     ros::Publisher pub_torus_array_;
     ros::Publisher pub_inliers_;


### PR DESCRIPTION
Add `geometry_msgs/PolygonStamped` interface to TorusFinder.

@orikuma 
もしもロバスト推定が必要なら使ってください.

eusから`geometry_msgs/PolygonStamped`を出せば、そこから3次元の円を推定します。

ただ、適当に重心とかから始めたら良いとは思います。