### PR TITLE
[jsk_pcl_ros] Remove cuboid_parameter.cfg and add InteractiveCuboidLikelihood.cfg and PlaneSupportedCuboidEstimator.cfg.

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -89,7 +89,8 @@ add_service_files(FILES SwitchTopic.srv
 generate_dynamic_reconfigure_options(
   cfg/VoxelGridLargeScale.cfg
   cfg/PolygonArrayAreaLikelihood.cfg
-  cfg/cuboid_parameter.cfg
+  cfg/PlaneSupportedCuboidEstimator.cfg
+  cfg/InteractiveCuboidLikelihood.cfg
   cfg/ExtractParticlesTopNBase.cfg
   cfg/PoseWithCovarianceStampedToGaussianPointCloud.cfg
   cfg/HeightmapMorphologicalFiltering.cfg

--- a/jsk_pcl_ros/cfg/InteractiveCuboidLikelihood.cfg
+++ b/jsk_pcl_ros/cfg/InteractiveCuboidLikelihood.cfg
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+# set up parameters that we care about
+PACKAGE = 'jsk_pcl_ros'
+
+try:
+    import imp
+    imp.find_module(PACKAGE)
+    from dynamic_reconfigure.parameter_generator_catkin import *;
+except:
+    import roslib; roslib.load_manifest(PACKAGE)
+    from dynamic_reconfigure.parameter_generator import *;
+
+def commonParameter():
+    gen = ParameterGenerator ()
+    gen.add("use_range_likelihood", bool_t, 0, "", False)
+    gen.add("range_likelihood_local_min_z", double_t, 0, "", 0.0, 0.0, 1.0)
+    gen.add("range_likelihood_local_max_z", double_t, 0, "", 0.0, 0.0, 1.0)
+    gen.add("use_occlusion_likelihood", bool_t, 0, "", False)
+    gen.add("use_inside_points_distance_zero", bool_t, 0, "", False)
+    gen.add("min_inliers", int_t, 0, "", 10, 0, 1000)
+    gen.add("outlier_distance", double_t, 0, "", 0.1, 0.0, 1.0)
+    gen.add("plane_distance_error_power", double_t, 0, "", 2, 0, 10)
+    gen.add("use_support_plane_angular_likelihood", bool_t, 0, "", False)
+    gen.add("support_plane_angular_likelihood_weight_power", double_t, 0, "", 1.0, 0.0, 10.0)
+    gen.add("use_surface_area_likelihood", bool_t, 0, "", False)
+    gen.add("surface_area_error_power", double_t, 0, "", 1.0, 0.0, 10.0)
+    gen.add("use_polygon_likelihood", bool_t, 0, "", False)
+    gen.add("use_inliers", bool_t, 0, "", False)
+    gen.add("inliers_power", double_t, 0, "", 2, 0, 10)
+    gen.add("expected_density", double_t, 0, "", 0.01, 0.0, 1.0)
+    return gen
+
+interactive_cuboid_likelihood_gen = commonParameter()
+interactive_cuboid_likelihood_gen.add("dx", double_t, 0, "", 0.1, 0.01, 1.0)
+interactive_cuboid_likelihood_gen.add("dy", double_t, 0, "", 0.1, 0.01, 1.0)
+interactive_cuboid_likelihood_gen.add("dz", double_t, 0, "", 0.1, 0.01, 1.0)
+
+if __name__ == "__main__":
+    exit(interactive_cuboid_likelihood_gen.generate (PACKAGE, "jsk_pcl_ros", "InteractiveCuboidLikelihood"))

--- a/jsk_pcl_ros/cfg/PlaneSupportedCuboidEstimator.cfg
+++ b/jsk_pcl_ros/cfg/PlaneSupportedCuboidEstimator.cfg
@@ -65,17 +65,9 @@ plane_supported_cuboid_estimator_gen.add("min_dz", double_t, 0, "", 0.001, 0.001
 plane_supported_cuboid_estimator_gen.add("use_init_polygon_likelihood", bool_t, 0, "", False)
 plane_supported_cuboid_estimator_gen.add("fast_cloud_threshold", double_t, 0, "", 2.0, 0.0, 10.0)
 
-
-interactive_cuboid_likelihood_gen = commonParameter()
-interactive_cuboid_likelihood_gen.add("dx", double_t, 0, "", 0.1, 0.01, 1.0)
-interactive_cuboid_likelihood_gen.add("dy", double_t, 0, "", 0.1, 0.01, 1.0)
-interactive_cuboid_likelihood_gen.add("dz", double_t, 0, "", 0.1, 0.01, 1.0)
-
 if __name__ == "__main__":
-    exit(not(not plane_supported_cuboid_estimator_gen.generate (PACKAGE, "jsk_pcl_ros", "PlaneSupportedCuboidEstimator")
-             and 
-             not interactive_cuboid_likelihood_gen.generate (PACKAGE, "jsk_pcl_ros", "InteractiveCuboidLikelihood")))
-    
+    exit(plane_supported_cuboid_estimator_gen.generate (PACKAGE, "jsk_pcl_ros", "PlaneSupportedCuboidEstimator"))
+
 # CMake do not know dependency between this script and
 # PlaneSupportedCuboidEstimator.cfg and InteractiveCuboidLikelihood.cfg.
 # So you need to run following command when you edit cuboid_parameter.py


### PR DESCRIPTION
This commit give up to re-use definition of dynamic_reconfigure because
generate_dynamic_reconfigure_options automatically install cpp files
estimated from cfg files.

closes https://github.com/jsk-ros-pkg/jsk_recognition/issues/1401