### PR TITLE
[jsk_perception] Ignore slic dir which is cloned at building time

### DIFF
--- a/jsk_perception/.gitignore
+++ b/jsk_perception/.gitignore
@@ -1,3 +1,4 @@
+slic/
 trained_data
 launch/eusmodel_detection_elevator-panels-eng2.launch
 launch/eusmodel_detection_elevator-panels-eng8.launch


### PR DESCRIPTION
Modified:
  - jsk_perception/.gitignore