### PR TITLE
add Resize rate feedback

### DIFF
--- a/jsk_pcl_ros/include/jsk_pcl_ros/mask_image_to_depth_considered_mask_image.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/mask_image_to_depth_considered_mask_image.h
@@ -94,6 +94,11 @@ namespace jsk_pcl_ros
     int region_height_;
     int region_x_off_;
     int region_y_off_;
+    double region_width_ratio_;
+    double region_height_ratio_;
+    double region_x_off_ratio_;
+    double region_y_off_ratio_;
+    bool use_region_ratio_;
     bool use_mask_region_;
     bool in_the_order_of_depth_;
 

--- a/jsk_pcl_ros/launch/extract_only_directed_region_of_close_mask_image.launch
+++ b/jsk_pcl_ros/launch/extract_only_directed_region_of_close_mask_image.launch
@@ -13,14 +13,16 @@
   <node pkg="nodelet" type="nodelet" name="multi_resizer"
         args="load jsk_pcl/ResizePointsPublisher multipoints_resize_manager" output="screen">
     <remap from="~input" to="$(arg input_points)" />
+    <remap from="~input/mask" to="$(arg mask_region)" />
     <remap from="~output" to="/multi_resized_points2" />
     <param name="not_use_rgb" value="True" />
   </node>
 
-  <arg name="RESIZE_RATE" default="0.5" />
+  <arg name="RESIZE_RATE" default="1" />
   <node pkg="resized_image_transport" type="image_resizer" name="image_resizer"
         output="screen" >
     <remap from="~input/image" to="$(arg input_image)" />
+    <remap from="~input/mask" to="$(arg mask_region)" />
     <remap from="~output/image" to="~image_rect" />
     <param name="resize_scale_x" value="$(arg RESIZE_RATE)" />
     <param name="resize_scale_y" value="$(arg RESIZE_RATE)" />
@@ -30,11 +32,8 @@
    <remap from="image" to="/image_resizer/image_rect" />
     <remap from="/edge/image" to="/edge_detect/image" />
   </node>
-  <node pkg="image_view2" type="image_view2" name="interactive_view" >
+  <node pkg="image_view" type="image_view" name="interactive_view" >
     <remap from="image" to="/edge_detect/image" />
-    <rosparam>
-      interaction_mode: rectangle
-    </rosparam>
   </node>
 
   <node pkg="jsk_perception" type="mask_image_generator" name="mask_image_generator"
@@ -43,7 +42,7 @@
   </node>
 
   <node pkg="jsk_perception" type="rect_to_mask_image" name="rect_to_mask_image">
-    <remap from="~input" to="/edge_detect/image/screenrectangle" />
+    <remap from="~input" to="/depth/mask/screenrectangle" />
     <remap from="~input/camera_info" to="/image_resizer/camera_info" />
   </node>
 
@@ -56,8 +55,11 @@
     <remap from="~output" to="/depth/mask" />
     <remap from="~input/maskregion" to="$(arg mask_region)" />
   </node>
-  <node pkg="image_view" type="image_view" name="depth_mask_view" >
+  <node pkg="image_view2" type="image_view2" name="depth_mask_view" >
     <remap from="image" to="/depth/mask" />
+    <rosparam>
+      interaction_mode: rectangle
+    </rosparam>
   </node>
 
   <node pkg="jsk_perception" type="sparse_image_encoder" name="sparse_image_encoder"

--- a/jsk_pcl_ros/src/mask_image_to_depth_considered_mask_image_nodelet.cpp
+++ b/jsk_pcl_ros/src/mask_image_to_depth_considered_mask_image_nodelet.cpp
@@ -76,9 +76,13 @@ namespace jsk_pcl_ros
     int tmp_x_off = 0;
     int tmp_y_off = 0;
     bool flag = true;
-    for (size_t j = 0; j < mask.rows; j++) {
-      for (size_t i = 0; i < mask.cols; i++) {
+    int maskwidth = mask.cols;
+    int maskheight = mask.rows;
+    int cnt = 0;
+    for (size_t j = 0; j < maskheight; j++) {
+      for (size_t i = 0; i < maskwidth; i++) {
         if (mask.at<uchar>(j, i) != 0) {
+          cnt++;
           if (flag == true) {
             tmp_x_off = i;
             tmp_y_off = j;
@@ -88,11 +92,13 @@ namespace jsk_pcl_ros
             tmp_width = i-tmp_x_off + 1;
             tmp_height = j-tmp_y_off + 1;
           }}}}
-    ROS_INFO("mask resion callback: width:%d height:%d x_off:%d y_off:%d", tmp_width, tmp_height, tmp_x_off, tmp_y_off);
-    region_width_ = tmp_width;
-    region_height_ = tmp_height;
-    region_x_off_ = tmp_x_off;
-    region_y_off_ = tmp_y_off;
+    ROS_INFO("mask_image_to_depth nodelet : tmp width:%d height:%d x_off:%d y_off:%d", tmp_width, tmp_height, tmp_x_off, tmp_y_off);
+    region_width_ratio_ = ((double) tmp_width) / maskwidth;
+    region_height_ratio_ = ((double) tmp_height) / maskheight;
+    region_x_off_ratio_ = ((double) tmp_x_off) / maskwidth;
+    region_y_off_ratio_ = ((double) tmp_y_off) / maskheight;
+    use_region_ratio_ = true;
+    ROS_INFO("mask_image_to_depth nodelet : next region width_ratio:%f height_ratio:%f x_off_ratio:%f y_off_ratio:%f", region_width_ratio_, region_height_ratio_, region_x_off_ratio_, region_y_off_ratio_);
   }
 
 
@@ -148,6 +154,12 @@ namespace jsk_pcl_ros
         edge_cloud->points.resize(width * height);
         edge_cloud->width = width;
         edge_cloud->height = height;
+        if (use_region_ratio_){
+          region_width_ = width * region_width_ratio_;
+          region_height_ = height * region_height_ratio_;
+          region_x_off_ = width * region_x_off_ratio_;
+          region_y_off_ = height * region_y_off_ratio_;
+        }
         if (use_mask_region_ == false || region_width_ == 0 || region_height_ == 0){
           for (size_t j = 0; j < mask.rows; j++) {
             for (size_t i = 0; i < mask.cols; i++) {

--- a/jsk_pcl_ros/src/mask_image_to_depth_considered_mask_image_nodelet.cpp
+++ b/jsk_pcl_ros/src/mask_image_to_depth_considered_mask_image_nodelet.cpp
@@ -92,13 +92,13 @@ namespace jsk_pcl_ros
             tmp_width = i-tmp_x_off + 1;
             tmp_height = j-tmp_y_off + 1;
           }}}}
-    ROS_INFO("mask_image_to_depth nodelet : tmp width:%d height:%d x_off:%d y_off:%d", tmp_width, tmp_height, tmp_x_off, tmp_y_off);
+    NODELET_INFO("mask_image_to_depth_considered_mask_image_nodelet : tmp width:%d height:%d x_off:%d y_off:%d", tmp_width, tmp_height, tmp_x_off, tmp_y_off);
     region_width_ratio_ = ((double) tmp_width) / maskwidth;
     region_height_ratio_ = ((double) tmp_height) / maskheight;
     region_x_off_ratio_ = ((double) tmp_x_off) / maskwidth;
     region_y_off_ratio_ = ((double) tmp_y_off) / maskheight;
     use_region_ratio_ = true;
-    ROS_INFO("mask_image_to_depth nodelet : next region width_ratio:%f height_ratio:%f x_off_ratio:%f y_off_ratio:%f", region_width_ratio_, region_height_ratio_, region_x_off_ratio_, region_y_off_ratio_);
+    NODELET_INFO("mask_image_to_depth_considered_mask_image_nodelet : next region width_ratio:%f height_ratio:%f x_off_ratio:%f y_off_ratio:%f", region_width_ratio_, region_height_ratio_, region_x_off_ratio_, region_y_off_ratio_);
   }
 
 
@@ -131,8 +131,8 @@ namespace jsk_pcl_ros
      const sensor_msgs::Image::ConstPtr& image_msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
-    if (point_cloud2_msg->width == image_msg->width && point_cloud2_msg->height == image_msg->height){
-      if (in_the_order_of_depth_ == true){
+    if (point_cloud2_msg->width == image_msg->width && point_cloud2_msg->height == image_msg->height) {
+      if (in_the_order_of_depth_ == true) {
         vital_checker_->poke();
         pcl::PointCloud<pcl::PointXYZ>::Ptr
           cloud (new pcl::PointCloud<pcl::PointXYZ>);
@@ -154,13 +154,13 @@ namespace jsk_pcl_ros
         edge_cloud->points.resize(width * height);
         edge_cloud->width = width;
         edge_cloud->height = height;
-        if (use_region_ratio_){
+        if (use_region_ratio_) {
           region_width_ = width * region_width_ratio_;
           region_height_ = height * region_height_ratio_;
           region_x_off_ = width * region_x_off_ratio_;
           region_y_off_ = height * region_y_off_ratio_;
         }
-        if (use_mask_region_ == false || region_width_ == 0 || region_height_ == 0){
+        if (use_mask_region_ == false || region_width_ == 0 || region_height_ == 0) {
           for (size_t j = 0; j < mask.rows; j++) {
             for (size_t i = 0; i < mask.cols; i++) {
               if (mask.at<uchar>(j, i) != 0) {//if white
@@ -185,7 +185,7 @@ namespace jsk_pcl_ros
           int y_end = region_y_off_+ region_height_;
           for (size_t j = region_y_off_; j < y_end; j++) {
             for (size_t i = region_x_off_; i < x_end; i++) {
-              if (i < image_msg->width && j <image_msg->height){
+              if (i < image_msg->width && j <image_msg->height) {
                 if (mask.at<uchar>(j, i) != 0) {//if white
                   points_exist = true;
                   edge_cloud->points[j * width + i] = cloud->points[j * width + i];
@@ -223,7 +223,7 @@ namespace jsk_pcl_ros
         cv::Mat tmp_mask = cv::Mat::zeros(image_msg->height, image_msg->width, CV_8UC1);
         int data_len=image_msg->width * image_msg->height;
         int cnt = 0;
-        if (use_mask_region_ ==false || region_width_ == 0 || region_height_ == 0){
+        if (use_mask_region_ ==false || region_width_ == 0 || region_height_ == 0) {
           for (size_t j = 0; j < mask.rows; j++) {
             for (size_t i = 0; i < mask.cols; i++) {
               if (mask.at<uchar>(j, i) != 0) {//if white

--- a/jsk_pcl_ros/src/resize_points_publisher_nodelet.cpp
+++ b/jsk_pcl_ros/src/resize_points_publisher_nodelet.cpp
@@ -19,6 +19,9 @@
 #include <dynamic_reconfigure/server.h>
 #include <jsk_pcl_ros/ResizePointsPublisherConfig.h>
 
+#include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
+
 namespace jsk_pcl_ros
 {
   class ResizePointsPublisher : public jsk_topic_tools::ConnectionBasedNodelet
@@ -33,6 +36,7 @@ namespace jsk_pcl_ros
     message_filters::Subscriber<PCLIndicesMsg> sub_indices_;
     boost::shared_ptr <dynamic_reconfigure::Server<Config> >  srv_;
     ros::Subscriber sub_;
+    ros::Subscriber resizedmask_sub_;
     boost::shared_ptr<message_filters::Synchronizer<SyncPolicy> >sync_;
     ros::Publisher pub_;
     bool not_use_rgb_;
@@ -48,13 +52,36 @@ namespace jsk_pcl_ros
                      &ResizePointsPublisher::configCallback, this, _1, _2);
       srv_->setCallback (f);
       pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);
-
+      resizedmask_sub_ = pnh_->subscribe("input/mask", 1, &ResizePointsPublisher::resizedmaskCallback, this);
     }
 
     void configCallback(Config &config, uint32_t level){
       boost::mutex::scoped_lock lock(mutex_);
-      step_x_=config.step_x;
-      step_y_=config.step_y;
+      step_x_ = config.step_x;
+      step_y_ = config.step_y;
+    }
+
+    void resizedmaskCallback (const sensor_msgs::Image::ConstPtr& msg){
+      boost::mutex::scoped_lock lock(mutex_);
+      cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy
+        (msg, sensor_msgs::image_encodings::MONO8);
+      cv::Mat mask = cv_ptr->image;
+      int maskwidth = mask.cols;
+      int maskheight = mask.rows;
+      int cnt = 0;
+      for (size_t j = 0; j < maskheight; j++){
+        for (size_t i = 0; i < maskwidth; i++){
+          if (mask.at<uchar>(j, i) != 0){
+            cnt++;
+          }
+        }
+      }
+      int surface_per = ((double) cnt) / (maskwidth * maskheight) * 100;
+      step_x_ = surface_per /10;
+      if (step_x_ < 1) {
+        step_x_ = 1;
+      }
+      step_y_ = step_x_;
     }
 
     void subscribe()

--- a/jsk_pcl_ros/src/resize_points_publisher_nodelet.cpp
+++ b/jsk_pcl_ros/src/resize_points_publisher_nodelet.cpp
@@ -55,13 +55,13 @@ namespace jsk_pcl_ros
       resizedmask_sub_ = pnh_->subscribe("input/mask", 1, &ResizePointsPublisher::resizedmaskCallback, this);
     }
 
-    void configCallback(Config &config, uint32_t level){
+    void configCallback(Config &config, uint32_t level) {
       boost::mutex::scoped_lock lock(mutex_);
       step_x_ = config.step_x;
       step_y_ = config.step_y;
     }
 
-    void resizedmaskCallback (const sensor_msgs::Image::ConstPtr& msg){
+    void resizedmaskCallback (const sensor_msgs::Image::ConstPtr& msg) {
       boost::mutex::scoped_lock lock(mutex_);
       cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy
         (msg, sensor_msgs::image_encodings::MONO8);

--- a/resized_image_transport/include/resized_image_transport/image_resizer_nodelet.h
+++ b/resized_image_transport/include/resized_image_transport/image_resizer_nodelet.h
@@ -5,6 +5,7 @@
 
 #include "resized_image_transport/image_processing_nodelet.h"
 #include "resized_image_transport/ImageResizerConfig.h"
+#include <sensor_msgs/image_encodings.h>
 
 namespace resized_image_transport
 {
@@ -20,9 +21,12 @@ namespace resized_image_transport
     void onInit();
     void initReconfigure();
     void initParams();
+    void mask_region_callback(const sensor_msgs::Image::ConstPtr& msg);
     void config_cb (ImageResizerConfig &config, uint32_t level);
     void process(const sensor_msgs::ImageConstPtr &src_img, const sensor_msgs::CameraInfoConstPtr &src_info,
 		 sensor_msgs::ImagePtr &dst_img, sensor_msgs::CameraInfo &dst_info);
+    ros::Subscriber sub_;
+    int raw_width_, raw_height_;
   };
 }
 #endif

--- a/resized_image_transport/src/image_resizer_nodelet.cpp
+++ b/resized_image_transport/src/image_resizer_nodelet.cpp
@@ -2,7 +2,7 @@
 
 namespace resized_image_transport
 {
-  void ImageResizer::onInit(){
+  void ImageResizer::onInit() {
     raw_width_ = 0;
     raw_height_ = 0;
     initNodeHandle();
@@ -12,33 +12,33 @@ namespace resized_image_transport
     sub_ = pnh.subscribe("input/mask", 1, &ImageResizer::mask_region_callback, this);
   }
 
-  void ImageResizer::initReconfigure(){
+  void ImageResizer::initReconfigure() {
     ReconfigureServer::CallbackType f
       = boost::bind(&ImageResizer::config_cb, this, _1, _2);
     reconfigure_server_.setCallback(f);
   }
 
-  void ImageResizer::initParams(){
+  void ImageResizer::initParams() {
     ImageProcessing::initParams();
     period_ = ros::Duration(1.0);
     std::string interpolation_method;
     pnh.param<std::string>("interpolation", interpolation_method, "LINEAR");
     if(interpolation_method == "NEAREST"){
       interpolation_ = cv::INTER_NEAREST;
-    }else if(interpolation_method == "LINEAR"){
+    }else if(interpolation_method == "LINEAR") {
       interpolation_ = cv::INTER_LINEAR;
-    }else if(interpolation_method == "AREA"){
+    }else if(interpolation_method == "AREA") {
       interpolation_ = cv::INTER_AREA;
-    }else if(interpolation_method == "CUBIC"){
+    }else if(interpolation_method == "CUBIC") {
       interpolation_ = cv::INTER_CUBIC;
-    }else if(interpolation_method == "LANCZOS4"){
+    }else if(interpolation_method == "LANCZOS4") {
       interpolation_ = cv::INTER_LANCZOS4;
     }else{
       ROS_ERROR("unknown interpolation method");
     }
   }
 
-  void ImageResizer::mask_region_callback(const sensor_msgs::Image::ConstPtr& msg){
+  void ImageResizer::mask_region_callback(const sensor_msgs::Image::ConstPtr& msg) {
     boost::mutex::scoped_lock lock(mutex_);
     cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy
       (msg, sensor_msgs::image_encodings::MONO8);
@@ -49,9 +49,9 @@ namespace resized_image_transport
     int maskwidth = mask.cols;
     int maskheight = mask.rows;
     int cnt = 0;
-    for (size_t j = 0; j < maskheight; j++){
-      for (size_t i = 0; i < maskwidth; i++){
-        if (mask.at<uchar>(j, i) != 0){
+    for (size_t j = 0; j < maskheight; j++) {
+      for (size_t i = 0; i < maskwidth; i++) {
+        if (mask.at<uchar>(j, i) != 0) {
           cnt++;
         }
       }
@@ -66,10 +66,10 @@ namespace resized_image_transport
     //raw image wo step de bunkatu pixel dasu
     ox = step_x / 2;
     oy = step_y / 2;
-    for (int i = ox; i < raw_width_; i += step_x){
+    for (int i = ox; i < raw_width_; i += step_x) {
       pixel_x++;
     }
-    for (int i = oy; i < raw_height_; i += step_y){
+    for (int i = oy; i < raw_height_; i += step_y) {
       pixel_y++;
     }
     resize_x_ = ((double) pixel_x) / raw_width_;
@@ -91,10 +91,11 @@ namespace resized_image_transport
   void ImageResizer::process(const sensor_msgs::ImageConstPtr &src_img, const sensor_msgs::CameraInfoConstPtr &src_info,
 			 sensor_msgs::ImagePtr &dst_img, sensor_msgs::CameraInfo &dst_info){
     int image_width, image_height;
-    if(use_camera_info_){
+    if(use_camera_info_) {
       image_width = src_info->width;
       image_height = src_info->height;
-    }else{
+    }
+    else {
       image_width = src_img->width;
       image_height = src_img->height;
     }
@@ -108,7 +109,7 @@ namespace resized_image_transport
     cv_bridge::CvImagePtr cv_img = cv_bridge::toCvCopy(src_img);
 
     cv::Mat tmpmat(height, width, cv_img->image.type());
-    if (raw_width_ == 0){
+    if (raw_width_ == 0) {
       raw_width_ = tmpmat.cols;
       raw_height_ = tmpmat.rows;
     }
@@ -117,7 +118,7 @@ namespace resized_image_transport
     cv_img->image = tmpmat;
 
     dst_img = cv_img->toImageMsg();
-    if(use_camera_info_){
+    if (use_camera_info_) {
       dst_info = *src_info;
       dst_info.height = height;
       dst_info.width = width;


### PR DESCRIPTION
#### add resize rate feedback in extract_only_directed_region_of_close_mask_image.launch
* If you direct region of interest in interactive view, mask image callback is called in 3 node. (mask_image_to_depth_considered_mask_image_nodelet,   resize_points_publisher_nodelet,   image_resizer_nodelet)
* If you select wide region, output image will be coarse.