### PR TITLE
 [jsk_pcl_ros] Check header.frame_id before resolving 3-D spacially

### DIFF
--- a/doc/jsk_pcl_ros/nodes/plane_concatenator.md
+++ b/doc/jsk_pcl_ros/nodes/plane_concatenator.md
@@ -37,3 +37,11 @@ Concatenate near planes and build new set of planes.
 * `~ransac_refinement_eps_angle` (Double, default: `0.1`)
 
   Eps angle threshold of RANSAC refinment using normal direction of the plane.
+* `~min_size` (default: `100`)
+
+  Minimum inlier of concatenated polygons.
+* `~min_area` (default: `0.1`)
+* `~max_area` (default: `100.0`)
+
+  Minimum and maximum area of concatenated polygons.
+

--- a/jsk_pcl_ros/cfg/PlaneConcatenator.cfg
+++ b/jsk_pcl_ros/cfg/PlaneConcatenator.cfg
@@ -29,4 +29,6 @@ gen.add("ransac_refinement_outlier_threshold", double_t, 0,
 gen.add("ransac_refinement_eps_angle", double_t, 0,
         "ransac refinement of eps angle", 0.1, 0.0, 1.0)
 gen.add("min_size", int_t, 0, "minimum indices size", 100, 0, 1000)
+gen.add("max_area", double_t, 0, "the max area of the convex areas", 100, 0, 100)
+gen.add("min_area", double_t, 0, "the minimum area of the convex areas", 0.1, 0, 5)
 exit (gen.generate (PACKAGE, "jsk_pcl_ros", "PlaneConcatenator"))

--- a/jsk_pcl_ros/include/jsk_pcl_ros/plane_concatenator.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/plane_concatenator.h
@@ -113,6 +113,8 @@ namespace jsk_pcl_ros
     double ransac_refinement_eps_distance_;
     double ransac_refinement_eps_angle_;
     int min_size_;
+    double min_area_;
+    double max_area_;
   private:
     
   };

--- a/jsk_pcl_ros/src/multi_plane_extraction_nodelet.cpp
+++ b/jsk_pcl_ros/src/multi_plane_extraction_nodelet.cpp
@@ -37,7 +37,8 @@
 #include <pluginlib/class_list_macros.h>
 #include <pcl/filters/extract_indices.h>
 #include <pcl/segmentation/extract_polygonal_prism_data.h>
-
+#include <jsk_recognition_utils/pcl_ros_util.h>
+#include <jsk_topic_tools/log_utils.h>
 #include <pcl/filters/project_inliers.h>
 #include <set>
 
@@ -160,6 +161,35 @@ namespace jsk_pcl_ros
   {
     boost::mutex::scoped_lock lock(mutex_);
     vital_checker_->poke();
+    // check header
+    if (use_indices_) {
+      if(!jsk_recognition_utils::isSameFrameId(input->header.frame_id,
+                                               indices->header.frame_id) ||
+         !jsk_recognition_utils::isSameFrameId(input->header.frame_id,
+                                               coefficients->header.frame_id) ||
+         !jsk_recognition_utils::isSameFrameId(input->header.frame_id,
+                                               polygons->header.frame_id)) {
+        JSK_NODELET_ERROR("frame_id does not match. cloud: %s, indices: %s, coefficients: %s, polygons: %s",
+                          input->header.frame_id.c_str(),
+                          indices->header.frame_id.c_str(),
+                          coefficients->header.frame_id.c_str(),
+                          polygons->header.frame_id.c_str());
+        return;
+      }
+    }
+    else {
+      if(!jsk_recognition_utils::isSameFrameId(input->header.frame_id,
+                                               coefficients->header.frame_id) ||
+         !jsk_recognition_utils::isSameFrameId(input->header.frame_id,
+                                               polygons->header.frame_id)) {
+        JSK_NODELET_ERROR("frame_id does not match. cloud: %s, coefficients: %s, polygons: %s",
+                          input->header.frame_id.c_str(),
+                          coefficients->header.frame_id.c_str(),
+                          polygons->header.frame_id.c_str());
+        return;
+      }
+    }
+  
     Eigen::Vector3f viewpoint;
     try {
       if (use_sensor_frame_) {

--- a/jsk_pcl_ros/src/plane_concatenator_nodelet.cpp
+++ b/jsk_pcl_ros/src/plane_concatenator_nodelet.cpp
@@ -138,7 +138,9 @@ namespace jsk_pcl_ros
            ++it) {
         new_one_indices = addIndices(*new_one_indices, *all_indices[*it]);
       }
-      new_indices.push_back(new_one_indices);
+      if (new_one_indices->indices.size() > min_size_) {
+        new_indices.push_back(new_one_indices);
+      }
     }
     
     // refinement
@@ -156,21 +158,31 @@ namespace jsk_pcl_ros
     new_ros_indices.header = cloud_msg->header;
     new_ros_coefficients.header = cloud_msg->header;
     new_ros_polygons.header = cloud_msg->header;
-    new_ros_indices.cluster_indices
-      = pcl_conversions::convertToROSPointIndices(new_indices, cloud_msg->header);
-    new_ros_coefficients.coefficients
-      = pcl_conversions::convertToROSModelCoefficients(
-        new_refined_coefficients, cloud_msg->header);
-    
     for (size_t i = 0; i < new_indices.size(); i++) {
       ConvexPolygon::Ptr convex
         = convexFromCoefficientsAndInliers<PointT>(
           cloud, new_indices[i], new_refined_coefficients[i]);
-      geometry_msgs::PolygonStamped polygon;
-      polygon.polygon = convex->toROSMsg();
-      polygon.header = cloud_msg->header;
-      new_ros_polygons.polygons.push_back(polygon);
+      if (convex->area() > min_area_ && convex->area() < max_area_) {
+        geometry_msgs::PolygonStamped polygon;
+        polygon.polygon = convex->toROSMsg();
+        polygon.header = cloud_msg->header;
+        new_ros_polygons.polygons.push_back(polygon);
+        pcl_msgs::PointIndices ros_indices;
+        ros_indices.header = cloud_msg->header;
+        ros_indices.indices = new_indices[i]->indices;
+        new_ros_indices.cluster_indices.push_back(ros_indices);
+        pcl_msgs::ModelCoefficients ros_coefficients;
+        ros_coefficients.header = cloud_msg->header;
+        ros_coefficients.values = new_refined_coefficients[i]->values;
+        new_ros_coefficients.coefficients.push_back(ros_coefficients);
+      }
     }
+    
+    // new_ros_indices.cluster_indices
+    //   = pcl_conversions::convertToROSPointIndices(new_indices, cloud_msg->header);
+    // new_ros_coefficients.coefficients
+    //   = pcl_conversions::convertToROSModelCoefficients(
+    //     new_refined_coefficients, cloud_msg->header);
 
     pub_indices_.publish(new_ros_indices);
     pub_polygon_.publish(new_ros_polygons);
@@ -250,6 +262,8 @@ namespace jsk_pcl_ros
       = config.ransac_refinement_outlier_threshold;
     ransac_refinement_eps_angle_ = config.ransac_refinement_eps_angle;
     min_size_ = config.min_size;
+    min_area_ = config.min_area;
+    max_area_ = config.max_area;
   }
 
   void PlaneConcatenator::updateDiagnostic(

--- a/jsk_perception/src/polygon_array_color_histogram.cpp
+++ b/jsk_perception/src/polygon_array_color_histogram.cpp
@@ -42,6 +42,7 @@
 #include <jsk_recognition_utils/sensor_model_utils.h>
 #include <jsk_recognition_utils/cv_utils.h>
 #include <sensor_msgs/image_encodings.h>
+#include <jsk_recognition_utils/pcl_ros_util.h>
 
 namespace jsk_perception
 {
@@ -112,6 +113,14 @@ namespace jsk_perception
     boost::mutex::scoped_lock lock(mutex_);
     if (!info_) {
       JSK_NODELET_WARN("No camera_info is available");
+      return;
+    }
+    // check frame_id
+    if (!jsk_recognition_utils::isSameFrameId(image_msg->header.frame_id,
+                                              polygon_msg->header.frame_id)) {
+      JSK_NODELET_ERROR("frame_id does not match. image: %s, polygon: %s",
+                        image_msg->header.frame_id.c_str(),
+                        polygon_msg->header.frame_id.c_str());
       return;
     }
     try 

--- a/jsk_recognition_utils/include/jsk_recognition_utils/pcl_ros_util.h
+++ b/jsk_recognition_utils/include/jsk_recognition_utils/pcl_ros_util.h
@@ -57,6 +57,13 @@ namespace jsk_recognition_utils
   void publishPointIndices(ros::Publisher& pub,
                            const pcl::PointIndices& indices,
                            const std_msgs::Header& header);
+  
+  /**
+   * @brief
+   * Return true if a and b are the same frame_id
+   */
+  bool isSameFrameId(const std::string& a, const std::string& b);
+                     
 }
 
 #endif

--- a/jsk_recognition_utils/src/pcl_ros_util.cpp
+++ b/jsk_recognition_utils/src/pcl_ros_util.cpp
@@ -47,4 +47,24 @@ namespace jsk_recognition_utils
     msg.header = header;
     pub.publish(msg);
   }
+
+  bool isSameFrameId(const std::string& a, const std::string& b)
+  {
+    // we can ignore the first /
+    std::string aa;
+    if (a.length() > 0 && a[0] == '/') {
+      aa = a.substr(1, a.length() - 1);
+    }
+    else {
+      aa = a;
+    }
+    std::string bb;
+    if (b.length() > 0 && b[0] == '/') {
+      bb = b.substr(1, b.length() - 1);
+    }
+    else {
+      bb = b;
+    }
+    return aa == bb;
+  }
 }


### PR DESCRIPTION
    Modified:
         jsk_pcl_ros/src/multi_plane_extraction_nodelet.cpp
         jsk_perception/src/polygon_array_color_histogram.cpp
         jsk_recognition_utils/include/jsk_recognition_utils/pcl_ros_util.h
         jsk_recognition_utils/src/pcl_ros_util.cpp
