### PR TITLE
[jsk_perception] check if pcam.intrinsicMatrix is valid

### DIFF
--- a/jsk_perception/src/point_pose_extractor.cpp
+++ b/jsk_perception/src/point_pose_extractor.cpp
@@ -861,7 +861,9 @@ public:
     // from ros messages to keypoint and pin hole camera model
     features2keypoint (msg->features, sourceimg_keypoints, sourceimg_descriptors);
     pcam.fromCameraInfo(msg->info);
-
+    if ( cv::countNonZero(pcam.intrinsicMatrix()) == 0 ) {
+      ROS_FATAL("intrinsic matrix is zero, your camera info looks invalid");
+    }
     if ( !_initialized ) {
       // make template images from camera info
       initialize();


### PR DESCRIPTION
* check if pcam intrinsicMatrix is valid
intrinsicMatrix of camera_info from usb_cam node (you can exec by rosrun usb_cam usb_cam_node) is invalid.
This resulted in the failure of #873 .
