### PR TITLE
[jsk_pcl_ros/PoseWithCovarianceStampedtoGussianPointCloud] Add new

### DIFF
--- a/jsk_pcl_ros/README.md
+++ b/jsk_pcl_ros/README.md
@@ -1993,9 +1993,15 @@ Pointcloud is computed within a region of 3 sigma.
 * `~cut_plane` (default: `xy`)
 
   You can choose a plane to compute gaussian distribution from `xy`, `yz` or `zx`.
-* `~resolution` (default: `0.01`)
+* `~sampling_num` (default: `10`)
 
-  Sampling distance between each poiint in pointcloud.
+  The number of sampling for each axis. The number of points will square of `~sampling_num`.
+* `~normalize_method` (default: `normalize_area`)
+* `~normalize_value` (default: `1.0`)
+
+  You can choose `normalize_area` or `normalize_height` to normalize gaussian distribution.
+  If you choo `normalize_area`, area of gaussian distribution will be `~normalize_value`.
+  If you choo `normalize_height`, the maximum height of gaussian distribution will be `~normalize_value`.
 
 ### jsk\_pcl/ColorizeHeight2DMapping
 ![](images/colorize_height_2d_mapping.png)

--- a/jsk_pcl_ros/cfg/PoseWithCovarianceStampedToGaussianPointCloud.cfg
+++ b/jsk_pcl_ros/cfg/PoseWithCovarianceStampedToGaussianPointCloud.cfg
@@ -15,6 +15,10 @@ from math import pi
 
 gen = ParameterGenerator ()
 
+normalize_enum = gen.enum([gen.const("normalize_area", str_t, "normalize_area", "normalize_area"),
+                           gen.const("normalize_height", str_t, "normalize_height", "normalize_height")],
+                          "normalize")
+
 plane_enum = gen.enum([gen.const("xy", str_t, "xy", "xy"),
                        gen.const("flipped_xy", str_t, "flipped_xy", "flipped_xy"),
                        gen.const("yz", str_t, "yz", "yz"),
@@ -22,6 +26,8 @@ plane_enum = gen.enum([gen.const("xy", str_t, "xy", "xy"),
                        gen.const("zx", str_t, "zx", "zx"),
                        gen.const("flipped_zx", str_t, "flipped_zx", "flipped_zx")],
                       "plane")
+gen.add("normalize_method", str_t, 0, "", "normalize_area", edit_method=normalize_enum)
+gen.add("normalize_value", double_t, 0, "", 1.0, 0.001, 10.0)
 gen.add("cut_plane", str_t, 0, "", "xy", edit_method=plane_enum)
-gen.add("resolution", double_t, 0, "", 0.01, 0.01, 0.1)
+gen.add("sampling_num", int_t, 0, "", 100, 10, 1000)
 exit (gen.generate (PACKAGE, "jsk_pcl_ros", "PoseWithCovarianceStampedToGaussianPointCloud"))

--- a/jsk_pcl_ros/include/jsk_pcl_ros/pose_with_covariance_stamped_to_gaussian_pointcloud.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/pose_with_covariance_stamped_to_gaussian_pointcloud.h
@@ -65,7 +65,9 @@ namespace jsk_pcl_ros
     ros::Subscriber sub_;
     std::string cut_plane_;
     double threshold_;
-    double resolution_;
+    std::string normalize_method_;
+    double normalize_value_;
+    int sampling_num_;
     boost::shared_ptr<dynamic_reconfigure::Server<Config> > srv_;
   };
 }


### PR DESCRIPTION
normalize method: normalize_area and normalize_height

When you want to visualize smaller covariance, the maximum height of normal distribution will be higher
and you cannot get good visualization.

`normalize_height` is introduced to solve that situation, the height of maximum value of normal distribution will be normalized to a fixed value.