### PR TITLE
[jsk_perception] fix output image encoding in kmeans and gaussian_blur

### DIFF
--- a/jsk_perception/src/gaussian_blur.cpp
+++ b/jsk_perception/src/gaussian_blur.cpp
@@ -81,9 +81,6 @@ namespace jsk_perception
     cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(
       image_msg, image_msg->encoding);
     cv::Mat image = cv_ptr->image;
-    if (image_msg->encoding == sensor_msgs::image_encodings::RGB8) {
-      cv::cvtColor(image, image, CV_RGB2BGR);
-    }
     cv::Mat applied_image;
     if (kernel_size_ % 2 == 1) {
       cv::GaussianBlur(image, applied_image, cv::Size(kernel_size_, kernel_size_), sigma_x_, sigma_y_);

--- a/jsk_perception/src/kmeans.cpp
+++ b/jsk_perception/src/kmeans.cpp
@@ -80,9 +80,6 @@ namespace jsk_perception
     cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(
       image_msg, image_msg->encoding);
     cv::Mat image = cv_ptr->image;
-    if (isRGB(image_msg->encoding)) {
-      cv::cvtColor(image, image, CV_RGB2BGR);
-    }
 
     cv::Mat reshaped_img = image.reshape(1, image.cols * image.rows);
     cv::Mat reshaped_img32f;


### PR DESCRIPTION
出力画像のエンコードが，
BGAが正解のところを入力画像のものを使うようになっていたので，
修正しました．

@wkentaro 

修正前
![screenshot_from_2015-06-14 12 12 45](https://cloud.githubusercontent.com/assets/6636600/8146949/c49ca830-1290-11e5-9110-59541473826f.png)
修正後
![screenshot_from_2015-06-14 12 20 36](https://cloud.githubusercontent.com/assets/6636600/8146950/c6358aea-1290-11e5-9b0e-da8d3d8b6f1a.png)
