### PR TITLE
[jsk_pcl_ros]  add apply mask image publisher

### DIFF
--- a/jsk_pcl_ros/cfg/MaskImageToDepthConsideredMaskImage.cfg
+++ b/jsk_pcl_ros/cfg/MaskImageToDepthConsideredMaskImage.cfg
@@ -15,7 +15,7 @@ from math import pi
 
 gen = ParameterGenerator ()
 
-gen.add("extract_num", int_t, 0, "Set the number of extract points", 500, 0, 10000)
+gen.add("extract_num", int_t, 0, "Set the number of extract points", 400, 0, 10000)
 gen.add("use_mask_region", bool_t, 0, "Use interactive mask region definition", True)
 gen.add("in_the_order_of_depth", bool_t, 0, "extract points in the order of depth", True)
 exit (gen.generate (PACKAGE, "jsk_pcl_ros", "MaskImageToDepthConsideredMaskImage"))

--- a/jsk_pcl_ros/include/jsk_pcl_ros/mask_image_to_depth_considered_mask_image.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/mask_image_to_depth_considered_mask_image.h
@@ -89,6 +89,7 @@ namespace jsk_pcl_ros
     message_filters::Subscriber<sensor_msgs::PointCloud2> sub_input_;
     message_filters::Subscriber<sensor_msgs::Image> sub_image_;
     ros::Publisher pub_;
+    ros::Publisher applypub_;
     ros::Subscriber sub_;
     int region_width_;
     int region_height_;

--- a/jsk_pcl_ros/launch/extract_only_directed_region_of_close_mask_image.launch
+++ b/jsk_pcl_ros/launch/extract_only_directed_region_of_close_mask_image.launch
@@ -16,6 +16,8 @@
     <remap from="~input/mask" to="$(arg mask_region)" />
     <remap from="~output" to="/multi_resized_points2" />
     <param name="not_use_rgb" value="True" />
+    <param name="step_x" value="1" />
+    <param name="step_y" value="1" />
   </node>
 
   <arg name="RESIZE_RATE" default="1" />

--- a/jsk_pcl_ros/launch/extract_only_directed_region_of_close_mask_image.launch
+++ b/jsk_pcl_ros/launch/extract_only_directed_region_of_close_mask_image.launch
@@ -53,14 +53,20 @@
     <remap from="~input" to="/multi_resized_points2" />
     <remap from="~input/image" to="/edge_detect/image" />
     <remap from="~output" to="/depth/mask" />
+    <remap from="~applyoutput" to="/depth/mask/apply" />
     <remap from="~input/maskregion" to="$(arg mask_region)" />
   </node>
   <node pkg="image_view2" type="image_view2" name="depth_mask_view" >
     <remap from="image" to="/depth/mask" />
     <rosparam>
       interaction_mode: rectangle
+      region_continuous_publish: false
     </rosparam>
   </node>
+  <node pkg="image_view" type="image_view" name="applied_depth_mask_view" >
+    <remap from="image" to="/depth/mask/apply" />
+  </node>
+
 
   <node pkg="jsk_perception" type="sparse_image_encoder" name="sparse_image_encoder"
         output="screen">
@@ -72,12 +78,4 @@
 
   <include file="$(find jsk_perception)/launch/sparse_image_decoder.launch">
   </include>
-
-  <node pkg="jsk_perception" type="apply_mask_image" name="apply">
-    <remap from="~input" to="/edge_detect/image" />
-    <remap from="~input/mask" to="$(arg mask_region)" />
-  </node>
-  <node pkg="image_view" type="image_view" name="masked_view" >
-    <remap from="image" to="apply/output" />
-  </node>
 </launch>

--- a/jsk_pcl_ros/src/resize_points_publisher_nodelet.cpp
+++ b/jsk_pcl_ros/src/resize_points_publisher_nodelet.cpp
@@ -77,7 +77,8 @@ namespace jsk_pcl_ros
         }
       }
       int surface_per = ((double) cnt) / (maskwidth * maskheight) * 100;
-      step_x_ = surface_per /10;
+      // step_x_ = surface_per /10;
+      step_x_ = sqrt(surface_per);
       if (step_x_ < 1) {
         step_x_ = 1;
       }

--- a/resized_image_transport/src/image_resizer_nodelet.cpp
+++ b/resized_image_transport/src/image_resizer_nodelet.cpp
@@ -57,7 +57,8 @@ namespace resized_image_transport
       }
     }
     int surface_per = ((double) cnt) / (maskwidth * maskheight) * 100;
-    step_x = surface_per /10;
+    // step_x = surface_per /10;
+    step_x = sqrt (surface_per);
     if (step_x < 1) {
       step_x = 1;
     }


### PR DESCRIPTION
##### add apply mask image publisher
Usually, we should use jsk_perception/apply_mask_image.cpp for applying mask image.
But by resize-feedback, cannot use apply_mask_image node.
Instead, publish applymaskimage by mask_image_to_depth_considered_mask_image node.
##### change default parameter of extract num in mask_image_to_depth_considered_mask_image


