### PR TITLE
[jsk_pcl_ros] Add simple belief filter

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -340,6 +340,8 @@ jsk_pcl_nodelet(src/convex_connected_voxels_nodelet.cpp
   "jsk_pcl/ConvexConnectedVoxels" "convex_connected_voxels")
 jsk_pcl_nodelet(src/normal_estimation_omp_nodelet.cpp
   "jsk_pcl/NormalEstimationOMP" "normal_estimation_omp")
+jsk_pcl_nodelet(src/belief_cloud_filter_nodelet.cpp
+  "jsk_pcl/BeliefCloudFilter" "belief_cloud_filter")
 if (PCL_GPU_KINFU_LARGE_SCALE_FOUND)
   jsk_pcl_nodelet(src/kinfu_nodelet.cpp
     "jsk_pcl/Kinfu" "kinfu")

--- a/jsk_pcl_ros/include/jsk_pcl_ros/belief_cloud_filter.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/belief_cloud_filter.h
@@ -1,0 +1,92 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+
+#ifndef JSK_PCL_ROS_BELIEF_CLOUD_FILTER_H_
+#define JSK_PCL_ROS_BELIEF_CLOUD_FILTER_H_
+
+#include <jsk_topic_tools/diagnostic_nodelet.h>
+
+#include <sensor_msgs/PointCloud2.h>
+#include <sensor_msgs/Image.h>
+#include <sensor_msgs/CameraInfo.h>
+
+namespace jsk_pcl_ros
+{
+  namespace belief_cloud_initial_model
+  {
+    const std::string none = "none";
+    const std::string uniform = "uniform";
+    const std::string gaussian = "gaussian";
+    const std::string pcd = "pcd";
+    const std::string topic = "topic";
+  }
+
+  class BeliefCloudFilter: public jsk_topic_tools::DiagnosticNodelet
+  {
+  public:
+    BeliefCloudFilter(): DiagnosticNodelet("BeliefCloudFilter") { }
+  protected:
+    virtual void onInit();
+    virtual void subscribe();
+    virtual void unsubscribe();
+    virtual bool setupInitialModel();
+    virtual void filter(const sensor_msgs::PointCloud2::ConstPtr& cloud);
+    inline double gaussian(double x, double mean, double variance)
+    {
+      return 1 / sqrt(2 * M_PI * variance * variance) * exp(- (x - mean) * (x - mean) / (2.0 * variance * variance));
+    }
+
+    std::string initial_model_;
+    double belief_cloud_dx_;
+    double belief_cloud_dy_;
+    double belief_cloud_dz_;
+    double belief_cloud_size_x_;
+    double belief_cloud_size_y_;
+    double belief_cloud_size_z_;
+    
+    // for gaussian model
+    std::vector<double> gaussian_means_;
+    std::vector<double> gaussian_covariances_;
+    double cutoff_threshold_;
+    ros::Publisher pub_;
+    ros::Publisher pub_initial_model_;
+    ros::Subscriber sub_;
+  private:
+    
+  };
+}
+
+#endif

--- a/jsk_pcl_ros/jsk_pcl_nodelets.xml
+++ b/jsk_pcl_ros/jsk_pcl_nodelets.xml
@@ -498,6 +498,11 @@
     <description>
     </description>
   </class>
+  <class name="jsk_pcl/BeliefCloudFilter" type="jsk_pcl_ros::BeliefCloudFilter"
+         base_class_type="nodelet::Nodelet">
+    <description>
+    </description>
+  </class>
   <class name="jsk_pcl/Kinfu" type="jsk_pcl_ros::Kinfu"
          base_class_type="nodelet::Nodelet">
     <description>

--- a/jsk_pcl_ros/sample/belief_cloud_filter_sample.launch
+++ b/jsk_pcl_ros/sample/belief_cloud_filter_sample.launch
@@ -1,0 +1,33 @@
+<launch>
+  <node pkg="image_view2" type="image_view2" name="image_view2">
+    <remap from="image" to="/multisense/left/image_rect_color" />
+  </node>
+  <node pkg="jsk_perception" type="rect_to_mask_image" name="mask_image">
+    <remap from="~input" to="/multisense/left/image_rect_color/screenrectangle" />
+    <remap from="~input/camera_info" to="/multisense/left/camera_info" />
+  </node>
+  <node pkg="jsk_pcl_ros" type="mask_image_filter" name="mask_image_filter">
+    <remap from="~input" to="/multisense/resize_1_4/points" />
+    <remap from="~input/mask" to="mask_image/output" />
+    <remap from="~input/camera_info" to="/multisense/left/camera_info" />
+  </node>
+  <node pkg="nodelet" type="nodelet" name="mask_image_filter_points"
+        args="standalone pcl/ExtractIndices">
+    <remap from="~input" to="/multisense/resize_1_4/points" />
+    <remap from="~indices" to="mask_image_filter/output" />
+  </node>
+  <node pkg="jsk_pcl_ros" type="tf_transform_cloud" name="ground_cloud">
+    <remap from="~input" to="mask_image_filter_points/output" />
+    <rosparam>
+      target_frame_id: ground
+    </rosparam>
+  </node>
+  <node pkg="jsk_pcl_ros" type="belief_cloud_filter" name="belief_cloud_filter">
+    <remap from="~input" to="ground_cloud/output" />
+    <rosparam>
+      initial_model: gaussian
+      gaussian_means: [2, 0, 1.2]
+      gaussian_covariances: [1.0, 1.0, 0.2]
+    </rosparam>
+  </node>
+</launch>

--- a/jsk_pcl_ros/src/belief_cloud_filter_nodelet.cpp
+++ b/jsk_pcl_ros/src/belief_cloud_filter_nodelet.cpp
@@ -1,0 +1,148 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#define BOOST_PARAMETER_MAX_ARITY 7
+#include "jsk_pcl_ros/belief_cloud_filter.h"
+#include <jsk_topic_tools/rosparam_utils.h>
+#include <jsk_topic_tools/log_utils.h>
+#include "jsk_pcl_ros/pcl_conversion_util.h"
+
+namespace jsk_pcl_ros
+{
+
+  void BeliefCloudFilter::onInit()
+  {
+    DiagnosticNodelet::onInit();
+    pnh_->param("initial_model", initial_model_, std::string("none"));
+    if (!setupInitialModel()) {
+      JSK_NODELET_FATAL("Failed to setup initial model");
+      return;
+    }
+    pnh_->param("belief_cloud_dx", belief_cloud_dx_, 0.05);
+    pnh_->param("belief_cloud_dy", belief_cloud_dy_, 0.05);
+    pnh_->param("belief_cloud_dz", belief_cloud_dz_, 0.05);
+    pnh_->param("belief_cloud_size_x", belief_cloud_size_x_, 5.0);
+    pnh_->param("belief_cloud_size_y", belief_cloud_size_y_, 5.0);
+    pnh_->param("belief_cloud_size_z", belief_cloud_size_z_, 5.0);
+    pnh_->param("cutoff_threshold", cutoff_threshold_, 0.1);
+    pub_initial_model_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "initial_model", 1);
+    pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);
+  }
+  
+  void BeliefCloudFilter::subscribe()
+  {
+    sub_ = pnh_->subscribe("input", 1, &BeliefCloudFilter::filter, this);
+  }
+
+  void BeliefCloudFilter::unsubscribe()
+  {
+    sub_.shutdown();
+  }
+
+  bool BeliefCloudFilter::setupInitialModel()
+  {
+    if (initial_model_ == belief_cloud_initial_model::gaussian) {
+      if (jsk_topic_tools::readVectorParameter(*pnh_, "gaussian_means", gaussian_means_) &&
+          jsk_topic_tools::readVectorParameter(*pnh_, "gaussian_covariances", gaussian_covariances_) &&
+          gaussian_means_.size() == 3 &&
+          gaussian_covariances_.size() == 3) {
+        return true;
+      }
+      else {
+        JSK_NODELET_FATAL("~gaussian_means and ~gaussian_covariances should be provided");
+        return false;
+      }
+    }
+    else {
+      JSK_NODELET_FATAL("%s is not supported as initial model", initial_model_.c_str());
+      return false;
+    }
+  }
+
+  void BeliefCloudFilter::filter(const sensor_msgs::PointCloud2::ConstPtr& cloud_msg)
+  {
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
+    pcl::fromROSMsg(*cloud_msg, *cloud);
+    pcl::PointCloud<pcl::PointXYZI>::Ptr belief_cloud(new pcl::PointCloud<pcl::PointXYZI>);
+    for (size_t i = 0; i < cloud->points.size(); i++) {
+      pcl::PointXYZ p = cloud->points[i];
+      if (isnan(p.x) || isnan(p.y) || isnan(p.z)) {
+        continue;
+      }
+      double prob = gaussian(p.x, gaussian_means_[0], gaussian_covariances_[0]) * 
+        gaussian(p.y, gaussian_means_[1], gaussian_covariances_[1]) * 
+        gaussian(p.z, gaussian_means_[2], gaussian_covariances_[2]);
+      if (prob > cutoff_threshold_) {
+        pcl::PointXYZI b;
+        b.x = p.x;
+        b.y = p.y;
+        b.z = p.z;
+        b.intensity = prob;
+        belief_cloud->points.push_back(b);
+      }
+    }
+    sensor_msgs::PointCloud2 ros_belief_cloud;
+    pcl::toROSMsg(*belief_cloud, ros_belief_cloud);
+    ros_belief_cloud.header = cloud_msg->header;
+    pub_.publish(ros_belief_cloud);
+    
+    pcl::PointCloud<pcl::PointXYZI>::Ptr belief_density_cloud(new pcl::PointCloud<pcl::PointXYZI>);
+    for (double x = - belief_cloud_size_x_; x <= belief_cloud_size_x_; x += belief_cloud_dx_) {
+      for (double y = - belief_cloud_size_y_; y <= belief_cloud_size_y_; y += belief_cloud_dy_) {
+        for (double z = - belief_cloud_size_z_; z <= belief_cloud_size_z_; z += belief_cloud_dz_) {
+          double prob = gaussian(x, gaussian_means_[0], gaussian_covariances_[0]) * 
+            gaussian(y, gaussian_means_[1], gaussian_covariances_[1]) * 
+            gaussian(z, gaussian_means_[2], gaussian_covariances_[2]);
+          if (prob > cutoff_threshold_) {
+            pcl::PointXYZI b;
+            b.x = x;
+            b.y = y;
+            b.z = z;
+            b.intensity = prob;
+            belief_density_cloud->points.push_back(b);
+          }
+        }
+      }
+    }
+    sensor_msgs::PointCloud2 ros_belief_density_cloud;
+    pcl::toROSMsg(*belief_density_cloud, ros_belief_density_cloud);
+    ros_belief_density_cloud.header = cloud_msg->header;
+    pub_initial_model_.publish(ros_belief_density_cloud);
+  }
+
+}
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS (jsk_pcl_ros::BeliefCloudFilter, nodelet::Nodelet);


### PR DESCRIPTION
Do not merge yet.

BeliefCloudFilter is a filter pointcloud in voxel space based on Bayesian rules.

* Initial belief distribution (3-Dimensional gaussian)
![screenshot_from_2015-07-20 20 43 00](https://cloud.githubusercontent.com/assets/40454/8776091/746140c8-2f29-11e5-849a-d53f4253ad67.png)
![screenshot_from_2015-07-20 20 43 16](https://cloud.githubusercontent.com/assets/40454/8776096/833c4e58-2f29-11e5-9894-6da13f4ff1b1.png)

* Add observation

white cloud is a pointcloud computed from 2-D ROI (left top)
![screenshot_from_2015-07-20 20 45 28](https://cloud.githubusercontent.com/assets/40454/8776102/8df3f9a4-2f29-11e5-9be8-8cab802b09c6.png)
![screenshot_from_2015-07-20 21 53 19](https://cloud.githubusercontent.com/assets/40454/8776128/c14c71d2-2f29-11e5-94fa-368c613b3a19.png)



Integrate it in occupancy grid.
![screenshot_from_2015-07-20 20 47 31](https://cloud.githubusercontent.com/assets/40454/8776112/9cedc674-2f29-11e5-9a70-7094d2c072a5.png)


