### PR TITLE
Set min max area

### DIFF
--- a/doc/jsk_pcl_ros/nodes/region_growing_multiple_plane_segmentation.md
+++ b/doc/jsk_pcl_ros/nodes/region_growing_multiple_plane_segmentation.md
@@ -43,6 +43,12 @@ and evaluation function of connectivity if based on the following equation:
 * `~min_size` (Integer, default: `100`)
 
    The minimum number of the points of each plane.
+* `~min_area` (Double, default: `0.1`)
+
+   The minimum area of the convex areas.
+* `~max_area` (Double, default: `100`)
+
+   The max area of the convex areas.
 * `~cluster_tolerance` (Double, default: `0.1`)
 
    The spatial tolerance for new cluster candidates.

--- a/jsk_pcl_ros/cfg/RegionGrowingMultiplePlaneSegmentation.cfg
+++ b/jsk_pcl_ros/cfg/RegionGrowingMultiplePlaneSegmentation.cfg
@@ -16,6 +16,8 @@ from math import pi
 gen = ParameterGenerator ()
 gen.add("max_size", int_t, 0, "the max number of the points of each cluster", 25000, 0, 50000)
 gen.add("min_size", int_t, 0, "the minimum number of the points of each cluster", 100, 0, 1000)
+gen.add("max_area", double_t, 0, "the max area of the convex areas", 100, 0, 100)
+gen.add("min_area", double_t, 0, "the minimum area of the convex areas", 0.1, 0, 1)
 gen.add("angular_threshold", double_t, 0, "angular threshold of normal",
         0.04, 0, pi)
 gen.add("distance_threshold", double_t, 0, "distance threshold of normal",

--- a/jsk_pcl_ros/include/jsk_pcl_ros/region_growing_multiple_plane_segmentation.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/region_growing_multiple_plane_segmentation.h
@@ -145,6 +145,8 @@ namespace jsk_pcl_ros
     double max_curvature_;
     int min_size_;
     int max_size_;
+    double min_area_;
+    double max_area_;
     double cluster_tolerance_;
     double ransac_refine_outlier_distance_threshold_;
     int ransac_refine_max_iterations_;

--- a/jsk_pcl_ros/src/region_growing_multiple_plane_segmentation_nodelet.cpp
+++ b/jsk_pcl_ros/src/region_growing_multiple_plane_segmentation_nodelet.cpp
@@ -92,6 +92,8 @@ namespace jsk_pcl_ros
     max_curvature_ = config.max_curvature;
     min_size_ = config.min_size;
     max_size_ = config.max_size;
+    min_area_ = config.min_area;
+    max_area_ = config.max_area;
     cluster_tolerance_ = config.cluster_tolerance;
     ransac_refine_outlier_distance_threshold_
       = config.ransac_refine_outlier_distance_threshold;
@@ -187,6 +189,9 @@ namespace jsk_pcl_ros
           = convexFromCoefficientsAndInliers<pcl::PointXYZRGB>(
             cloud, plane_inliers, plane_coefficients);
         if (convex) {
+          if (min_area_ > convex->area() || convex->area() > max_area_) {
+            continue;
+          }
           {
             // check direction consistency of coefficients and convex
             Eigen::Vector3f coefficient_normal(plane_coefficients->values[0],


### PR DESCRIPTION
region growing multiplane segmentationの中でconvexと判定される面積にmin-maxの制限を書けられるようにしました．

これまでのプログラムに影響が内容にdefaultのmax_areaは100[m^2]と大きめにしました．

ご確認よろしくお願いします，