### PR TITLE
Add suffix for manager name to enable multiple hsi_color_filter.launch

### DIFF
--- a/jsk_pcl_ros/launch/hsi_color_filter.launch
+++ b/jsk_pcl_ros/launch/hsi_color_filter.launch
@@ -21,7 +21,7 @@
   <arg name="i_min" default="0" />
 
   <arg name="create_manager" default="true" />
-  <arg name="manager" default="hsi_filter_manager" />
+  <arg name="manager" default="hsi_filter_manager$(arg FILTER_NAME_SUFFIX)" />
 
   <group ns="$(arg DEFAULT_NAMESPACE)">
     <node if="$(arg create_manager)"


### PR DESCRIPTION
Add suffix for manager name to enable multiple hsi_color_filter.launch.
Previously, manager name conflict occurred.
This is originally derived from https://github.com/jsk-enshu/robot-programming/pull/68.