### PR TITLE
[imagesift] modify mask region when mask region has no region

### DIFF
--- a/imagesift/src/imagesift.cpp
+++ b/imagesift/src/imagesift.cpp
@@ -124,6 +124,10 @@ namespace imagesift
             if (mask_ptr) {
                 cv::Mat mask = cv_bridge::toCvShare(mask_ptr, mask_ptr->encoding)->image;
                 region = jsk_perception::boundingRectOfMaskImage(mask);
+                ROS_DEBUG ("region x:%d y:%d width:%d height:%d", region.x, region.y, region.width, region.height);
+                if (region.width == 0 || region.height ==0) {
+                    region = cv::Rect(0, 0, imagemsg.width, imagemsg.height);
+                }
                 image = image(region);
             }
             else {


### PR DESCRIPTION
When width or height of the input mask image is 0, imagesift process die.
To avoid this, when width or height is 0, use all region of image instead of mask image region.