### PR TITLE
[jsk_pcl_ros/RegionGrowingMultiplePlaneSegmentation] Fix computation of normal to decide order of vertices

### DIFF
--- a/jsk_pcl_ros/include/jsk_pcl_ros/geo_util.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/geo_util.h
@@ -234,6 +234,7 @@ namespace jsk_pcl_ros
     virtual void clearTriangleDecompositionCache() {
       cached_triangles_.clear();
     }
+    virtual Eigen::Vector3f getNormalFromVertices();
     virtual bool isTriangle();
     template <class PointT>
     typename pcl::PointCloud<PointT>::Ptr samplePoints(double grid_size)

--- a/jsk_pcl_ros/src/geo_util.cpp
+++ b/jsk_pcl_ros/src/geo_util.cpp
@@ -804,6 +804,17 @@ namespace jsk_pcl_ros
     return ret;
   }
 
+  Eigen::Vector3f Polygon::getNormalFromVertices()
+  {
+    if (vertices_.size() >= 3) {
+      return (vertices_[1] - vertices_[0]).cross(vertices_[2] - vertices_[0]).normalized();
+    }
+    else {
+      JSK_ROS_ERROR("the number of vertices is not enough");
+      return Eigen::Vector3f(0, 0, 0);
+    }
+  }
+
   size_t Polygon::previousIndex(size_t i)
   {
     if (i == 0) {

--- a/jsk_pcl_ros/src/region_growing_multiple_plane_segmentation_nodelet.cpp
+++ b/jsk_pcl_ros/src/region_growing_multiple_plane_segmentation_nodelet.cpp
@@ -178,7 +178,7 @@ namespace jsk_pcl_ros
           Eigen::Vector3f coefficient_normal(plane_coefficients->values[0],
                                              plane_coefficients->values[1],
                                              plane_coefficients->values[2]);
-          if (convex->getNormal().dot(coefficient_normal) < 0) {
+          if (convex->getNormalFromVertices().dot(coefficient_normal) < 0) {
             convex = boost::make_shared<ConvexPolygon>(convex->flipConvex());
           }
           geometry_msgs::PolygonStamped polygon;


### PR DESCRIPTION
Fix computation of normal to decide order of vertices by comparing normals from vertices and coefficients

Add getNormalFromVertices method to polygon