### PR TITLE
[jsk_pcl_ros] Do not compile build_check.cpp in normal compilation time, just in run_tests

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -441,8 +441,10 @@ execute_process(
   )
 
 configure_file(src/build_check.cpp.in build_check.cpp)
-add_executable(build_check build_check.cpp)
+add_executable(build_check EXCLUDE_FROM_ALL build_check.cpp)
 target_link_libraries(build_check jsk_pcl_ros jsk_pcl_ros_base jsk_pcl_ros_util jsk_pcl_ros_moveit)
+add_dependencies(run_tests build_check)
+
 generate_messages(DEPENDENCIES
   ${PCL_MSGS} sensor_msgs geometry_msgs jsk_recognition_msgs jsk_footstep_msgs)
 


### PR DESCRIPTION
Little bit a tricky, do not compile build_check.cpp in normal compilation because ros buildfarm looks fail
to build it (memory starvation?).

http://jenkins.ros.org/view/IbinS64/job/ros-indigo-jsk-pcl-ros_binarydeb_saucy_amd64/69/console
```
[ 56%] Building CXX object CMakeFiles/build_check.dir/build_check.cpp.o
/usr/lib/ccache/c++   -DROSCONSOLE_BACKEND_LOG4CXX -DROS_PACKAGE_NAME=\"jsk_pcl_ros\" -DUSE_OLD_YAML -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -D_FORTIFY_SOURCE=2   -Wno-deprecated -fopenmp -O2 -g -DNDEBUG -I/tmp/buildd/ros-indigo-jsk-pcl-ros-0.3.5-0saucy-20150910-0811/obj-x86_64-linux-gnu/devel/include -I/usr/include/vtk-5.8 -I/usr/include/opencv -I/tmp/buildd/ros-indigo-jsk-pcl-ros-0.3.5-0saucy-20150910-0811/include -I/opt/ros/indigo/include -I/usr/include/eigen3 -I/usr/include/pcl-1.7 -I/usr/include/ni -I/usr/include/qhull    -O2 -g -o CMakeFiles/build_check.dir/build_check.cpp.o -c /tmp/buildd/ros-indigo-jsk-pcl-ros-0.3.5-0saucy-20150910-0811/obj-x86_64-linux-gnu/build_check.cpp
Build timed out (after 120 minutes). Marking the build as aborted.
```