### PR TITLE
[jsk_perception] Read reference color histogram from a yaml file in PolygonArrayColorLikelihood to avoid race condition between input topics

### DIFF
--- a/doc/jsk_perception/nodes/polygon_array_color_likelihood.md
+++ b/doc/jsk_perception/nodes/polygon_array_color_likelihood.md
@@ -26,3 +26,20 @@ Compute polygon likelihood based on distance of histograms.
 * `~max_queue_size` (default: `10`)
 
   Max queue size
+
+* `~reference_file`
+
+  If this parameter is specified, PolygonArrayColorLikelihood reads reference histogram from
+  a yaml file instead of subscribing `~input/reference`.
+  The yaml file format is
+  ```yaml
+  bins:
+  - 
+    min_value: xx
+    max_value: xx
+    count: xx
+  - 
+    min_value: xx
+    max_value: xx
+    count: xx
+  ```

--- a/jsk_perception/CMakeLists.txt
+++ b/jsk_perception/CMakeLists.txt
@@ -21,6 +21,12 @@ find_package(Boost REQUIRED COMPONENTS filesystem system signals)
 find_package(Eigen REQUIRED)
 include_directories(${Eigen_INCLUDE_DIRS})
 
+pkg_check_modules(yaml_cpp yaml-cpp REQUIRED)
+IF(${yaml_cpp_VERSION} VERSION_LESS "0.5.0")
+## indigo yaml-cpp : 0.5.0 /  hydro yaml-cpp : 0.3.0
+  add_definitions("-DUSE_OLD_YAML")
+ENDIF()
+
 FIND_PACKAGE( OpenMP REQUIRED)
 if(OPENMP_FOUND)
 message("OPENMP FOUND")
@@ -165,7 +171,7 @@ add_library(${PROJECT_NAME} SHARED ${jsk_perception_nodelet_sources}
   src/image_utils.cpp
   src/histogram_of_oriented_gradients.cpp
   )
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${robot_self_filter_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${robot_self_filter_LIBRARIES} yaml-cpp)
 if(robot_self_filter_FOUND)
   include_directories(${robot_self_filter_INCLUDE_DIRS})
   target_link_libraries(${PROJECT_NAME} ${robot_self_filter_LIBRARIES})

--- a/jsk_perception/include/jsk_perception/polygon_array_color_likelihood.h
+++ b/jsk_perception/include/jsk_perception/polygon_array_color_likelihood.h
@@ -74,6 +74,7 @@ namespace jsk_perception
     virtual void configCallback(Config &config, uint32_t level);
     virtual double compareHist(
       const cv::MatND& ref_hist, const cv::MatND& target_hist);
+    virtual void readReference(const std::string& file);
     boost::mutex mutex_;
     ros::Publisher pub_;
     ros::Subscriber sub_reference_;
@@ -86,6 +87,7 @@ namespace jsk_perception
     bool approximate_sync_;
     int max_queue_size_;
     int coefficient_method_;
+    bool reference_from_file_;
   private:
     
   };

--- a/jsk_perception/package.xml
+++ b/jsk_perception/package.xml
@@ -47,6 +47,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>robot_self_filter</build_depend>
+  <build_depend>yaml-cpp</build_depend>
 
   <run_depend>angles</run_depend>
   <run_depend>cv_bridge</run_depend>
@@ -79,6 +80,7 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>robot_self_filter</run_depend>
+  <run_depend>yaml-cpp</run_depend>
 
   <export>
     <nodelet plugin="${prefix}/jsk_perception_nodelets.xml"/>


### PR DESCRIPTION
…


Modified:
  - doc/jsk_perception/nodes/polygon_array_color_likelihood.md
  - jsk_perception/CMakeLists.txt
  - jsk_perception/include/jsk_perception/polygon_array_color_likelihood.h
  - jsk_perception/package.xml
  - jsk_perception/src/polygon_array_color_likelihood.cpp