### PR TITLE
 [jsk_pcl_ros] Add new feature to skip tracking according to     background substraction.

### DIFF
--- a/doc/jsk_pcl_ros/nodes/particle_filter_tracking.md
+++ b/doc/jsk_pcl_ros/nodes/particle_filter_tracking.md
@@ -9,6 +9,11 @@ This nodelet tracks the target pointcloud.
 
   Input pointcloud
 
+* `~input_change` (`sensor_msgs/PointCloud2`)
+
+  Input change pointcloud, which is only enabled when `~use_change_detection` is true.
+
+
 * `~renew_model` (`sensor_msgs/PointCloud2`)
 
   Reference pointcloud to track.
@@ -43,6 +48,14 @@ This nodelet tracks the target pointcloud.
 
   average computation time
 
+* `~output/velocity` (`geometry_msgs/TwistStamped`)
+
+  Velocity of object.
+
+* `~output/no_move` (`std_msgs/Bool`)
+* `~output/no_move_raw` (`std_msgs/Bool`)
+
+  These topics will be true if object looks stable.
 
 ##### Advertising Servicies
 * `~renew_model` (`jsk_pcl_ros/SetPointCloud2`)
@@ -148,6 +161,18 @@ This nodelet tracks the target pointcloud.
 
   Maximum distance between points to take into account when computing likelihood
 
+* `~use_change_detection` (Bool, default: `false`)
+
+  Use change detection to skip tracking when no change in pointcloud.
+
+* `~static_velocity_thr` (Double, default: `0.1`)
+
+  Velocity threshold to regard object is stable.
+
+* `~change_cloud_near_thr` (Double, default: `0.2`)
+
+  Distance threshold to trigger tracking when `~use_change_detection` is true.
+
 ## Sample
 
 run the below command.
@@ -158,3 +183,8 @@ roslaunch jsk_pcl_ros tracking_hydro.launch  #(When use hydro)
 ```
 
 Push the "Select" button at the top bar , drag and surround the target poincloud which you want to track in the rectangle area.Then, finally, push the "SelectPointCloudPublishActoin" button at SelectPointCloudPublishAction Panel. The tracker will start tracking the target.
+
+tabletop_tracking.launch is specialized for tracking tabletop objects.
+```
+roslaunch jsk_pcl_ros tabletop_tracking.launch
+```

--- a/jsk_pcl_ros/cfg/ParticleFilterTracking.cfg
+++ b/jsk_pcl_ros/cfg/ParticleFilterTracking.cfg
@@ -39,5 +39,6 @@ gen.add("default_step_covariance_pitch", double_t, 0, "pitch of step covariance"
         0.004, 0.0, 1.0)
 gen.add("default_step_covariance_yaw", double_t, 0, "yaw of step covariance",
         0.004, 0.0, 1.0)
-
+gen.add("static_velocity_thr", double_t, 0, "", 0.1, 0.0, 1.0)
+gen.add("change_cloud_near_thr", double_t, 0, "", 0.2, 0.0, 1.0)
 exit (gen.generate (PACKAGE, "jsk_pcl_ros", "ParticleFilterTracking"))

--- a/jsk_pcl_ros/launch/tabletop_tracking.launch
+++ b/jsk_pcl_ros/launch/tabletop_tracking.launch
@@ -1,0 +1,130 @@
+<launch>
+  <node pkg="jsk_topic_tools" type="relay" name="input_relay">
+    <remap from="~input" to="/multisense_local/resize_1_4/points" />
+  </node>
+  <node pkg="jsk_pcl_ros" type="organized_multi_plane_segmentation" name="multi_plane_estimate">
+    <remap from="~input" to="input_relay/output"/>
+    <rosparam>
+      max_curvature: 0.01
+      estimate_normal: true
+    </rosparam>
+  </node>
+  <node pkg="nodelet" type="nodelet"
+        name="plane_extraction"
+        args="standalone jsk_pcl/MultiPlaneExtraction"
+        output="screen">
+    <remap from="~input" to="input_relay/output" />
+    <remap from="~indices" to="/multi_plane_estimate/output_refined" />
+    <remap from="~input_polygons" to="/multi_plane_estimate/output_refined_polygon" />
+    <remap from="~input_coefficients" to="/multi_plane_estimate/output_refined_coefficients" />
+    <rosparam>
+      use_sensor_frame: true
+      sensor_frame: head_root
+    </rosparam>
+  </node>
+
+  <node pkg="nodelet" type="nodelet" name="euclidean_clustering"
+        args="standalone jsk_pcl/EuclideanClustering " output="screen">
+    <remap from="~input" to="/plane_extraction/output" />
+    <rosparam>
+      tolerance: 0.02
+      min_size: 100
+    </rosparam>
+  </node>
+
+  <node pkg="nodelet" type="nodelet"
+        name="throttle_segmentation"
+        args="standalone jsk_topic_tools/LightweightThrottle"
+        output="screen">
+    <remap from="~input" to="euclidean_clustering/output" />
+    <remap from="~output" to="euclidean_clustering/output_throttle" />
+  </node>
+
+  
+  <node pkg="nodelet" type="nodelet"
+        name="segmentation_decomposer"
+        args="standalone jsk_pcl/ClusterPointIndicesDecomposer"
+        output="screen">
+    <remap from="~input" to="/plane_extraction/output" />
+    <remap from="~target" to="/euclidean_clustering/output_throttle" />
+    <remap from="~align_planes" to="/multi_plane_estimate/output_refined_polygon" />
+    <remap from="~align_planes_coefficients"
+           to="/multi_plane_estimate/output_refined_coefficients" />
+    <rosparam>
+      align_boxes: true
+      use_pca: true
+      publish_clouds: false
+      publish_tf: false
+    </rosparam>
+  </node>
+
+  <node pkg="jsk_interactive_marker"
+        type="bounding_box_marker"
+        name="bounding_box_marker"
+        output="screen"
+        >
+    <remap from="~bounding_box_array" to="segmentation_decomposer/boxes" />
+  </node>
+  <node pkg="nodelet" type="nodelet"
+        name="selected_cloud"
+        args="standalone jsk_pcl/SelectedClusterPublisher"
+        output="screen">
+    <remap from="~input" to="/plane_extraction/output" />
+    <remap from="~indices" to="/euclidean_clustering/output" />
+    <remap from="~selected_index" to="/bounding_box_marker/selected_index" />
+    <remap from="~output" to="/selected_pointcloud" />
+  </node>
+
+  <node pkg="nodelet" type="nodelet"
+        name="octree_change_detector"
+        args="standalone jsk_pcl/OctreeChangePublisher">
+    <remap from="~input" to="voxelgrid/output" />
+    <rosparam>
+      resolution: 0.1
+      noise_filter: 8
+    </rosparam>
+  </node>
+
+  <node pkg="nodelet" type="nodelet"
+        name="voxelgrid"
+        args="standalone jsk_pcl/OctreeVoxelGrid"
+        output="screen" clear_params="true">
+    <remap from="~input" to="input_relay/output" />
+    <param name="resolution" value="0.01" />
+    <rosparam>
+      point_type: xyzrgb
+      marker_color_alpha: 0.5
+    </rosparam>
+  </node>
+
+    <node pkg="nodelet" type="nodelet"
+          name="model_voxelgrid"
+        args="standalone jsk_pcl/OctreeVoxelGrid"
+        output="screen" clear_params="true">
+    <remap from="~input" to="/selected_pointcloud" />
+    <param name="resolution" value="0.01" />
+    <rosparam>
+      point_type: xyzrgb
+      marker_color_alpha: 0.5
+    </rosparam>
+  </node>
+
+
+  
+  <node pkg="nodelet" type="nodelet"
+        name="particle_filter_tracker"
+        args="standalone jsk_pcl/ParticleFilterTracking"
+        output="screen" clear_params="true">
+    <remap from="~input" to="voxelgrid/output" />
+    <remap from="~input_change" to="octree_change_detector/octree_change_result" />
+    <remap from="~renew_model" to="model_voxelgrid/output" />
+    <rosparam>
+      max_particle_num: 1000
+      use_change_detection: true
+      default_step_covariance_x: 0.00004
+      default_step_covariance_y: 0.00004
+      default_step_covariance_z: 0.00004
+    </rosparam>
+  </node>
+  
+</launch>

--- a/jsk_pcl_ros/src/particle_filter_tracking_nodelet.cpp
+++ b/jsk_pcl_ros/src/particle_filter_tracking_nodelet.cpp
@@ -32,12 +32,17 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
+#define BOOST_PARAMETER_MAX_ARITY 7
+
 #include <jsk_topic_tools/log_utils.h>
 #include "jsk_pcl_ros/particle_filter_tracking.h"
 #include <pcl/tracking/impl/distance_coherence.hpp>
 #include <pcl/tracking/impl/approx_nearest_pair_point_cloud_coherence.hpp>
 #include <pluginlib/class_list_macros.h>
 #include <jsk_topic_tools/rosparam_utils.h>
+#include <geometry_msgs/TwistStamped.h>
+#include <std_msgs/Bool.h>
+#include <pcl/kdtree/kdtree_flann.h>
 
 using namespace pcl::tracking;
 
@@ -157,7 +162,7 @@ namespace jsk_pcl_ros
     double max_distance;
     pnh_->param("max_distance", max_distance, 0.01);
     coherence->setMaximumDistance(max_distance);
-
+    pnh_->param("use_change_detection", use_change_detection_, false);
     tracker_set_cloud_coherence(coherence);
 
     //Set publish setting
@@ -175,8 +180,28 @@ namespace jsk_pcl_ros
       "output/rms_angle_error", 1);
     pub_rms_distance_ = pnh_->advertise<std_msgs::Float32>(
       "output/rms_distance_error", 1);
+    pub_velocity_ = pnh_->advertise<geometry_msgs::TwistStamped>(
+      "output/velocity", 1);
+    pub_no_move_raw_ = pnh_->advertise<std_msgs::Bool>(
+      "output/no_move_raw", 1);
+    pub_no_move_ = pnh_->advertise<std_msgs::Bool>(
+      "output/no_move", 1);
+    pub_skipped_ = pnh_->advertise<std_msgs::Bool>(
+      "output/skipped", 1);
     //Set subscribe setting
-    sub_ = pnh_->subscribe("input", 1, &ParticleFilterTracking::cloud_cb,this);
+    if (use_change_detection_) {
+      sub_input_cloud_.subscribe(*pnh_, "input", 4);
+      sub_change_cloud_.subscribe(*pnh_, "input_change", 4);
+      change_sync_ = boost::make_shared<message_filters::Synchronizer<SyncChangePolicy> >(100);
+      change_sync_->connectInput(sub_input_cloud_, sub_change_cloud_);
+      change_sync_->registerCallback(
+        boost::bind(
+          &ParticleFilterTracking::cloud_change_cb,
+          this, _1, _2));
+    }
+    else {
+      sub_ = pnh_->subscribe("input", 1, &ParticleFilterTracking::cloud_cb,this);
+    }
     if (align_box_) {
       sub_input_.subscribe(*pnh_, "renew_model", 1);
       sub_box_.subscribe(*pnh_, "renew_box", 1);
@@ -222,6 +247,8 @@ namespace jsk_pcl_ros
     default_step_covariance_[3] = config.default_step_covariance_roll;
     default_step_covariance_[4] = config.default_step_covariance_pitch;
     default_step_covariance_[5] = config.default_step_covariance_yaw;
+    static_velocity_thr_ = config.static_velocity_thr;
+    change_cloud_near_threshold_ = config.change_cloud_near_thr;
     if (tracker_ || reversed_tracker_) 
     {
       JSK_NODELET_INFO("update tracker parameter");
@@ -293,6 +320,28 @@ namespace jsk_pcl_ros
     result_pointcloud2.header.stamp = stamp_;
     track_result_publisher_.publish(result_pointcloud2);
 
+    if (counter_ > 0) {         // publish velocity
+      geometry_msgs::TwistStamped twist;
+      twist.header.frame_id = reference_frame_id();
+      twist.header.stamp = stamp_;
+      double dt = (stamp_ - prev_stamp_).toSec();
+      twist.twist.linear.x = (result.x - prev_result_.x) / dt;
+      twist.twist.linear.y = (result.y - prev_result_.y) / dt;
+      twist.twist.linear.z = (result.z - prev_result_.z) / dt;
+      twist.twist.angular.x = (result.roll - prev_result_.roll) / dt;
+      twist.twist.angular.y = (result.pitch - prev_result_.pitch) / dt;
+      twist.twist.angular.z = (result.yaw - prev_result_.yaw) / dt;
+      pub_velocity_.publish(twist);
+      Eigen::Vector3f vel(twist.twist.linear.x, twist.twist.linear.y, twist.twist.linear.z);
+      bool is_static = vel.norm() < static_velocity_thr_;
+      no_move_buffer_.addValue(is_static);
+      std_msgs::Bool no_move_raw, no_move;
+      no_move_raw.data = is_static;
+      no_move.data = no_move_buffer_.isAllTrueFilled();
+      pub_no_move_.publish(no_move);
+      pub_no_move_raw_.publish(no_move_raw);
+    }
+    
     Eigen::Affine3f diff_trans = transformation.inverse() * initial_pose_;
     double distance_error = Eigen::Vector3f(diff_trans.translation()).norm();
     double angle_error = Eigen::AngleAxisf(diff_trans.rotation()).angle();
@@ -305,6 +354,9 @@ namespace jsk_pcl_ros
     ros_angle_rms.data = angle_rms;
     pub_rms_distance_.publish(ros_distance_rms);
     pub_rms_angle_.publish(ros_angle_rms);
+    prev_result_ = result;
+    prev_stamp_ = stamp_;
+    ++counter_;
   }
   
   std::string ParticleFilterTracking::reference_frame_id()
@@ -392,6 +444,45 @@ namespace jsk_pcl_ros
     return tfTransformation;
   }
 
+  void ParticleFilterTracking::cloud_change_cb(const sensor_msgs::PointCloud2::ConstPtr &pc_msg,
+                                               const sensor_msgs::PointCloud2::ConstPtr &change_cloud_msg)
+  {
+    if (no_move_buffer_.isAllTrueFilled()) {
+      jsk_recognition_utils::ScopedWallDurationReporter r
+        = timer_.reporter(pub_latest_time_, pub_average_time_);
+      // change change_cloud
+      pcl::PointCloud<pcl::PointXYZRGB>::Ptr change_cloud(new pcl::PointCloud<pcl::PointXYZRGB>);
+      pcl::fromROSMsg(*change_cloud_msg, *change_cloud);
+      if (change_cloud->points.size() == 0) {
+        stamp_ = pc_msg->header.stamp;
+        publish_result();
+        return;
+      }
+      pcl::KdTreeFLANN<pcl::PointXYZRGB> kdtree;
+      kdtree.setInputCloud(change_cloud);
+      std::vector<int> k_indices;
+      std::vector<float> k_sqr_distances;
+      pcl::PointXYZRGB p;
+      p.x = prev_result_.x;
+      p.y = prev_result_.y;
+      p.z = prev_result_.z;
+      if (kdtree.radiusSearch(p, change_cloud_near_threshold_, k_indices, k_sqr_distances, 1) > 0) {
+        JSK_NODELET_INFO("change detection triggered!");
+        // there is near pointcloud
+        cloud_cb(*pc_msg);
+        r.setIsEnabled(false);
+        no_move_buffer_.clear();
+      }
+      else {
+        // publish previous result
+        stamp_ = pc_msg->header.stamp;
+        publish_result();
+      }
+    }
+    else {
+      cloud_cb(*pc_msg);
+    }
+  }
   
   //OpenNI Grabber's cloud Callback function
   void ParticleFilterTracking::cloud_cb(const sensor_msgs::PointCloud2 &pc)
@@ -658,6 +749,8 @@ namespace jsk_pcl_ros
     else {
       reversed_tracker_->setReferenceCloud(ref);
     }
+    counter_ = 0;
+    no_move_buffer_.clear();
   }
 
   void ParticleFilterTracking::tracker_reset_tracking()

--- a/jsk_recognition_utils/include/jsk_recognition_utils/pcl_util.h
+++ b/jsk_recognition_utils/include/jsk_recognition_utils/pcl_util.h
@@ -230,9 +230,12 @@ namespace jsk_recognition_utils
     virtual ~SeriesedBoolean();
     virtual void addValue(bool val);
     virtual bool getValue();
+    virtual bool isAllTrueFilled();
+    virtual void clear();
   protected:
   private:
     boost::circular_buffer<bool> buf_;
+    const int buf_len_;
   };
 
   ////////////////////////////////////////////////////////

--- a/jsk_recognition_utils/include/jsk_recognition_utils/time_util.h
+++ b/jsk_recognition_utils/include/jsk_recognition_utils/time_util.h
@@ -50,11 +50,14 @@ namespace jsk_recognition_utils
                                ros::Publisher& pub_latest,
                                ros::Publisher& pub_average);
     virtual ~ScopedWallDurationReporter();
+    virtual void setIsPublish(bool);
+    virtual void setIsEnabled(bool);
   protected:
     WallDurationTimer* parent_;
     ros::WallTime start_time_;
     ros::Publisher pub_latest_, pub_average_;
-    const bool is_publish_;
+    bool is_publish_;
+    bool is_enabled_;
   private:
     
   };

--- a/jsk_recognition_utils/src/pcl_util.cpp
+++ b/jsk_recognition_utils/src/pcl_util.cpp
@@ -240,7 +240,7 @@ namespace jsk_recognition_utils
   }
 
   SeriesedBoolean::SeriesedBoolean(const int buf_len):
-    buf_(buf_len)
+    buf_(buf_len), buf_len_(buf_len)
   {
   }
   
@@ -251,6 +251,11 @@ namespace jsk_recognition_utils
   void SeriesedBoolean::addValue(bool val)
   {
     buf_.push_front(val);
+  }
+
+  bool SeriesedBoolean::isAllTrueFilled()
+  {
+    return (buf_.size() == buf_len_ && getValue());
   }
   
   bool SeriesedBoolean::getValue()
@@ -268,6 +273,11 @@ namespace jsk_recognition_utils
       }
       return true;
     }
+  }
+
+  void SeriesedBoolean::clear()
+  {
+    buf_.clear();
   }
 
   TimeredDiagnosticUpdater::TimeredDiagnosticUpdater(

--- a/jsk_recognition_utils/src/time_util.cpp
+++ b/jsk_recognition_utils/src/time_util.cpp
@@ -40,7 +40,7 @@ namespace jsk_recognition_utils
 {
   ScopedWallDurationReporter::ScopedWallDurationReporter(WallDurationTimer* parent):
     parent_(parent), start_time_(ros::WallTime::now()),
-    is_publish_(false)
+    is_publish_(false), is_enabled_(true)
   {
 
   }
@@ -51,7 +51,7 @@ namespace jsk_recognition_utils
     ros::Publisher& pub_average):
     parent_(parent), start_time_(ros::WallTime::now()),
     pub_latest_(pub_latest), pub_average_(pub_average),
-    is_publish_(true)
+    is_publish_(true), is_enabled_(true)
   {
 
   }
@@ -60,17 +60,29 @@ namespace jsk_recognition_utils
   {
     ros::WallTime end_time = ros::WallTime::now();
     ros::WallDuration d = end_time - start_time_;
-    parent_->report(d);
-    if (is_publish_) {
-      std_msgs::Float32 ros_latest;
-      ros_latest.data = parent_->latestSec();
-      pub_latest_.publish(ros_latest);
-      std_msgs::Float32 ros_average;
-      ros_average.data = parent_->meanSec();
-      pub_average_.publish(ros_latest);
+    if (is_enabled_) {
+      parent_->report(d);
+      if (is_publish_) {
+        std_msgs::Float32 ros_latest;
+        ros_latest.data = parent_->latestSec();
+        pub_latest_.publish(ros_latest);
+        std_msgs::Float32 ros_average;
+        ros_average.data = parent_->meanSec();
+        pub_average_.publish(ros_average);
+      }
     }
   }
 
+  void ScopedWallDurationReporter::setIsPublish(bool v)
+  {
+    is_publish_ = v;
+  }
+
+  void ScopedWallDurationReporter::setIsEnabled(bool v)
+  {
+    is_enabled_ = v;
+  }
+  
   WallDurationTimer::WallDurationTimer(const int max_num):
     max_num_(max_num), buffer_(max_num)
   {


### PR DESCRIPTION
Sample launch is tabletop_tracking.launch

Now particle_filter_tracking can skip tracking when object looks stable
and difference pointcloud (which should be computed by
octree_change_detector)
are far from target object.

It can dramatically decrease computation.


![screenshot from 2016-01-09 18 48 04](https://cloud.githubusercontent.com/assets/40454/12215471/984c16f6-b701-11e5-9d87-51bd301f4711.png)
