### PR TITLE
fix c++ version mismatch problem with boost

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -132,11 +132,6 @@ macro(jsk_pcl_util_nodelet _nodelet_cpp _nodelet_class _single_nodelet_exec_name
     jsk_pcl_util_nodelet_sources jsk_pcl_util_nodelet_executables)
 endmacro(jsk_pcl_util_nodelet _nodelet_cpp _nodelet_class _single_nodelet_exec_name)
 
-if ($ENV{TRAVIS_JOB_ID})
-  add_definitions("-O2 -g -std=c++0x")
-else ($ENV{TRAVIS_JOB_ID})
-  add_definitions("-O0 -std=c++0x")
-endif ($ENV{TRAVIS_JOB_ID})
 
 # pcl_ros::Filter based class is not working...
 # https://github.com/ros-perception/perception_pcl/issues/9

--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -132,6 +132,11 @@ macro(jsk_pcl_util_nodelet _nodelet_cpp _nodelet_class _single_nodelet_exec_name
     jsk_pcl_util_nodelet_sources jsk_pcl_util_nodelet_executables)
 endmacro(jsk_pcl_util_nodelet _nodelet_cpp _nodelet_class _single_nodelet_exec_name)
 
+if ($ENV{TRAVIS_JOB_ID})
+  add_definitions("-O2 -g")
+else ($ENV{TRAVIS_JOB_ID})
+  add_definitions("-O0")
+endif ($ENV{TRAVIS_JOB_ID})
 
 # pcl_ros::Filter based class is not working...
 # https://github.com/ros-perception/perception_pcl/issues/9


### PR DESCRIPTION
Fix for issue: particle_filter_tracker dies after startup when running in Ubuntu 14.04 indigo #984

Tested working on Ubuntu 14.04 indigo, openni2_launch, with Asus Xtion Pro.