### PR TITLE
[jsk_recognition_utils] Test tf::Transformer::lookupTransformation

### DIFF
--- a/jsk_recognition_utils/CMakeLists.txt
+++ b/jsk_recognition_utils/CMakeLists.txt
@@ -62,8 +62,9 @@ add_library(jsk_recognition_utils SHARED
   src/geo/cylinder.cpp
   src/geo/grid_plane.cpp
   )
+add_executable(echo_tf_lookup_transform test/echo_tf_lookup_transform.cpp)
 
-install(TARGETS jsk_recognition_utils
+install(TARGETS jsk_recognition_utils echo_tf_lookup_transform
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})

--- a/jsk_recognition_utils/test/echo_tf_lookup_transform.cpp
+++ b/jsk_recognition_utils/test/echo_tf_lookup_transform.cpp
@@ -1,0 +1,53 @@
+#include <iostream>
+#include <ros/ros.h>
+#include <tf/transform_listener.h>
+
+
+void printTF(tf::StampedTransform& transform) {
+  std::cout << ">>>>>>>>>>>>>>>>>>>>>> printTF >>>>>>>>>>>>>>>>>>>>>>>>" << std::endl;
+  std::cout << "frame_id: " << transform.frame_id_ << std::endl;
+  std::cout << "child_frame_id: " << transform.child_frame_id_ << std::endl;
+  std::cout << "position_x: " << transform.getOrigin().getX() << std::endl;
+  std::cout << "position_y: " << transform.getOrigin().getY() << std::endl;
+  std::cout << "position_z: " << transform.getOrigin().getZ() << std::endl;
+  std::cout << "rotation_x: " << transform.getRotation().getX() << std::endl;
+  std::cout << "rotation_y: " << transform.getRotation().getY() << std::endl;
+  std::cout << "rotation_z: " << transform.getRotation().getZ() << std::endl;
+  std::cout << "rotation_w: " << transform.getRotation().getW() << std::endl;
+  std::cout << "<<<<<<<<<<<<<<<<<<<<<< printTF <<<<<<<<<<<<<<<<<<<<<<<<" << std::endl;
+}
+
+
+int main(int argc, char* argv[]) {
+  if (argc < 3) {
+    std::cout << "Usage: simple_lookup_transform source_frame target_frame" << std::endl;
+    return 1;
+  }
+
+  ros::init(argc, argv, "simple_lookup_transform");
+
+  boost::mutex mutex;
+  tf::TransformListener* tf_listener;
+
+  mutex.lock();
+  tf_listener = new tf::TransformListener(ros::Duration(30.0));
+  mutex.unlock();
+
+  std::string source_frame(argv[1]);
+  std::string target_frame(argv[2]);
+
+  tf_listener->waitForTransform(target_frame, source_frame, ros::Time(), ros::Duration(1.0));
+
+  tf::StampedTransform transform;
+  printf("lookupTransform(target_frame=\"%s\", source_frame=\"%s\"): \n",
+         target_frame.c_str(), source_frame.c_str());
+  tf_listener->lookupTransform(
+    /*target_frame=*/target_frame,
+    /*source_frame=*/source_frame,
+    /*time=*/ros::Time(),
+    /*transform=*/transform);
+  printTF(transform);
+
+  ros::spinOnce();
+  return 0;
+}

--- a/jsk_recognition_utils/test/test_tf_lookup_transform.rviz
+++ b/jsk_recognition_utils/test/test_tf_lookup_transform.rviz
@@ -1,0 +1,129 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+      Splitter Ratio: 0.5
+    Tree Height: 745
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.588679
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.03
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        base:
+          Value: true
+        head:
+          Value: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        base:
+          head:
+            {}
+      Update Interval: 0
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: base
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Topic: /initialpose
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 2.74491
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.06
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0.0553164
+        Y: 0.566958
+        Z: 0.546232
+      Name: Current View
+      Near Clip Distance: 0.01
+      Pitch: 0.210398
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 0.125406
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1026
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000013c00000378fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006400fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000002800000378000000dd00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f00000378fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000002800000378000000b000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000006900000003efc0100000002fb0000000800540069006d0065010000000000000690000002f600fffffffb0000000800540069006d00650100000000000004500000000000000000000004390000037800000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1680
+  X: 0
+  Y: 24

--- a/jsk_recognition_utils/test/test_tf_lookup_transform.test
+++ b/jsk_recognition_utils/test/test_tf_lookup_transform.test
@@ -1,0 +1,11 @@
+<launch>
+
+  <node name="tf_publisher"
+        pkg="tf" type="static_transform_publisher"
+        args="0 0 1 0 0 0 base head 10" />
+
+  <node name="rviz"
+        pkg="rviz" type="rviz"
+        args="-d $(find jsk_recognition_utils)/test/test_tf_lookup_transform.rviz" />
+
+</launch>


### PR DESCRIPTION
the output of 
```
roslaunch jsk_recognition_utils test_tf_lookup_transform.test
rosrun jsk_recognition_utils echo_tf_lookup_transform base head
```
is below.
I was surprised by this result because
* z is minus
* frame_id is same target_id not source_frame (I expected `source_frame -> target_frame` is correspond to `frame_id -> child_frame_id`)

```
lookupTransform(target_frame="head", source_frame="base"):
>>>>>>>>>>>>>>>>>>>>>> printTF >>>>>>>>>>>>>>>>>>>>>>>>
frame_id: head
child_frame_id: base
position_x: 0
position_y: 0
position_z: -1
rotation_x: 0
rotation_y: 0
rotation_z: 0
rotation_w: 1
<<<<<<<<<<<<<<<<<<<<<< printTF <<<<<<<<<<<<<<<<<<<<<<<<
```

![image](https://cloud.githubusercontent.com/assets/4310419/10671678/ef3533e4-7926-11e5-8d01-8439bdfbdbd2.png)

cc: @garaemon @aginika @YuOhara 
