### PR TITLE
[jsk_perception] Add attributeError message to image_publisher.py

### DIFF
--- a/jsk_perception/scripts/image_publisher.py
+++ b/jsk_perception/scripts/image_publisher.py
@@ -31,5 +31,9 @@ while not rospy.is_shutdown():
     except IOError, e:
         rospy.loginfo("cannot read the image at %s" % file_name)
         rospy.loginfo(e.message)
+    except AttributeError, e:
+        rospy.logerr("Did you set properly ~file_name param ?")
+        rospy.loginfo(e.message)
+        exit()
     rate.sleep()
 


### PR DESCRIPTION
Prevent below error message and show error message instead.
```
Traceback (most recent call last):
  File "/home/inagaki/ros/hydro/src/jsk-ros-pkg/jsk_recognition/jsk_perception/scripts/image_publisher.py", line 21, in <module>
    image_message = bridge.cv2_to_imgmsg(image, encoding="bgr8")
  File "/opt/ros/hydro/lib/python2.7/dist-packages/cv_bridge/core.py", line 232, in cv2_to_imgmsg
    img_msg.height = cvim.shape[0]
AttributeError: 'NoneType' object has no attribute 'shape'
```


instead
```
[ERROR] [WallTime: 1429271489.289614] Did you set properly ~file_name param
```