### PR TITLE
[jsk_perception] Stop using deprecated PLUGINLIB_DECLARE_CLASS

### DIFF
--- a/.travis.rosinstall.jade
+++ b/.travis.rosinstall.jade
@@ -1,8 +1,4 @@
 - git:
-    uri: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
-    local-name: jsk-ros-pkg/jsk_3rdparty
-    version: 2.0.11
-- git:
     uri: https://github.com/sniekum/ml_classifiers.git
     local-name: sniekum/ml_classifiers
     version: master

--- a/jsk_perception/jsk_perception_nodelets.xml
+++ b/jsk_perception/jsk_perception_nodelets.xml
@@ -153,31 +153,31 @@
       compute superpixels
     </description>
   </class>
-  <class name="jsk_perception/HoughCircleDetector" type="HoughCircleDetector"
+  <class name="jsk_perception/HoughCircleDetector" type="jsk_perception::HoughCircleDetector"
          base_class_type="nodelet::Nodelet">
     <description>
       nodelet to detect circles based on hough transformation
     </description>
   </class>
-  <class name="jsk_perception/ColorHistogram" type="ColorHistogram"
+  <class name="jsk_perception/ColorHistogram" type="jsk_perception::ColorHistogram"
          base_class_type="nodelet::Nodelet">
     <description>
       Nodelet to compute histogram
     </description>
   </class>
-  <class name="jsk_perception/EdgeDetector" type="EdgeDetector"
+  <class name="jsk_perception/EdgeDetector" type="jsk_perception::EdgeDetector"
          base_class_type="nodelet::Nodelet">
     <description>
       Nodelet to detect edges
     </description>
   </class>
-  <class name="jsk_perception/SparseImageEncoder" type="SparseImageEncoder"
+  <class name="jsk_perception/SparseImageEncoder" type="jsk_perception::SparseImageEncoder"
          base_class_type="nodelet::Nodelet">
     <description>
       Nodelet to encode image to an array of sparse matrix.
     </description>
   </class>
-  <class name="jsk_perception/SparseImageDecoder" type="SparseImageDecoder"
+  <class name="jsk_perception/SparseImageDecoder" type="jsk_perception::SparseImageDecoder"
          base_class_type="nodelet::Nodelet">
     <description>
       Nodelet to decode from an array of sparse matrix to image.

--- a/jsk_perception/src/color_histogram.cpp
+++ b/jsk_perception/src/color_histogram.cpp
@@ -302,5 +302,4 @@ namespace jsk_perception
 }
 
 #include <pluginlib/class_list_macros.h>
-typedef jsk_perception::ColorHistogram ColorHistogram;
-PLUGINLIB_DECLARE_CLASS (jsk_perception, ColorHistogram, ColorHistogram, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(jsk_perception::ColorHistogram, nodelet::Nodelet);

--- a/jsk_perception/src/edge_detector.cpp
+++ b/jsk_perception/src/edge_detector.cpp
@@ -9,7 +9,6 @@
 
 #include <dynamic_reconfigure/server.h>
 
-#include <pluginlib/class_list_macros.h>
 
 namespace enc = sensor_msgs::image_encodings;
 
@@ -137,5 +136,5 @@ public:
 };
 }
 
-typedef jsk_perception::EdgeDetector EdgeDetector;
-PLUGINLIB_DECLARE_CLASS (jsk_perception, EdgeDetector, EdgeDetector, nodelet::Nodelet);
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(jsk_perception::EdgeDetector, nodelet::Nodelet);

--- a/jsk_perception/src/hough_circles.cpp
+++ b/jsk_perception/src/hough_circles.cpp
@@ -151,5 +151,4 @@ namespace jsk_perception
 }
 
 #include <pluginlib/class_list_macros.h>
-typedef jsk_perception::HoughCircleDetector HoughCircleDetector;
-PLUGINLIB_DECLARE_CLASS (jsk_perception, HoughCircleDetector, HoughCircleDetector, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(jsk_perception::HoughCircleDetector, nodelet::Nodelet);

--- a/jsk_perception/src/sparse_image_decoder.cpp
+++ b/jsk_perception/src/sparse_image_decoder.cpp
@@ -7,7 +7,6 @@
 #include <nodelet/nodelet.h>
 #include <jsk_topic_tools/log_utils.h>
 #include <image_transport/image_transport.h>
-#include <pluginlib/class_list_macros.h>
 #include <sensor_msgs/image_encodings.h>
 #include <jsk_recognition_msgs/SparseImage.h>
 
@@ -111,5 +110,5 @@ public:
 }; // end of SparseImageDecoder class definition
 } // end of jsk_perception namespace
 
-typedef jsk_perception::SparseImageDecoder SparseImageDecoder;
-PLUGINLIB_DECLARE_CLASS (jsk_perception, SparseImageDecoder, SparseImageDecoder, nodelet::Nodelet);
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(jsk_perception::SparseImageDecoder, nodelet::Nodelet);

--- a/jsk_perception/src/sparse_image_encoder.cpp
+++ b/jsk_perception/src/sparse_image_encoder.cpp
@@ -7,7 +7,6 @@
 #include <nodelet/nodelet.h>
 #include <jsk_topic_tools/log_utils.h>
 #include <image_transport/image_transport.h>
-#include <pluginlib/class_list_macros.h>
 #include <sensor_msgs/image_encodings.h>
 #include <jsk_recognition_msgs/SparseImage.h>
 
@@ -121,5 +120,5 @@ public:
 }; // end of SparseImageEncoder class definition
 } // end of jsk_perception namespace
 
-typedef jsk_perception::SparseImageEncoder SparseImageEncoder;
-PLUGINLIB_DECLARE_CLASS (jsk_perception, SparseImageEncoder, SparseImageEncoder, nodelet::Nodelet);
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(jsk_perception::SparseImageEncoder, nodelet::Nodelet);


### PR DESCRIPTION
Modified:
  - jsk_perception/src/color_histogram.cpp
  - jsk_perception/src/edge_detector.cpp
  - jsk_perception/src/hough_circles.cpp
  - jsk_perception/src/sparse_image_decoder.cpp
  - jsk_perception/src/sparse_image_encoder.cpp