### PR TITLE
[jsk_pcl_ros] Do not call callback until initialization done

### DIFF
--- a/jsk_pcl_ros/include/jsk_pcl_ros/region_growing_multiple_plane_segmentation.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/region_growing_multiple_plane_segmentation.h
@@ -64,7 +64,9 @@ namespace jsk_pcl_ros
       sensor_msgs::PointCloud2,
       sensor_msgs::PointCloud2 > NormalSyncPolicy;
     RegionGrowingMultiplePlaneSegmentation()
-      : DiagnosticNodelet("RegionGrowingMultiplePlaneSegmentation"), timer_(10) {}
+      : DiagnosticNodelet("RegionGrowingMultiplePlaneSegmentation"), 
+        timer_(10), 
+        done_initialization_(false) {}
     
   protected:
     ////////////////////////////////////////////////////////
@@ -154,6 +156,7 @@ namespace jsk_pcl_ros
     double cluster_tolerance_;
     double ransac_refine_outlier_distance_threshold_;
     int ransac_refine_max_iterations_;
+    bool done_initialization_;
     ////////////////////////////////////////////////////////
     // static parameters
     ////////////////////////////////////////////////////////

--- a/jsk_pcl_ros/include/jsk_pcl_ros/torus_finder.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/torus_finder.h
@@ -92,6 +92,7 @@ namespace jsk_pcl_ros
     int min_size_;
     bool voxel_grid_sampling_;
     double voxel_size_;
+    bool done_initialization_;
   private:
   };
 }

--- a/jsk_pcl_ros/src/region_growing_multiple_plane_segmentation_nodelet.cpp
+++ b/jsk_pcl_ros/src/region_growing_multiple_plane_segmentation_nodelet.cpp
@@ -66,6 +66,7 @@ namespace jsk_pcl_ros
       *pnh_, "output/latest_time", 1);
     pub_average_time_ = advertise<std_msgs::Float32>(
       *pnh_, "output/average_time", 1);
+    done_initialization_ = true;
   }
 
   void RegionGrowingMultiplePlaneSegmentation::subscribe()
@@ -127,6 +128,9 @@ namespace jsk_pcl_ros
     const sensor_msgs::PointCloud2::ConstPtr& normal_msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+    if (!done_initialization_) {
+      return;
+    }
     vital_checker_->poke();
     {
       jsk_recognition_utils::ScopedWallDurationReporter r

--- a/jsk_pcl_ros/src/torus_finder_nodelet.cpp
+++ b/jsk_pcl_ros/src/torus_finder_nodelet.cpp
@@ -78,6 +78,7 @@ namespace jsk_pcl_ros
     pub_pose_stamped_ = advertise<geometry_msgs::PoseStamped>(*pnh_, "output/pose", 1);
     pub_coefficients_ = advertise<PCLModelCoefficientMsg>(
       *pnh_, "output/coefficients", 1);
+    done_initialization_ = true;
   }
 
   void TorusFinder::configCallback(Config &config, uint32_t level)
@@ -109,6 +110,9 @@ namespace jsk_pcl_ros
   void TorusFinder::segmentFromPoints(
     const geometry_msgs::PolygonStamped::ConstPtr& polygon_msg)
   {
+    if (!done_initialization_) {
+      return;
+    }
     // Convert to pointcloud and call it
     // No normal
     pcl::PointCloud<pcl::PointNormal>::Ptr cloud


### PR DESCRIPTION
Modified:
  - jsk_pcl_ros/include/jsk_pcl_ros/region_growing_multiple_plane_segmentation.h
  - jsk_pcl_ros/include/jsk_pcl_ros/torus_finder.h
  - jsk_pcl_ros/src/region_growing_multiple_plane_segmentation_nodelet.cpp
  - jsk_pcl_ros/src/torus_finder_nodelet.cpp