### PR TITLE
[jsk_perception] add nodelet ThreaholdBinarizer and CentroidPublisher

### DIFF
--- a/jsk_perception/CMakeLists.txt
+++ b/jsk_perception/CMakeLists.txt
@@ -104,6 +104,8 @@ jsk_perception_nodelet(src/rgb_decomposer.cpp "jsk_perception/RGBDecomposer" "rg
 jsk_perception_nodelet(src/hsv_decomposer.cpp "jsk_perception/HSVDecomposer" "hsv_decomposer")
 jsk_perception_nodelet(src/lab_decomposer.cpp "jsk_perception/LabDecomposer" "lab_decomposer")
 jsk_perception_nodelet(src/ycc_decomposer.cpp "jsk_perception/YCCDecomposer" "ycc_decomposer")
+jsk_perception_nodelet(src/threshold_binarizer.cpp "jsk_perception/ThresholdBinarizer" "threshold_binarizer")
+jsk_perception_nodelet(src/centroid_publisher.cpp "jsk_perception/CentroidPublisher" "centroid_publisher")
 jsk_perception_nodelet(src/contour_finder.cpp "jsk_perception/ContourFinder" "contour_finder")
 jsk_perception_nodelet(src/snake_segmentation.cpp "jsk_perception/SnakeSegmentation" "snake_segmentation")
 jsk_perception_nodelet(src/colorize_labels.cpp "jsk_perception/ColorizeLabels" "colorize_labels")

--- a/jsk_perception/include/jsk_perception/centroid_publisher.h
+++ b/jsk_perception/include/jsk_perception/centroid_publisher.h
@@ -1,0 +1,63 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+
+#ifndef JSK_PERCEPTION_HSV_DECOMPOSER_H_
+#define JSK_PERCEPTION_HSV_DECOMPOSER_H_
+
+#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <sensor_msgs/Image.h>
+#include <geometry_msgs/PointStamped.h>
+
+namespace jsk_perception
+{
+  class CentroidPublisher: public jsk_topic_tools::DiagnosticNodelet
+  {
+  public:
+    CentroidPublisher();
+    ~CentroidPublisher();
+  protected:
+    virtual void onInit();
+    virtual void subscribe();
+    virtual void unsubscribe();
+    virtual void input_cb(const sensor_msgs::Image::ConstPtr& image_msg);
+    ros::Subscriber sub_;
+    ros::Publisher pub_;
+  private:
+    
+  };
+}
+
+#endif

--- a/jsk_perception/include/jsk_perception/threshold_binarizer.h
+++ b/jsk_perception/include/jsk_perception/threshold_binarizer.h
@@ -54,7 +54,7 @@ namespace jsk_perception
     virtual void binarize(const sensor_msgs::Image::ConstPtr& image_msg);
     ros::Subscriber sub_;
     ros::Publisher pub_;
-    int thre_lower, thre_upper;
+    int thre_lower_, thre_upper_;
   private:
     
   };

--- a/jsk_perception/include/jsk_perception/threshold_binarizer.h
+++ b/jsk_perception/include/jsk_perception/threshold_binarizer.h
@@ -1,0 +1,63 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+
+#ifndef JSK_PERCEPTION_HSV_DECOMPOSER_H_
+#define JSK_PERCEPTION_HSV_DECOMPOSER_H_
+
+#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <sensor_msgs/Image.h>
+
+namespace jsk_perception
+{
+  class ThresholdBinarizer: public jsk_topic_tools::DiagnosticNodelet
+  {
+  public:
+    ThresholdBinarizer();
+    ~ThresholdBinarizer();
+  protected:
+    virtual void onInit();
+    virtual void subscribe();
+    virtual void unsubscribe();
+    virtual void binarize(const sensor_msgs::Image::ConstPtr& image_msg);
+    ros::Subscriber sub_;
+    ros::Publisher pub_;
+    int thre_lower, thre_upper;
+  private:
+    
+  };
+}
+
+#endif

--- a/jsk_perception/jsk_perception_nodelets.xml
+++ b/jsk_perception/jsk_perception_nodelets.xml
@@ -111,6 +111,16 @@
     <description>
     </description>
   </class>
+  <class name="jsk_perception/ThresholdBinarizer" type="jsk_perception::ThresholdBinarizer"
+         base_class_type="nodelet::Nodelet">
+    <description>
+    </description>
+  </class>
+  <class name="jsk_perception/CentroidPublisher" type="jsk_perception::CentroidPublisher"
+         base_class_type="nodelet::Nodelet">
+    <description>
+    </description>
+  </class>
   <class name="jsk_perception/LabDecomposer" type="jsk_perception::LabDecomposer"
          base_class_type="nodelet::Nodelet">
   </class>

--- a/jsk_perception/launch/threshold_centroid_test.launch
+++ b/jsk_perception/launch/threshold_centroid_test.launch
@@ -1,0 +1,27 @@
+<launch>
+  <arg name="INPUT_IMAGE" default="/camera/rgb/image_raw"/>
+  <arg name="INPUT_CAMERA_INFO" default="/camera/rgb/camera_info"/>
+  <node pkg="nodelet" type="nodelet" name="threshold_centroid_manager"
+        args="manager" />
+  <node pkg="nodelet" type="nodelet"
+        name="hsv_decomposer"
+        args="load jsk_perception/HSVDecomposer threshold_centroid_manager">
+    <remap from="~input" to="$(arg INPUT_IMAGE)" />
+  </node>
+  <node pkg="nodelet" type="nodelet"
+        name="threshold_binarizer"
+        args="load jsk_perception/ThresholdBinarizer threshold_centroid_manager">
+    <remap from="~input" to="/hsv_decomposer/output/hue"/>
+  </node>
+  <node pkg="nodelet" type="nodelet"
+        name="centroid_publisher"
+        args="load jsk_perception/CentroidPublisher threshold_centroid_manager">
+    <remap from="~input" to="/threshold_binarizer/output"/>
+  </node>
+  <node pkg="nodelet" type="nodelet"
+        name="project_image_point"
+        args="load jsk_perception/ProjectImagePoint threshold_centroid_manager">
+    <remap from="~input" to="/centroid_publisher/centroid" />
+    <remap from="~input/camera_info" to="/camera/rgb/camera_info" />
+  </node>
+</launch>

--- a/jsk_perception/src/centroid_publisher.cpp
+++ b/jsk_perception/src/centroid_publisher.cpp
@@ -1,0 +1,88 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+
+#include "jsk_perception/centroid_publisher.h"
+#include <sensor_msgs/image_encodings.h>
+#include <cv_bridge/cv_bridge.h>
+#include <opencv2/opencv.hpp>
+
+namespace jsk_perception
+{
+  CentroidPublisher::CentroidPublisher(): DiagnosticNodelet("CentroidPublisher")
+  {
+  }
+
+  CentroidPublisher::~CentroidPublisher()
+  {
+  }
+
+  void CentroidPublisher::onInit()
+  {
+    DiagnosticNodelet::onInit();
+    pub_ = advertise<geometry_msgs::PointStamped>(*pnh_, "centroid", 1);
+  }
+
+  void CentroidPublisher::subscribe()
+  {
+    sub_ = pnh_->subscribe("input", 1, &CentroidPublisher::input_cb, this);
+  }
+
+  void CentroidPublisher::unsubscribe()
+  {
+    sub_.shutdown();
+  }
+
+  void CentroidPublisher::input_cb(
+    const sensor_msgs::Image::ConstPtr& image_msg)
+  {
+    double cx, cy;
+    cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(image_msg, image_msg->encoding);
+    cv::Mat image = cv_ptr->image;
+    cv::Moments moments = cv::moments(image, 1);
+    cx = moments.m10/moments.m00;
+    cy = moments.m01/moments.m00;
+
+    geometry_msgs::PointStamped point;
+    point.header = image_msg->header;
+    point.point.x = cx;
+    point.point.y = cy;
+    point.point.z = 0;
+    pub_.publish(point);
+  }
+}
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS (jsk_perception::CentroidPublisher, nodelet::Nodelet);

--- a/jsk_perception/src/threshold_binarizer.cpp
+++ b/jsk_perception/src/threshold_binarizer.cpp
@@ -43,11 +43,11 @@ namespace jsk_perception
 {
   ThresholdBinarizer::ThresholdBinarizer(): DiagnosticNodelet("ThresholdBinarizer")
   {
-    thre_lower = 0;
-    thre_upper = 255;
+    thre_lower_ = 0;
+    thre_upper_ = 255;
     cv::namedWindow ("TrackbarWindow", CV_WINDOW_AUTOSIZE);
-    cv::createTrackbar ("TrackbarLower", "TrackbarWindow", &thre_lower, 256, 0);
-    cv::createTrackbar ("TrackbarUpper", "TrackbarWindow", &thre_upper, 256, 0);
+    cv::createTrackbar ("TrackbarLower", "TrackbarWindow", &thre_lower_, 256, 0);
+    cv::createTrackbar ("TrackbarUpper", "TrackbarWindow", &thre_upper_, 256, 0);
     cv::startWindowThread();
   }
 
@@ -80,8 +80,8 @@ namespace jsk_perception
     cv::Mat binary_image_lower, binary_image_upper, binary_image;
 
     cv::waitKey(10);
-    cv::threshold(image, binary_image_lower, thre_lower-1, 255, cv::THRESH_BINARY);
-    cv::threshold(image, binary_image_upper, thre_upper-1, 255, cv::THRESH_BINARY_INV);
+    cv::threshold(image, binary_image_lower, thre_lower_-1, 255, cv::THRESH_BINARY);
+    cv::threshold(image, binary_image_upper, thre_upper_-1, 255, cv::THRESH_BINARY_INV);
     cv:bitwise_and(binary_image_lower, binary_image_upper, binary_image);
     pub_.publish(cv_bridge::CvImage(image_msg->header,
                                     sensor_msgs::image_encodings::MONO8,

--- a/jsk_perception/src/threshold_binarizer.cpp
+++ b/jsk_perception/src/threshold_binarizer.cpp
@@ -1,0 +1,93 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+
+#include "jsk_perception/threshold_binarizer.h"
+#include <sensor_msgs/image_encodings.h>
+#include <cv_bridge/cv_bridge.h>
+#include <opencv2/opencv.hpp>
+
+namespace jsk_perception
+{
+  ThresholdBinarizer::ThresholdBinarizer(): DiagnosticNodelet("ThresholdBinarizer")
+  {
+    thre_lower = 0;
+    thre_upper = 255;
+    cv::namedWindow ("TrackbarWindow", CV_WINDOW_AUTOSIZE);
+    cv::createTrackbar ("TrackbarLower", "TrackbarWindow", &thre_lower, 256, 0);
+    cv::createTrackbar ("TrackbarUpper", "TrackbarWindow", &thre_upper, 256, 0);
+    cv::startWindowThread();
+  }
+
+  ThresholdBinarizer::~ThresholdBinarizer()
+  {
+    cv::destroyWindow("TrackbarWindow");
+  }
+
+  void ThresholdBinarizer::onInit()
+  {
+    DiagnosticNodelet::onInit();
+    pub_ = advertise<sensor_msgs::Image>(*pnh_, "output", 1);
+  }
+
+  void ThresholdBinarizer::subscribe()
+  {
+    sub_ = pnh_->subscribe("input", 1, &ThresholdBinarizer::binarize, this);
+  }
+
+  void ThresholdBinarizer::unsubscribe()
+  {
+    sub_.shutdown();
+  }
+
+  void ThresholdBinarizer::binarize(
+    const sensor_msgs::Image::ConstPtr& image_msg)
+  {
+    cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(image_msg, image_msg->encoding);
+    cv::Mat image = cv_ptr->image;
+    cv::Mat binary_image_lower, binary_image_upper, binary_image;
+
+    cv::waitKey(10);
+    cv::threshold(image, binary_image_lower, thre_lower-1, 255, cv::THRESH_BINARY);
+    cv::threshold(image, binary_image_upper, thre_upper-1, 255, cv::THRESH_BINARY_INV);
+    cv:bitwise_and(binary_image_lower, binary_image_upper, binary_image);
+    pub_.publish(cv_bridge::CvImage(image_msg->header,
+                                    sensor_msgs::image_encodings::MONO8,
+                                    binary_image).toImageMsg());
+  }
+}
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS (jsk_perception::ThresholdBinarizer, nodelet::Nodelet);


### PR DESCRIPTION
数週間前に練習と思って書いたものですが，
もしよければマージお願いします．

ThreaholdBinarizer
グレースケール画像を入力として，最小値，最大値を指定して二値化した画像を出力します．
最小値，最大値はトラックバーから変えられます．

CentroidPublisher
二値画像を入力として重心位置を出力します．

簡単な例として，
HSVDecomposer -> ThreaholdBinarizer -> CentroidPublisher -> ProjectImagePoint
で，Rvizのカメラ画像に指定した色の領域の位置を表示しています．
https://drive.google.com/a/jsk.imi.i.u-tokyo.ac.jp/file/d/0B5qanGnXorOuM09ZYXptdEhHQ1E/view?usp=sharing
