### PR TITLE
[jsk_pcl_ros]commit for prevventing rounding error

### DIFF
--- a/jsk_pcl_ros/src/viewpoint_sampler.cpp
+++ b/jsk_pcl_ros/src/viewpoint_sampler.cpp
@@ -62,10 +62,10 @@ namespace jsk_pcl_ros
   void ViewpointSampler::next()
   {
     angle_ += angle_step_;
-    if (angle_ > angle_max_) {
+    if (angle_ > angle_max_ * 1.001) { // 1.001 for prevent rounding error
       angle_ = angle_min_;
       radius_ += radius_step_;
-      if (radius_ > radius_max_) {
+      if (radius_ > radius_max_ * 1.001) { // 1.001 for prevent rounding error
         radius_ = radius_min_;
         ++index_;
       }


### PR DESCRIPTION
```
In [2]: 1.6-1.2 > 0.4
Out[2]: True
In [4]: 2.0-1.2 > 0.8
Out[4]: False
```
みたいな感じで，doubleの比較で意図と違う動作になっていて，それでposeにnanが入っていたので，
1.001倍を加えました．
（もっと良い方法がある気もしますが，)普通に使う分には1.001倍の影響がないと思います

fyi @rkoyama1623 