### PR TITLE
[jsk_perception] Fix supported encodings of split_fore_background.py

### DIFF
--- a/doc/jsk_perception/nodes/split_fore_background.rst
+++ b/doc/jsk_perception/nodes/split_fore_background.rst
@@ -16,7 +16,7 @@ Subscribing Topic
 
   Raw image.
 
-* ``~input/depth`` (``sensor_msgs/Image``, encoding: ``16UC1``)
+* ``~input/depth`` (``sensor_msgs/Image``, encoding: ``16UC1`` or ``32FC1``)
 
   Depth image.
 

--- a/jsk_perception/node_scripts/split_fore_background.py
+++ b/jsk_perception/node_scripts/split_fore_background.py
@@ -36,7 +36,8 @@ class SplitForeBackground(ConnectionBasedTransport):
 
     def _apply(self, img_msg, depth_msg):
         # validation
-        if depth_msg.encoding == '16UC1':
+        supported_encodings = {'16UC1', '32FC1'}
+        if depth_msg.encoding not in supported_encodings:
             jsk_logwarn('Unsupported depth image encoding: {0}'
                         .format(depth_msg.encoding))
         if not (img_msg.height == depth_msg.height and


### PR DESCRIPTION
It supports both 16UC1 and 32FC1.