### PR TITLE
[jsk_perception] Fix tile_image.py for hydro.

### DIFF
--- a/jsk_perception/node_scripts/tile_image.py
+++ b/jsk_perception/node_scripts/tile_image.py
@@ -9,7 +9,9 @@ from jsk_topic_tools import ConnectionBasedTransport
 import message_filters
 import rospy
 from sensor_msgs.msg import Image
-import os
+import pkg_resources
+from distutils.version import StrictVersion
+
 
 class TileImages(ConnectionBasedTransport):
     def __init__(self):
@@ -19,10 +21,10 @@ class TileImages(ConnectionBasedTransport):
             rospy.logerr('need to specify input_topics')
             sys.exit(1)
         self.approximate_sync = rospy.get_param('~approximate_sync', True)
-        if os.environ['ROS_DISTRO'] == 'hydro' and self.approximate_sync:
+        if (StrictVersion(pkg_resources.get_distribution('message_filters').version) < StrictVersion('1.11.4') and
+            self.approximate_sync):
             rospy.logerr('hydro message_filters does not support approximate sync. Force to set ~approximate_sync=false')
             self.approximate_sync = False
-
         self.pub_img = self.advertise('~output', Image, queue_size=1)
 
     def subscribe(self):

--- a/jsk_recognition_utils/python/jsk_recognition_utils/visualize.py
+++ b/jsk_recognition_utils/python/jsk_recognition_utils/visualize.py
@@ -37,7 +37,7 @@ def get_tile_image(imgs, tile_shape=None):
 
     canvas = plt.get_current_fig_manager().canvas
     canvas.draw()
-    pil_img = PIL.Image.fromstring('RGB',
+    pil_img = PIL.Image.frombytes('RGB',
         canvas.get_width_height(), canvas.tostring_rgb())
     out_rgb = np.array(pil_img)
     out_bgr = cv2.cvtColor(out_rgb, cv2.COLOR_RGB2BGR)


### PR DESCRIPTION
1. Disable approximate sync for hydro. it's not supported on hydro
2. Use PIL.Image.frombytes instead of PIL.Image.fromstring