### PR TITLE
[jsk_pcl_ros] fix syntax error of build_check_helper.py

### DIFF
--- a/jsk_pcl_ros/scripts/build_check_helper.py
+++ b/jsk_pcl_ros/scripts/build_check_helper.py
@@ -19,7 +19,7 @@ with open(sys.argv[1]) as f:
                               "jsk_pcl_ros::Kinfu",
                               "jsk_pcl_ros::ResizePointsPublisher",
                               "jsk_pcl_ros::OrganizedEdgeDetector",
-                              "jsk_pcl_ros::OctomapServerContact"]:
+                              "jsk_pcl_ros::OctomapServerContact",
                               "jsk_pcl_ros::CollisionDetector"]:
             print "%s instance_%d;" % (class_name, counter)
             counter = counter + 1


### PR DESCRIPTION
Fix the bug in change of https://github.com/jsk-ros-pkg/jsk_recognition/pull/1297.
See https://github.com/jsk-ros-pkg/jsk_recognition/commit/0083f42ffa7ca03e2ad48719af0960d96c1e6e03#commitcomment-14398582 .