### PR TITLE
[jsk_pcl_ros] Add NormalEstimationOMP like pcl_ros but it can handle timestamp correctly

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -331,6 +331,8 @@ jsk_pcl_nodelet(src/geometric_consistency_grouping_nodelet.cpp
   "jsk_pcl/GeometricConsistencyGrouping" "geometric_consistency_grouping")
 jsk_pcl_nodelet(src/convex_connected_voxels_nodelet.cpp
   "jsk_pcl/ConvexConnectedVoxels" "convex_connected_voxels")
+jsk_pcl_nodelet(src/normal_estimation_omp_nodelet.cpp
+  "jsk_pcl/NormalEstimationOMP" "normal_estimation_omp")
 
 add_library(jsk_pcl_ros_base SHARED
   src/grid_index.cpp src/grid_map.cpp src/grid_line.cpp src/geo_util.cpp

--- a/jsk_pcl_ros/README.md
+++ b/jsk_pcl_ros/README.md
@@ -59,6 +59,31 @@ time end
 Represent range of time.
 
 ## nodelets
+### jsk\_pcl/NormalEstimationOMP
+This nodelet is almost same to `pcl/NormalEstimationOMP` of `pcl_ros` package,
+but it can handle timestamp correctly.
+
+#### Subscribing Topic
+* `~input` (`sensor_msgs/PointCloud2`)
+
+  Input pointcloud.
+
+#### Publishing Topic
+* `~output` (`sensor_msgs/PointCloud2`)
+
+  Output pointcloud, point type is `pcl::Normal`.
+* `~output_with_xyz` (`sensor_msgs/PointCloud2`)
+
+  Output pointcloud, point type is `pcl::XYZRGBNormal`.
+
+#### Parameters
+* `~k_search`
+
+  K search parameter for normal estimation
+* `~radius_search`
+
+  Radius search parameter for normal estimation
+
 ### jsk\_pcl/PointCloudLocalization
 ![](images/pointcloud_localization.png)
 

--- a/jsk_pcl_ros/include/jsk_pcl_ros/normal_estimation_omp.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/normal_estimation_omp.h
@@ -1,0 +1,77 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+
+#ifndef JSK_PCL_ROS_NORMAL_ESTIMATION_OMP_H_
+#define JSK_PCL_ROS_NORMAL_ESTIMATION_OMP_H_
+
+#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <pcl_ros/FeatureConfig.h>
+#include <dynamic_reconfigure/server.h>
+#include <pcl_conversions/pcl_conversions.h>
+namespace jsk_pcl_ros
+{
+  class NormalEstimationOMP: public jsk_topic_tools::DiagnosticNodelet
+  {
+  public:
+    typedef boost::shared_ptr<NormalEstimationOMP> Ptr;
+    typedef pcl_ros::FeatureConfig Config;
+    NormalEstimationOMP(): DiagnosticNodelet("NormalEstimationOMP") {}
+    
+  protected:
+
+    virtual void onInit();
+    virtual void subscribe();
+    virtual void unsubscribe();
+    virtual void estimate(
+      const sensor_msgs::PointCloud2::ConstPtr& cloud_msg);
+    virtual void configCallback(
+      Config& config, uint32_t level);
+    
+    boost::mutex mutex_;
+    ros::Publisher pub_;
+    ros::Publisher pub_with_xyz_;
+    ros::Subscriber sub_;
+    boost::shared_ptr <dynamic_reconfigure::Server<Config> > srv_;
+    int k_;
+    double search_radius_;
+    
+  private:
+    
+  };
+}
+
+#endif

--- a/jsk_pcl_ros/jsk_pcl_nodelets.xml
+++ b/jsk_pcl_ros/jsk_pcl_nodelets.xml
@@ -488,6 +488,11 @@
       jsk_pcl_ros::ColorizeMapRandomForest
     </description>
   </class>
+  <class name="jsk_pcl/NormalEstimationOMP" type="jsk_pcl_ros::NormalEstimationOMP"
+         base_class_type="nodelet::Nodelet">
+    <description>
+    </description>
+  </class>
   <!-- <class name="jsk_pcl/OrganizePointCloud" type="jsk_pcl_ros::OrganizePointCloud" -->
   <!--        base_class_type="nodelet::Nodelet"> -->
   <!--   <description> -->

--- a/jsk_pcl_ros/src/normal_estimation_omp_nodelet.cpp
+++ b/jsk_pcl_ros/src/normal_estimation_omp_nodelet.cpp
@@ -1,0 +1,119 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#define BOOST_PARAMETER_MAX_ARITY 7
+#include "jsk_pcl_ros/normal_estimation_omp.h"
+#include <pcl/point_types.h>
+#include <pcl/features/normal_3d_omp.h>
+
+namespace jsk_pcl_ros
+{
+  void NormalEstimationOMP::onInit()
+  {
+    pcl::console::setVerbosityLevel(pcl::console::L_ERROR);
+    DiagnosticNodelet::onInit();
+    srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
+    typename dynamic_reconfigure::Server<Config>::CallbackType f =
+      boost::bind (&NormalEstimationOMP::configCallback, this, _1, _2);
+    srv_->setCallback (f);
+    pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);
+    pub_with_xyz_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output_with_xyz", 1);
+  }
+
+  void NormalEstimationOMP::subscribe()
+  {
+    sub_ = pnh_->subscribe("input", 1, &NormalEstimationOMP::estimate, this);
+  }
+
+  void NormalEstimationOMP::unsubscribe()
+  {
+    sub_.shutdown();
+  }
+
+  void NormalEstimationOMP::configCallback(
+    Config& config, uint32_t level)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+    k_ = config.k_search;
+    search_radius_ = config.radius_search;
+  }
+
+  void NormalEstimationOMP::estimate(
+    const sensor_msgs::PointCloud2::ConstPtr& cloud_msg)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+    
+    pcl::PointCloud<pcl::PointXYZRGB>::Ptr
+      cloud(new pcl::PointCloud<pcl::PointXYZRGB>);
+    pcl::fromROSMsg(*cloud_msg, *cloud);
+    pcl::NormalEstimationOMP<pcl::PointXYZRGB, pcl::Normal> impl;
+    impl.setInputCloud(cloud);
+    pcl::search::KdTree<pcl::PointXYZRGB>::Ptr
+      tree (new pcl::search::KdTree<pcl::PointXYZRGB> ());
+    impl.setSearchMethod (tree);
+    impl.setKSearch(k_);
+    impl.setRadiusSearch(search_radius_);
+    pcl::PointCloud<pcl::Normal>::Ptr
+      normal_cloud(new pcl::PointCloud<pcl::Normal>);
+    impl.compute(*normal_cloud);
+
+    sensor_msgs::PointCloud2 ros_normal_cloud;
+    pcl::toROSMsg(*normal_cloud, ros_normal_cloud);
+    ros_normal_cloud.header = cloud_msg->header;
+    pub_.publish(ros_normal_cloud);
+
+    pcl::PointCloud<pcl::PointXYZRGBNormal>::Ptr
+      normal_xyz(new pcl::PointCloud<pcl::PointXYZRGBNormal>);
+    normal_xyz->points.resize(cloud->points.size());
+    for (size_t i = 0; i < normal_xyz->points.size(); i++) {
+      pcl::PointXYZRGBNormal p;
+      p.x = cloud->points[i].x;
+      p.y = cloud->points[i].y;
+      p.z = cloud->points[i].z;
+      p.normal_x = normal_cloud->points[i].normal_x;
+      p.normal_y = normal_cloud->points[i].normal_y;
+      p.normal_z = normal_cloud->points[i].normal_z;
+      normal_xyz->points[i] = p;
+    }
+
+    sensor_msgs::PointCloud2 ros_normal_xyz_cloud;
+    pcl::toROSMsg(*normal_xyz, ros_normal_xyz_cloud);
+    ros_normal_xyz_cloud.header = cloud_msg->header;
+    pub_with_xyz_.publish(ros_normal_xyz_cloud);
+  }
+}
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS (jsk_pcl_ros::NormalEstimationOMP, nodelet::Nodelet);


### PR DESCRIPTION
`jsk_pcl/NormalEstimatinOMP` is almost same as `pcl/NormalEstimationOMP` of `pcl_ros` but it DOES handle correct timestamp.

I will send it to upstream after they merge several serious pull request about timestamp of pcl_conversions.