### PR TITLE
[jsk_pcl_ros] extract only directed region of mask image

### DIFF
--- a/jsk_pcl_ros/README.md
+++ b/jsk_pcl_ros/README.md
@@ -1037,17 +1037,25 @@ jsk_pcl/MaskImageToDepthConsideredMaskImage generates mask image at close range 
 
   Input mask image. 
 
+* `~input/maskregion` (`sensor_msgs/Image`)
+
+  Input mask region.(To use interactively, use interaction_mode:grabcut_rect of image_view2.)
+
 #### Publishing Topic
 
 * `~output `(`sensor_msg/Image`)
 
   Output mask Image.  Points at close range is extracted.
 
-#### Publishing Topic
+#### Parameter
 
 * `~extract_num (Int, default: `500`)
 
   Num of extract points in mask image.
+
+* `~use_mask_region (Bool, default: True)
+
+  Whether use msk region option or not. If true, only selected region of mask image is extracted.
 
 ### jsk\_pcl/AttentionClipper
 #### What Is This

--- a/jsk_pcl_ros/cfg/MaskImageToDepthConsideredMaskImage.cfg
+++ b/jsk_pcl_ros/cfg/MaskImageToDepthConsideredMaskImage.cfg
@@ -15,5 +15,6 @@ from math import pi
 
 gen = ParameterGenerator ()
 
-gen.add("extract_num", int_t, 0, "set the number of extract points", 500, 0, 10000)
+gen.add("extract_num", int_t, 0, "Set the number of extract points", 500, 0, 10000)
+gen.add("use_mask_region", bool_t, 0, "Use interactive mask region definition", True)
 exit (gen.generate (PACKAGE, "jsk_pcl_ros", "MaskImageToDepthConsideredMaskImage"))

--- a/jsk_pcl_ros/include/jsk_pcl_ros/mask_image_to_depth_considered_mask_image.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/mask_image_to_depth_considered_mask_image.h
@@ -75,6 +75,7 @@ namespace jsk_pcl_ros
      const sensor_msgs::PointCloud2::ConstPtr& point_cloud2_msg,
      const sensor_msgs::Image::ConstPtr& image_msg);
     virtual void configCallback(Config &config, uint32_t level);
+    virtual void mask_region_callback(const sensor_msgs::Image::ConstPtr& msg);
   
     ////////////////////////////////////////////////////////
     // ROS variables
@@ -88,6 +89,13 @@ namespace jsk_pcl_ros
     message_filters::Subscriber<sensor_msgs::PointCloud2> sub_input_;
     message_filters::Subscriber<sensor_msgs::Image> sub_image_;
     ros::Publisher pub_;
+    ros::Subscriber sub_;
+    int region_width_;
+    int region_height_;
+    int region_x_off_;
+    int region_y_off_;
+    bool use_mask_region_;
+
   private:
   
   };

--- a/jsk_pcl_ros/src/mask_image_to_depth_considered_mask_image_nodelet.cpp
+++ b/jsk_pcl_ros/src/mask_image_to_depth_considered_mask_image_nodelet.cpp
@@ -38,6 +38,7 @@
 #include <cv_bridge/cv_bridge.h>
 #include <pcl/kdtree/kdtree_flann.h>
 
+
 namespace jsk_pcl_ros
 {
   void MaskImageToDepthConsideredMaskImage::onInit()
@@ -45,18 +46,54 @@ namespace jsk_pcl_ros
     DiagnosticNodelet::onInit();
     pnh_->param("approximate_sync", approximate_sync_, false);
     pub_ = advertise<sensor_msgs::Image>(*pnh_, "output", 1);
-    //    pnh_->param("extract_num", extract_num, 500);
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (
         &MaskImageToDepthConsideredMaskImage::configCallback, this, _1, _2);
     srv_->setCallback (f);
+    sub_ = pnh_->subscribe("input/maskregion", 1, &MaskImageToDepthConsideredMaskImage::mask_region_callback, this);
+    region_width_ = 0;
+    region_height_ = 0;
+    region_x_off_ = 0;
+    region_y_off_ = 0;
   }
 
   void MaskImageToDepthConsideredMaskImage::configCallback(Config &config, uint32_t level){
     boost::mutex::scoped_lock lock(mutex_);
-    extract_num_=config.extract_num;
+    extract_num_ = config.extract_num;
+    use_mask_region_ = config.use_mask_region;
   }
+
+
+  void MaskImageToDepthConsideredMaskImage::mask_region_callback(const sensor_msgs::Image::ConstPtr& msg){
+    boost::mutex::scoped_lock lock(mutex_);
+    cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy
+      (msg, sensor_msgs::image_encodings::MONO8);
+    cv::Mat mask = cv_ptr->image;
+    int tmp_width = 0;
+    int tmp_height = 0;
+    int tmp_x_off = 0;
+    int tmp_y_off = 0;
+    bool flag = true;
+    for (size_t j = 0; j < mask.rows; j++) {
+      for (size_t i = 0; i < mask.cols; i++) {
+        if (mask.at<uchar>(j, i) != 0) {
+          if (flag == true) {
+            tmp_x_off = i;
+            tmp_y_off = j;
+            flag = false;
+          }
+          else {
+            tmp_width = i-tmp_x_off + 1;
+            tmp_height = j-tmp_y_off + 1;
+          }}}}
+    ROS_INFO("mask resion callback: width:%d height:%d x_off:%d y_off:%d", tmp_width, tmp_height, tmp_x_off, tmp_y_off);
+    region_width_ = tmp_width;
+    region_height_ = tmp_height;
+    region_x_off_ = tmp_x_off;
+    region_y_off_ = tmp_y_off;
+  }
+
 
   void MaskImageToDepthConsideredMaskImage::subscribe()
   {
@@ -86,54 +123,89 @@ namespace jsk_pcl_ros
      const sensor_msgs::PointCloud2::ConstPtr& point_cloud2_msg,
      const sensor_msgs::Image::ConstPtr& image_msg)
   {
-    vital_checker_->poke();
-    pcl::PointCloud<pcl::PointXYZ>::Ptr
-      cloud (new pcl::PointCloud<pcl::PointXYZ>);
-    pcl::fromROSMsg(*point_cloud2_msg, *cloud);
-    pcl::PointCloud<pcl::PointXYZ>::Ptr
-      edge_cloud (new pcl::PointCloud<pcl::PointXYZ>);
+    boost::mutex::scoped_lock lock(mutex_);
+    if (point_cloud2_msg->width == image_msg->width && point_cloud2_msg->height == image_msg->height){
+      vital_checker_->poke();
+      pcl::PointCloud<pcl::PointXYZ>::Ptr
+        cloud (new pcl::PointCloud<pcl::PointXYZ>);
+      pcl::fromROSMsg(*point_cloud2_msg, *cloud);
+      pcl::PointCloud<pcl::PointXYZ>::Ptr
+        edge_cloud (new pcl::PointCloud<pcl::PointXYZ>);
 
-    int width = image_msg->width;
-    int height = image_msg->height;
-    pcl::PointXYZ nan_point;
-    nan_point.x = NAN;
-    nan_point.y = NAN;
-    nan_point.z = NAN;
-    cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy
-      (image_msg, sensor_msgs::image_encodings::MONO8);
-    cv::Mat mask = cv_ptr->image;
-    edge_cloud->is_dense = false;
-    edge_cloud->points.resize(width * height);
-    edge_cloud->width = width;
-    edge_cloud->height = height;
-    for (size_t j = 0; j < mask.rows; j++) {
-      for (size_t i = 0; i < mask.cols; i++) {
-        if (mask.at<uchar>(j, i)!=0) {//if white
-          edge_cloud->points[j * width + i] = cloud->points[j * width + i];
-        }
-        else{
-          edge_cloud->points[j * width + i] = nan_point;
+      int width = image_msg->width;
+      int height = image_msg->height;
+      bool points_exist = false;
+      pcl::PointXYZ nan_point;
+      nan_point.x = NAN;
+      nan_point.y = NAN;
+      nan_point.z = NAN;
+      cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy
+        (image_msg, sensor_msgs::image_encodings::MONO8);
+      cv::Mat mask = cv_ptr->image;
+      edge_cloud->is_dense = false;
+      edge_cloud->points.resize(width * height);
+      edge_cloud->width = width;
+      edge_cloud->height = height;
+      if (use_mask_region_ == false || region_width_ == 0 || region_height_ == 0){
+        for (size_t j = 0; j < mask.rows; j++) {
+          for (size_t i = 0; i < mask.cols; i++) {
+            if (mask.at<uchar>(j, i) != 0) {//if white
+              points_exist = true;
+              edge_cloud->points[j * width + i] = cloud->points[j * width + i];
+            }
+            else {
+              edge_cloud->points[j * width + i] = nan_point;
+            }
+          }
         }
       }
+      else {
+        ROS_INFO("directed region width:%d height:%d", region_width_, region_height_);
+        //set nan_point to all points first.
+        for (size_t j = 0; j < mask.rows; j++) {
+          for (size_t i = 0; i < mask.cols; i++) {
+            edge_cloud->points[j * width + i] = nan_point;
+          }
+        }
+        int x_end = region_x_off_+ region_width_;
+        int y_end = region_y_off_+ region_height_;
+        for (size_t j = region_y_off_; j < y_end; j++) {
+          for (size_t i = region_x_off_; i < x_end; i++) {
+            if (mask.at<uchar>(j, i) != 0) {//if white
+              points_exist = true;
+              edge_cloud->points[j * width + i] = cloud->points[j * width + i];
+            }
+            else {
+              edge_cloud->points[j * width + i] = nan_point;
+            }
+          }
+        }
+      }
+
+      if (points_exist) {
+        cv::Mat mask_image = cv::Mat::zeros(height, width, CV_8UC1);
+        pcl::KdTreeFLANN<pcl::PointXYZ> kdtree;
+        kdtree.setInputCloud(edge_cloud);
+        pcl::PointXYZ zero;
+        std::vector<int> near_indices;
+        std::vector<float> near_distances;
+        kdtree.nearestKSearch(zero, extract_num_, near_indices, near_distances);
+        ROS_INFO("directed num of extract points:%d   num of nearestKSearch points:%d", extract_num_, ((int) near_indices.size()));
+        int ext_num=std::min(extract_num_, ((int) near_indices.size()));
+        for (int idx = 0; idx < ext_num; idx++) {
+          int x = near_indices.at(idx) % width;
+          int y = near_indices.at(idx) / width;
+          mask_image.at<uchar>(y, x) = 255;
+        }
+        cv_bridge::CvImage mask_bridge(point_cloud2_msg->header,
+                                       sensor_msgs::image_encodings::MONO8,
+                                       mask_image);
+        pub_.publish(mask_bridge.toImageMsg());
+      }
     }
-    cv::Mat mask_image = cv::Mat::zeros(height, width, CV_8UC1);
-    pcl::KdTreeFLANN<pcl::PointXYZ> kdtree;
-    kdtree.setInputCloud(edge_cloud);
-    pcl::PointXYZ zero;
-    std::vector<int> near_indices;
-    std::vector<float> near_distances;
-    kdtree.nearestKSearch(zero, extract_num_, near_indices, near_distances);
-    ROS_INFO("directed num of extract points:%d   num of nearestKSearch points:%d", extract_num_, ((int) near_indices.size()));
-    int ext_num=std::min(extract_num_, ((int) near_indices.size()));
-    for(int idx=0; idx< ext_num; idx++){
-      int x=near_indices.at(idx)%width;
-      int y=near_indices.at(idx)/width;
-      mask_image.at<uchar>(y, x)=255;
+    else {
+      ROS_INFO("ERROR: Image and Points have different width and height.");
     }
-    cv_bridge::CvImage mask_bridge(point_cloud2_msg->header,
-                                   sensor_msgs::image_encodings::MONO8,
-                                   mask_image);
-    pub_.publish(mask_bridge.toImageMsg());
   }
 
   void MaskImageToDepthConsideredMaskImage::updateDiagnostic(


### PR DESCRIPTION
* use image_view2 interaction_mode:grabcut_rect
* When use_mask_region, only mask image inside grabcut_rect area is extracted.
