### PR TITLE
Revert "[jsk_perception] Add rosdoc.yaml to overwrite default file_pa…

### DIFF
--- a/jsk_perception/README.md
+++ b/jsk_perception/README.md
@@ -1,7 +1,3 @@
-<!-- please do not remove this, this is very important for rosdoc_lite -->
-\mainpage
-<!-- please do not remove this, this is very important for rosdoc_lite -->
-
 # jsk_perception
 
 ## nodes and nodelets

--- a/jsk_perception/mainpage.dox
+++ b/jsk_perception/mainpage.dox
@@ -1,0 +1,26 @@
+/**
+\mainpage
+\htmlinclude manifest.html
+
+\b jsk_perception is ... 
+
+<!-- 
+Provide an overview of your package.
+-->
+
+
+\section codeapi Code API
+
+<!--
+Provide links to specific auto-generated API documentation within your
+package that is of particular interest to a reader. Doxygen will
+document pretty much every part of your code, so do your best here to
+point the reader to the actual API.
+
+If your codebase is fairly large or has different sets of APIs, you
+should use the doxygen 'group' tag to keep these APIs together. For
+example, the roscpp documentation has 'libros' group.
+-->
+
+
+*/

--- a/jsk_perception/rosdoc.yaml
+++ b/jsk_perception/rosdoc.yaml
@@ -1,3 +1,0 @@
-- builder: doxygen
-  # See http://wiki.ros.org/Doxygen for default file_patterns
-  file_patterns: '*.c *.cpp *h *.cc *.hh *.py *.dox *.md'


### PR DESCRIPTION
Reverts jsk-ros-pkg/jsk_recognition#1097

jenkins uses doxygen 1.7.6  and it does not support md file as main page http://docs.ros.org/indigo/api/jsk_perception/html/
```
warning: ignoring unsupported tag `USE_MDFILE_AS_MAINPAGE =' at line 882, file /tmp/tmpPhHXob
```