### PR TITLE
machine tag should defined in somewhere else, not here

### DIFF
--- a/jsk_pcl_ros/launch/pointcloud_screenpoint.launch
+++ b/jsk_pcl_ros/launch/pointcloud_screenpoint.launch
@@ -1,5 +1,4 @@
 <launch>
-  <machine name="localhost" address="localhost"/>
   <arg name="cloud_machine" default="localhost"
        doc="point cloud processor machine" />
   <arg name="display_machine" default="localhost"


### PR DESCRIPTION
machine tag should defined in uppper launch file, for example https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_pr2_robot/jsk_pr2_startup/pr2.launch#L24