### PR TITLE
[jsk_recognition_utils] Depends on visualization_msgs

### DIFF
--- a/jsk_recognition_utils/CMakeLists.txt
+++ b/jsk_recognition_utils/CMakeLists.txt
@@ -16,12 +16,13 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   geometry_msgs
   jsk_topic_tools
+  visualization_msgs
 )
 
 catkin_package(
  INCLUDE_DIRS include
  LIBRARIES jsk_recognition_utils
- CATKIN_DEPENDS jsk_recognition_msgs pcl_ros
+ CATKIN_DEPENDS jsk_recognition_msgs pcl_ros visualization_msgs
 )
 
 find_package(OpenCV REQUIRED core imgproc)
@@ -39,12 +40,12 @@ link_libraries(${catkin_LIBRARIES} ${pcl_ros_LIBRARIES} ${OpenCV_LIBRARIES}  yam
 
 add_library(jsk_recognition_utils SHARED
   src/grid_index.cpp
-  src/grid_map.cpp 
-  src/grid_line.cpp 
+  src/grid_map.cpp
+  src/grid_line.cpp
   src/geo_util.cpp
   src/random_util.cpp
   src/pcl_ros_util.cpp
-  src/pcl_conversion_util.cpp 
+  src/pcl_conversion_util.cpp
   src/pcl_util.cpp
   src/tf_listener_singleton.cpp
   src/pcl/ear_clipping_patched.cpp

--- a/jsk_recognition_utils/package.xml
+++ b/jsk_recognition_utils/package.xml
@@ -21,6 +21,7 @@
   <build_depend>jsk_topic_tools</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>yaml-cpp</build_depend>
+  <build_depend>visualization_msgs</build_depend>
   <run_depend>jsk_recognition_msgs</run_depend>
   <run_depend>pcl_ros</run_depend>
   <run_depend>pcl_msgs</run_depend>
@@ -34,7 +35,7 @@
   <run_depend>jsk_topic_tools</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>yaml-cpp</run_depend>
-
+  <run_depend>visualization_msgs</run_depend>
   <export>
   </export>
 </package>


### PR DESCRIPTION
to solve build error
http://jenkins.ros.org/view/HbinP32/job/ros-hydro-jsk-recognition-utils_binarydeb_precise_i386/5/console

```
[ 16%] Building CXX object CMakeFiles/jsk_recognition_utils.dir/src/grid_map.cpp.o
/usr/lib/ccache/c++   -Djsk_recognition_utils_EXPORTS -DROS_PACKAGE_NAME=\"jsk_recognition_utils\" -DROSCONSOLE_BACKEND_LOG4CXX -DUSE_OLD_YAML -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -DNDEBUG  -fPIC -I/opt/ros/hydro/include -I/opt/ros/hydro/include/opencv -I/usr/include/eigen3 -I/usr/include/pcl-1.7 -I/usr/include/ni -I/usr/include/vtk-5.8 -I/usr/include/qhull -I/tmp/buildd/ros-hydro-jsk-recognition-utils-0.3.2-0precise-20150905-0817/include    -o CMakeFiles/jsk_recognition_utils.dir/src/grid_map.cpp.o -c /tmp/buildd/ros-hydro-jsk-recognition-utils-0.3.2-0precise-20150905-0817/src/grid_map.cpp
In file included from /tmp/buildd/ros-hydro-jsk-recognition-utils-0.3.2-0precise-20150905-0817/include/jsk_recognition_utils/grid_map.h:48:0,
                 from /tmp/buildd/ros-hydro-jsk-recognition-utils-0.3.2-0precise-20150905-0817/src/grid_map.cpp:36:
/tmp/buildd/ros-hydro-jsk-recognition-utils-0.3.2-0precise-20150905-0817/include/jsk_recognition_utils/geo_util.h:63:39: fatal error: visualization_msgs/Marker.h: No such file or directory
compilation terminated.
make[4]: *** [CMakeFiles/jsk_recognition_utils.dir/src/grid_map.cpp.o] Error 1
make[4]: Leaving directory `/tmp/buildd/ros-hydro-jsk-recognition-utils-0.3.2-0precise-20150905-0817/obj-i686-linux-gnu'
make[3]: *** [CMakeFiles/jsk_recognition_utils.dir/all] Error 2
make[3]: Leaving directory `/tmp/buildd/ros-hydro-jsk-recognition-utils-0.3.2-0precise-20150905-0817/obj-i686-linux-gnu'
make[2]: *** [all] Error 2
make[2]: Leaving directory `/tmp/buildd/ros-hydro-jsk-recognition-utils-0.3.2-0precise-20150905-0817/obj-i686-linux-gnu'
```