### PR TITLE
[jsk_recognition_utils] Handle canvas to get safely plot image

### DIFF
--- a/jsk_recognition_utils/python/jsk_recognition_utils/visualize.py
+++ b/jsk_recognition_utils/python/jsk_recognition_utils/visualize.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import math
-from StringIO import StringIO
 
 import cv2
 import matplotlib.pyplot as plt
@@ -33,9 +32,11 @@ def get_tile_image(imgs, tile_shape=None):
         plt.axis('off')
         plt.imshow(img_rgb)
 
-    f = StringIO()
-    plt.savefig(f, facecolor=(.9, .9, .9))
-    out_rgb = np.array(PIL.Image.open(f))
+    canvas = plt.get_current_fig_manager().canvas
+    canvas.draw()
+    pil_img = PIL.Image.fromstring('RGB',
+        canvas.get_width_height(), canvas.tostring_rgb())
+    out_rgb = np.array(pil_img)
     out_bgr = cv2.cvtColor(out_rgb, cv2.COLOR_RGB2BGR)
     plt.close()
     return out_bgr


### PR DESCRIPTION
The error outputs is:

```
[ERROR] [WallTime: 1444865314.827458] bad callback: <bound method Subscriber.callback of <message_filters.Subscriber instance at 0x7fb424165fc8>>
Traceback (most recent call last):
  File "/home/wkentaro/ros/indigo_parent/install/lib/python2.7/dist-packages/rospy/topics.py", line 720, in _invoke_callback
    cb(msg)
  File "/home/wkentaro/ros/indigo_parent/install/lib/python2.7/dist-packages/message_filters/__init__.py", line 74, in callback
    self.signalMessage(msg)
  File "/home/wkentaro/ros/indigo_parent/install/lib/python2.7/dist-packages/message_filters/__init__.py", line 56, in signalMessage
    cb(*(msg + args))
  File "/home/wkentaro/ros/indigo_parent/install/lib/python2.7/dist-packages/message_filters/__init__.py", line 225, in add
    self.signalMessage(*msgs)
  File "/home/wkentaro/ros/indigo_parent/install/lib/python2.7/dist-packages/message_filters/__init__.py", line 56, in signalMessage
    cb(*(msg + args))
  File "/home/wkentaro/ros/indigo/src/jsk-ros-pkg/jsk_recognition/jsk_perception/scripts/label_image_decomposer.py", line 70, in _apply_tile
    tile_img = get_tile_image(imgs)
  File "/home/wkentaro/ros/indigo/src/jsk-ros-pkg/jsk_recognition/jsk_recognition_utils/python/jsk_recognition_utils/visualize.py", line 38, in get_tile_image
    out_rgb = np.array(PIL.Image.open(f))
  File "/usr/lib/python2.7/dist-packages/PIL/Image.py", line 2028, in open
    raise IOError("cannot identify image file")
IOError: cannot identify image file
```