### PR TITLE
[jsk_pcl_ros] publish PoseWithCovarianceStamped msg which z-axis is a…

### DIFF
--- a/jsk_pcl_ros/include/jsk_pcl_ros/normal_estimation_omp.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/normal_estimation_omp.h
@@ -42,6 +42,7 @@
 #include <pcl_ros/FeatureConfig.h>
 #include <dynamic_reconfigure/server.h>
 #include <pcl_conversions/pcl_conversions.h>
+#include <geometry_msgs/PoseWithCovarianceStamped.h>
 namespace jsk_pcl_ros
 {
   class NormalEstimationOMP: public jsk_topic_tools::DiagnosticNodelet
@@ -64,6 +65,7 @@ namespace jsk_pcl_ros
     boost::mutex mutex_;
     ros::Publisher pub_;
     ros::Publisher pub_with_xyz_;
+    ros::Publisher pub_pose_with_covariance_stamped_;
     ros::Subscriber sub_;
     std::string sensor_frame_;
     boost::shared_ptr <dynamic_reconfigure::Server<Config> > srv_;


### PR DESCRIPTION
…ligned with an average normal vector

z軸が法線の向きになっているPoseStampedが欲しかったので追加してみました．
壁に手をつくような状況を想定しています．

位置：入力点群の平均の場所
回転：入力点群の法線の平均がz軸となるような回転

（PoseStampedWithCovarianceというmsgがあったので，ついでに分散も入れてみました）