### PR TITLE
Use jsk pcl ros utils namespace in jsk pcl nodelets

### DIFF
--- a/jsk_pcl_ros/jsk_pcl_nodelets.xml
+++ b/jsk_pcl_ros/jsk_pcl_nodelets.xml
@@ -1,155 +1,155 @@
 <library path="libjsk_pcl_ros_utils">
-  <class name="jsk_pcl/PCDReaderWithPose" type="jsk_pcl_ros::PCDReaderWithPose"
+  <class name="jsk_pcl/PCDReaderWithPose" type="jsk_pcl_ros_utils::PCDReaderWithPose"
          base_class_type="nodelet::Nodelet">
     <description>
       reconstract template pointcloud with recognized_pose
     </description>
   </class>
   <class name="jsk_pcl/AddPointIndices"
-         type="jsk_pcl_ros::AddPointIndices"
+         type="jsk_pcl_ros_utils::AddPointIndices"
          base_class_type="nodelet::Nodelet">
   </class>
   <class name="jsk_pcl/MaskImageToPointIndices"
-         type="jsk_pcl_ros::MaskImageToPointIndices"
+         type="jsk_pcl_ros_utils::MaskImageToPointIndices"
          base_class_type="nodelet::Nodelet">
   </class>
   <class name="jsk_pcl/MaskImageToDepthConsideredMaskImage"
-         type="jsk_pcl_ros::MaskImageToDepthConsideredMaskImage"
+         type="jsk_pcl_ros_utils::MaskImageToDepthConsideredMaskImage"
          base_class_type="nodelet::Nodelet">
     Generate depth considered mask image out of mask image
   </class>
-  <class name="jsk_pcl/TransformPointcloudInBoundingBox" type="jsk_pcl_ros::TransformPointcloudInBoundingBox"
+  <class name="jsk_pcl/TransformPointcloudInBoundingBox" type="jsk_pcl_ros_utils::TransformPointcloudInBoundingBox"
          base_class_type="nodelet::Nodelet">
     <description>
       transform pointcloud whose origin is the center of bounding box;
     </description>
   </class>
-  <class name="jsk_pcl/DepthImageError" type="jsk_pcl_ros::DepthImageError"
+  <class name="jsk_pcl/DepthImageError" type="jsk_pcl_ros_utils::DepthImageError"
          base_class_type="nodelet::Nodelet">
     <description>compute error of depth image</description>
   </class>
-  <class name="jsk_pcl/DelayPointCloud" type="jsk_pcl_ros::DelayPointCloud"
+  <class name="jsk_pcl/DelayPointCloud" type="jsk_pcl_ros_utils::DelayPointCloud"
          base_class_type="nodelet::Nodelet">
     <description>delay pointcloud messages</description>
   </class>
-  <class name="jsk_pcl/NormalConcatenater" type="jsk_pcl_ros::NormalConcatenater"
+  <class name="jsk_pcl/NormalConcatenater" type="jsk_pcl_ros_utils::NormalConcatenater"
          base_class_type="nodelet::Nodelet">
     <description>Concatenater normal to x, y, z and rgb pointcloud</description>
   </class>
-  <class name="jsk_pcl/TfTransformCloud" type="jsk_pcl_ros::TfTransformCloud"
+  <class name="jsk_pcl/TfTransformCloud" type="jsk_pcl_ros_utils::TfTransformCloud"
          base_class_type="nodelet::Nodelet">
     <description>
       publish transformed cloud with target id
     </description>
   </class>
-  <class name="jsk_pcl/TfTransformBoundingBox" type="jsk_pcl_ros::TfTransformBoundingBox"
+  <class name="jsk_pcl/TfTransformBoundingBox" type="jsk_pcl_ros_utils::TfTransformBoundingBox"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/TfTransformBoundingBoxArray" type="jsk_pcl_ros::TfTransformBoundingBoxArray"
+  <class name="jsk_pcl/TfTransformBoundingBoxArray" type="jsk_pcl_ros_utils::TfTransformBoundingBoxArray"
          base_class_type="nodelet::Nodelet">
   </class>
   <class name="jsk_pcl/NormalFlipToFrame"
-         type="jsk_pcl_ros::NormalFlipToFrame"
+         type="jsk_pcl_ros_utils::NormalFlipToFrame"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/CentroidPublisher" type="jsk_pcl_ros::CentroidPublisher"
+  <class name="jsk_pcl/CentroidPublisher" type="jsk_pcl_ros_utils::CentroidPublisher"
          base_class_type="nodelet::Nodelet">
     <description>
       publish the centroid of the pointcloud to /tf
     </description>
   </class>
   <class name="jsk_pcl/PolygonArrayDistanceLikelihood" 
-         type="jsk_pcl_ros::PolygonArrayDistanceLikelihood"
+         type="jsk_pcl_ros_utils::PolygonArrayDistanceLikelihood"
          base_class_type="nodelet::Nodelet">
   </class>
   <class name="jsk_pcl/PolygonArrayAreaLikelihood" 
-         type="jsk_pcl_ros::PolygonArrayAreaLikelihood"
+         type="jsk_pcl_ros_utils::PolygonArrayAreaLikelihood"
          base_class_type="nodelet::Nodelet">
   </class>
   <class name="jsk_pcl/PolygonArrayAngleLikelihood" 
-         type="jsk_pcl_ros::PolygonArrayAngleLikelihood"
+         type="jsk_pcl_ros_utils::PolygonArrayAngleLikelihood"
          base_class_type="nodelet::Nodelet">
   </class>
   <class name="jsk_pcl/PolygonArrayFootAngleLikelihood" 
-         type="jsk_pcl_ros::PolygonArrayFootAngleLikelihood"
+         type="jsk_pcl_ros_utils::PolygonArrayFootAngleLikelihood"
          base_class_type="nodelet::Nodelet">
   </class>
   <class name="jsk_pcl/PoseWithCovarianceStampedToGaussianPointCloud" 
-         type="jsk_pcl_ros::PoseWithCovarianceStampedToGaussianPointCloud"
+         type="jsk_pcl_ros_utils::PoseWithCovarianceStampedToGaussianPointCloud"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/ColorizeDistanceFromPlane" type="jsk_pcl_ros::ColorizeDistanceFromPlane"
+  <class name="jsk_pcl/ColorizeDistanceFromPlane" type="jsk_pcl_ros_utils::ColorizeDistanceFromPlane"
          base_class_type="nodelet::Nodelet">
     <description>
       colorize pointcloud according to the distance from the nearest plane
     </description>
   </class>
-  <class name="jsk_pcl/ColorizeHeight2DMapping" type="jsk_pcl_ros::ColorizeHeight2DMapping"
+  <class name="jsk_pcl/ColorizeHeight2DMapping" type="jsk_pcl_ros_utils::ColorizeHeight2DMapping"
          base_class_type="nodelet::Nodelet">
     <description>
     </description>
   </class>
   <class name="jsk_pcl/PolygonPointsSampler"
-         type="jsk_pcl_ros::PolygonPointsSampler"
+         type="jsk_pcl_ros_utils::PolygonPointsSampler"
          base_class_type="nodelet::Nodelet">
   </class>
   <class name="jsk_pcl/PolygonFlipper"
-         type="jsk_pcl_ros::PolygonFlipper"
+         type="jsk_pcl_ros_utils::PolygonFlipper"
          base_class_type="nodelet::Nodelet">
   </class>
   <class name="jsk_pcl/PolygonMagnifier"
-         type="jsk_pcl_ros::PolygonMagnifier"
+         type="jsk_pcl_ros_utils::PolygonMagnifier"
          base_class_type="nodelet::Nodelet">
   </class>
   <class name="jsk_pcl/SphericalPointCloudSimulator"
-         type="jsk_pcl_ros::SphericalPointCloudSimulator"
+         type="jsk_pcl_ros_utils::SphericalPointCloudSimulator"
          base_class_type="nodelet::Nodelet">
   </class>
   <class name="jsk_pcl/PlanarPointCloudSimulator"
-         type="jsk_pcl_ros::PlanarPointCloudSimulatorNodelet"
+         type="jsk_pcl_ros_utils::PlanarPointCloudSimulatorNodelet"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/PolygonArrayWrapper" type="jsk_pcl_ros::PolygonArrayWrapper"
+  <class name="jsk_pcl/PolygonArrayWrapper" type="jsk_pcl_ros_utils::PolygonArrayWrapper"
          base_class_type="nodelet::Nodelet">
     <description>
       wrap geometry_msgs::PolygonStamped and pcl_msgs::ModelCoefficients
-      into jsk_pcl_ros::PolygonArray and jsk_pcl_ros::ModelCoefficientsArray
+      into jsk_pcl_ros_utils::PolygonArray and jsk_pcl_ros_utils::ModelCoefficientsArray
     </description>
   </class>
-  <class name="jsk_pcl/PolygonArrayUnwrapper" type="jsk_pcl_ros::PolygonArrayUnwrapper"
+  <class name="jsk_pcl/PolygonArrayUnwrapper" type="jsk_pcl_ros_utils::PolygonArrayUnwrapper"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/PolygonAppender" type="jsk_pcl_ros::PolygonAppender"
+  <class name="jsk_pcl/PolygonAppender" type="jsk_pcl_ros_utils::PolygonAppender"
          base_class_type="nodelet::Nodelet">
     <description>append jsk_pcl_ros/PolygonArray </description>
   </class>
-  <class name="jsk_pcl/PolygonArrayTransformer" type="jsk_pcl_ros::PolygonArrayTransformer"
+  <class name="jsk_pcl/PolygonArrayTransformer" type="jsk_pcl_ros_utils::PolygonArrayTransformer"
          base_class_type="nodelet::Nodelet">
     <description>transform polygons to the specified tf frame</description>
   </class>
-  <class name="jsk_pcl/StaticPolygonArrayPublisher" type="jsk_pcl_ros::StaticPolygonArrayPublisher"
+  <class name="jsk_pcl/StaticPolygonArrayPublisher" type="jsk_pcl_ros_utils::StaticPolygonArrayPublisher"
          base_class_type="nodelet::Nodelet">
     <description>publish some static polygons as jsk_pcl_ros/PolygonArray message</description>
   </class>
-  <class name="jsk_pcl/PlaneRejector" type="jsk_pcl_ros::PlaneRejector"
+  <class name="jsk_pcl/PlaneRejector" type="jsk_pcl_ros_utils::PlaneRejector"
          base_class_type="nodelet::Nodelet">
     <description>rejects the planes which does not satisfy the parameters</description>
   </class>
-    <class name="jsk_pcl/PlaneReasoner" type="jsk_pcl_ros::PlaneReasoner"
+    <class name="jsk_pcl/PlaneReasoner" type="jsk_pcl_ros_utils::PlaneReasoner"
          base_class_type="nodelet::Nodelet">
     <description>
       group polygons into several groups like vertical planes, horizontal planes.
     </description>
   </class>
   <class name="jsk_pcl/PlaneConcatenator"
-         type="jsk_pcl_ros::PlaneConcatenator"
+         type="jsk_pcl_ros_utils::PlaneConcatenator"
          base_class_type="nodelet::Nodelet">
   </class>
   <class name="jsk_pcl/PointCloudToClusterPointIndices"
-         type="jsk_pcl_ros::PointCloudToClusterPointIndices"
+         type="jsk_pcl_ros_utils::PointCloudToClusterPointIndices"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/PointCloudToSTL" type="jsk_pcl_ros::PointCloudToSTL"
+  <class name="jsk_pcl/PointCloudToSTL" type="jsk_pcl_ros_utils::PointCloudToSTL"
          base_class_type="nodelet::Nodelet">
     <description>
     </description>

--- a/jsk_pcl_ros_utils/CMakeLists.txt
+++ b/jsk_pcl_ros_utils/CMakeLists.txt
@@ -160,81 +160,81 @@ else ($ENV{TRAVIS_JOB_ID})
   add_definitions("-O2 -g")
 endif ($ENV{TRAVIS_JOB_ID})
 
-jsk_pcl_util_nodelet(src/normal_flip_to_frame_nodelet.cpp "jsk_pcl/NormalFlipToFrame"
+jsk_pcl_util_nodelet(src/normal_flip_to_frame_nodelet.cpp "jsk_pcl_utils/NormalFlipToFrame"
   "normal_flip_to_frame")
-jsk_pcl_util_nodelet(src/centroid_publisher_nodelet.cpp "jsk_pcl/CentroidPublisher" "centroid_publisher")
+jsk_pcl_util_nodelet(src/centroid_publisher_nodelet.cpp "jsk_pcl_utils/CentroidPublisher" "centroid_publisher")
 jsk_pcl_util_nodelet(src/tf_transform_cloud_nodelet.cpp
-  "jsk_pcl/TfTransformCloud" "tf_transform_cloud")
+  "jsk_pcl_utils/TfTransformCloud" "tf_transform_cloud")
 jsk_pcl_util_nodelet(src/tf_transform_bounding_box_nodelet.cpp
-  "jsk_pcl/TfTransformBoundingBox" "tf_transform_bounding_box")
+  "jsk_pcl_utils/TfTransformBoundingBox" "tf_transform_bounding_box")
 jsk_pcl_util_nodelet(src/tf_transform_bounding_box_array_nodelet.cpp
-  "jsk_pcl/TfTransformBoundingBoxArray" "tf_transform_bounding_box_array")
+  "jsk_pcl_utils/TfTransformBoundingBoxArray" "tf_transform_bounding_box_array")
 jsk_pcl_util_nodelet(src/normal_concatenater_nodelet.cpp
-  "jsk_pcl/NormalConcatenater" "normal_concatenater")
+  "jsk_pcl_utils/NormalConcatenater" "normal_concatenater")
 jsk_pcl_util_nodelet(src/polygon_array_distance_likelihood_nodelet.cpp
-  "jsk_pcl/PolygonArrayDistanceLikelihood" "polygon_array_distance_likelihood")
+  "jsk_pcl_utils/PolygonArrayDistanceLikelihood" "polygon_array_distance_likelihood")
 jsk_pcl_util_nodelet(src/polygon_array_area_likelihood_nodelet.cpp
-  "jsk_pcl/PolygonArrayAreaLikelihood" "polygon_array_area_likelihood")
+  "jsk_pcl_utils/PolygonArrayAreaLikelihood" "polygon_array_area_likelihood")
 jsk_pcl_util_nodelet(src/polygon_array_angle_likelihood_nodelet.cpp
-  "jsk_pcl/PolygonArrayAngleLikelihood" "polygon_array_angle_likelihood")
+  "jsk_pcl_utils/PolygonArrayAngleLikelihood" "polygon_array_angle_likelihood")
 jsk_pcl_util_nodelet(src/polygon_array_foot_angle_likelihood_nodelet.cpp
-  "jsk_pcl/PolygonArrayFootAngleLikelihood" "polygon_array_foot_angle_likelihood")
+  "jsk_pcl_utils/PolygonArrayFootAngleLikelihood" "polygon_array_foot_angle_likelihood")
 jsk_pcl_util_nodelet(src/pose_with_covariance_stamped_to_gaussian_pointcloud_nodelet.cpp
-  "jsk_pcl/PoseWithCovarianceStampedToGaussianPointCloud" "pose_with_covariance_stamped_to_gaussian_pointcloud")
+  "jsk_pcl_utils/PoseWithCovarianceStampedToGaussianPointCloud" "pose_with_covariance_stamped_to_gaussian_pointcloud")
 jsk_pcl_util_nodelet(src/spherical_pointcloud_simulator_nodelet.cpp
-  "jsk_pcl/SphericalPointCloudSimulator" "spherical_pointcloud_simulator")
+  "jsk_pcl_utils/SphericalPointCloudSimulator" "spherical_pointcloud_simulator")
 jsk_pcl_util_nodelet(src/polygon_flipper_nodelet.cpp
-  "jsk_pcl/PolygonFlipper" "polygon_flipper")
+  "jsk_pcl_utils/PolygonFlipper" "polygon_flipper")
 jsk_pcl_util_nodelet(src/polygon_points_sampler_nodelet.cpp
-  "jsk_pcl/PolygonPointsSampler" "polygon_points_sampler")
+  "jsk_pcl_utils/PolygonPointsSampler" "polygon_points_sampler")
 jsk_pcl_util_nodelet(src/polygon_magnifier_nodelet.cpp
-  "jsk_pcl/PolygonMagnifier" "polygon_magnifier")
+  "jsk_pcl_utils/PolygonMagnifier" "polygon_magnifier")
 jsk_pcl_util_nodelet(src/planar_pointcloud_simulator_nodelet.cpp
-  "jsk_pcl/PlanarPointCloudSimulator" "planar_pointcloud_simulator")
+  "jsk_pcl_utils/PlanarPointCloudSimulator" "planar_pointcloud_simulator")
 jsk_pcl_util_nodelet(src/plane_rejector_nodelet.cpp
-  "jsk_pcl/PlaneRejector" "plane_rejector")
+  "jsk_pcl_utils/PlaneRejector" "plane_rejector")
 jsk_pcl_util_nodelet(src/pointcloud_to_cluster_point_indices_nodelet.cpp
-  "jsk_pcl/PointCloudToClusterPointIndices" "pointcloud_to_cluster_point_indices")
+  "jsk_pcl_utils/PointCloudToClusterPointIndices" "pointcloud_to_cluster_point_indices")
 jsk_pcl_util_nodelet(src/static_polygon_array_publisher_nodelet.cpp
-  "jsk_pcl/StaticPolygonArrayPublisher" "static_polygon_array_publisher")
+  "jsk_pcl_utils/StaticPolygonArrayPublisher" "static_polygon_array_publisher")
 jsk_pcl_util_nodelet(src/polygon_array_transformer_nodelet.cpp
-  "jsk_pcl/PolygonArrayTransformer" "polygon_array_transformer")
+  "jsk_pcl_utils/PolygonArrayTransformer" "polygon_array_transformer")
 jsk_pcl_util_nodelet(src/pointcloud_to_stl_nodelet.cpp
-  "jsk_pcl/PointCloudToSTL" "pointcloud_to_stl")
+  "jsk_pcl_utils/PointCloudToSTL" "pointcloud_to_stl")
 jsk_pcl_util_nodelet(src/polygon_appender_nodelet.cpp
-  "jsk_pcl/PolygonAppender" "polygon_appender")
+  "jsk_pcl_utils/PolygonAppender" "polygon_appender")
 jsk_pcl_util_nodelet(src/delay_pointcloud_nodelet.cpp
-  "jsk_pcl/DelayPointCloud" "delay_pointcloud")
+  "jsk_pcl_utils/DelayPointCloud" "delay_pointcloud")
 jsk_pcl_util_nodelet(src/depth_image_error_nodelet.cpp
-  "jsk_pcl/DepthImageError" "depth_image_error")
+  "jsk_pcl_utils/DepthImageError" "depth_image_error")
 jsk_pcl_util_nodelet(src/polygon_array_wrapper_nodelet.cpp
-  "jsk_pcl/PolygonArrayWrapper" "polygon_array_wrapper")
+  "jsk_pcl_utils/PolygonArrayWrapper" "polygon_array_wrapper")
 jsk_pcl_util_nodelet(src/polygon_array_unwrapper_nodelet.cpp
-  "jsk_pcl/PolygonArrayUnwrapper" "polygon_array_unwrapper")
+  "jsk_pcl_utils/PolygonArrayUnwrapper" "polygon_array_unwrapper")
 jsk_pcl_util_nodelet(src/colorize_distance_from_plane_nodelet.cpp
-  "jsk_pcl/ColorizeDistanceFromPlane" "colorize_distance_from_plane")
+  "jsk_pcl_utils/ColorizeDistanceFromPlane" "colorize_distance_from_plane")
 jsk_pcl_util_nodelet(src/colorize_height_2d_mapping_nodelet.cpp
-  "jsk_pcl/ColorizeHeight2DMapping" "colorize_height_2d_mapping")
+  "jsk_pcl_utils/ColorizeHeight2DMapping" "colorize_height_2d_mapping")
 jsk_pcl_util_nodelet(src/plane_reasoner_nodelet.cpp
-  "jsk_pcl/PlaneReasoner" "plane_reasoner")
+  "jsk_pcl_utils/PlaneReasoner" "plane_reasoner")
 jsk_pcl_util_nodelet(src/transform_pointcloud_in_bounding_box_nodelet.cpp
-  "jsk_pcl/TransformPointcloudInBoundingBox" "transform_pointcloud_in_bounding_box")
+  "jsk_pcl_utils/TransformPointcloudInBoundingBox" "transform_pointcloud_in_bounding_box")
 jsk_pcl_util_nodelet(src/point_indices_to_mask_image_nodelet.cpp
-  "jsk_pcl/PointIndicesToMaskImage" "point_indices_to_mask_image")
+  "jsk_pcl_utils/PointIndicesToMaskImage" "point_indices_to_mask_image")
 jsk_pcl_util_nodelet(src/mask_image_to_depth_considered_mask_image_nodelet.cpp
-  "jsk_pcl/MaskImageToDepthConsideredMaskImage" "mask_image_to_depth_considered_mask_image")
+  "jsk_pcl_utils/MaskImageToDepthConsideredMaskImage" "mask_image_to_depth_considered_mask_image")
 jsk_pcl_util_nodelet(src/mask_image_to_point_indices_nodelet.cpp
-  "jsk_pcl/MaskImageToPointIndices" "mask_image_to_point_indices")
+  "jsk_pcl_utils/MaskImageToPointIndices" "mask_image_to_point_indices")
 jsk_pcl_util_nodelet(src/label_to_cluster_point_indices_nodelet.cpp
-  "jsk_pcl/LabelToClusterPointIndices" "label_to_cluster_point_indices")
+  "jsk_pcl_utils/LabelToClusterPointIndices" "label_to_cluster_point_indices")
 jsk_pcl_util_nodelet(src/plane_concatenator_nodelet.cpp
-  "jsk_pcl/PlaneConcatenator" "plane_concatenator")
+  "jsk_pcl_utils/PlaneConcatenator" "plane_concatenator")
 jsk_pcl_util_nodelet(src/add_point_indices_nodelet.cpp
-  "jsk_pcl/AddPointIndices" "add_point_indices")
+  "jsk_pcl_utils/AddPointIndices" "add_point_indices")
 jsk_pcl_util_nodelet(src/pcd_reader_with_pose_nodelet.cpp
-  "jsk_pcl/PCDReaderWithPose" "pcd_reader_with_pose")
+  "jsk_pcl_utils/PCDReaderWithPose" "pcd_reader_with_pose")
 jsk_pcl_util_nodelet(src/pointcloud_relative_from_pose_stamped_nodelet.cpp
-  "jsk_pcl/PointCloudRelativeFromPoseStamped" "pointcloud_relative_from_pose_stamped")
+  "jsk_pcl_utils/PointCloudRelativeFromPoseStamped" "pointcloud_relative_from_pose_stamped")
 add_library(jsk_pcl_ros_utils SHARED ${jsk_pcl_util_nodelet_sources})
 add_dependencies(jsk_pcl_ros_utils ${PROJECT_NAME}_gencpp ${PROJECT_NAME}_gencfg)
 target_link_libraries(jsk_pcl_ros_utils

--- a/jsk_pcl_ros_utils/jsk_pcl_nodelets.xml
+++ b/jsk_pcl_ros_utils/jsk_pcl_nodelets.xml
@@ -1,169 +1,169 @@
 <library path="libjsk_pcl_ros_utils">
-  <class name="jsk_pcl/PCDReaderWithPose" type="jsk_pcl_ros_utils::PCDReaderWithPose"
+  <class name="jsk_pcl_utils/PCDReaderWithPose" type="jsk_pcl_ros_utils::PCDReaderWithPose"
          base_class_type="nodelet::Nodelet">
     <description>
       reconstract template pointcloud with recognized_pose
     </description>
   </class>
-  <class name="jsk_pcl/AddPointIndices"
+  <class name="jsk_pcl_utils/AddPointIndices"
          type="jsk_pcl_ros_utils::AddPointIndices"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/MaskImageToPointIndices"
+  <class name="jsk_pcl_utils/MaskImageToPointIndices"
          type="jsk_pcl_ros_utils::MaskImageToPointIndices"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/LabelToClusterPointIndices"
+  <class name="jsk_pcl_utils/LabelToClusterPointIndices"
          type="jsk_pcl_ros_utils::LabelToClusterPointIndices"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/MaskImageToDepthConsideredMaskImage"
+  <class name="jsk_pcl_utils/MaskImageToDepthConsideredMaskImage"
          type="jsk_pcl_ros_utils::MaskImageToDepthConsideredMaskImage"
          base_class_type="nodelet::Nodelet">
     Generate depth considered mask image out of mask image
   </class>
-  <class name="jsk_pcl/TransformPointcloudInBoundingBox" type="jsk_pcl_ros_utils::TransformPointcloudInBoundingBox"
+  <class name="jsk_pcl_utils/TransformPointcloudInBoundingBox" type="jsk_pcl_ros_utils::TransformPointcloudInBoundingBox"
          base_class_type="nodelet::Nodelet">
     <description>
       transform pointcloud whose origin is the center of bounding box;
     </description>
   </class>
-  <class name="jsk_pcl/PointIndicesToMaskImage"
+  <class name="jsk_pcl_utils/PointIndicesToMaskImage"
          type="jsk_pcl_ros_utils::PointIndicesToMaskImage"
          base_class_type="nodelet::Nodelet">
     Generate mask image out of point indices
   </class>
-  <class name="jsk_pcl/DepthImageError" type="jsk_pcl_ros_utils::DepthImageError"
+  <class name="jsk_pcl_utils/DepthImageError" type="jsk_pcl_ros_utils::DepthImageError"
          base_class_type="nodelet::Nodelet">
     <description>compute error of depth image</description>
   </class>
-  <class name="jsk_pcl/DelayPointCloud" type="jsk_pcl_ros_utils::DelayPointCloud"
+  <class name="jsk_pcl_utils/DelayPointCloud" type="jsk_pcl_ros_utils::DelayPointCloud"
          base_class_type="nodelet::Nodelet">
     <description>delay pointcloud messages</description>
   </class>
-  <class name="jsk_pcl/NormalConcatenater" type="jsk_pcl_ros_utils::NormalConcatenater"
+  <class name="jsk_pcl_utils/NormalConcatenater" type="jsk_pcl_ros_utils::NormalConcatenater"
          base_class_type="nodelet::Nodelet">
     <description>Concatenater normal to x, y, z and rgb pointcloud</description>
   </class>
-  <class name="jsk_pcl/TfTransformCloud" type="jsk_pcl_ros_utils::TfTransformCloud"
+  <class name="jsk_pcl_utils/TfTransformCloud" type="jsk_pcl_ros_utils::TfTransformCloud"
          base_class_type="nodelet::Nodelet">
     <description>
       publish transformed cloud with target id
     </description>
   </class>
-  <class name="jsk_pcl/TfTransformBoundingBox" type="jsk_pcl_ros_utils::TfTransformBoundingBox"
+  <class name="jsk_pcl_utils/TfTransformBoundingBox" type="jsk_pcl_ros_utils::TfTransformBoundingBox"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/TfTransformBoundingBoxArray" type="jsk_pcl_ros_utils::TfTransformBoundingBoxArray"
+  <class name="jsk_pcl_utils/TfTransformBoundingBoxArray" type="jsk_pcl_ros_utils::TfTransformBoundingBoxArray"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/NormalFlipToFrame"
+  <class name="jsk_pcl_utils/NormalFlipToFrame"
          type="jsk_pcl_ros_utils::NormalFlipToFrame"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/CentroidPublisher" type="jsk_pcl_ros_utils::CentroidPublisher"
+  <class name="jsk_pcl_utils/CentroidPublisher" type="jsk_pcl_ros_utils::CentroidPublisher"
          base_class_type="nodelet::Nodelet">
     <description>
       publish the centroid of the pointcloud to /tf
     </description>
   </class>
-  <class name="jsk_pcl/PolygonArrayDistanceLikelihood" 
+  <class name="jsk_pcl_utils/PolygonArrayDistanceLikelihood" 
          type="jsk_pcl_ros_utils::PolygonArrayDistanceLikelihood"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/PolygonArrayAreaLikelihood" 
+  <class name="jsk_pcl_utils/PolygonArrayAreaLikelihood" 
          type="jsk_pcl_ros_utils::PolygonArrayAreaLikelihood"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/PolygonArrayAngleLikelihood" 
+  <class name="jsk_pcl_utils/PolygonArrayAngleLikelihood" 
          type="jsk_pcl_ros_utils::PolygonArrayAngleLikelihood"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/PolygonArrayFootAngleLikelihood" 
+  <class name="jsk_pcl_utils/PolygonArrayFootAngleLikelihood" 
          type="jsk_pcl_ros_utils::PolygonArrayFootAngleLikelihood"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/PoseWithCovarianceStampedToGaussianPointCloud" 
+  <class name="jsk_pcl_utils/PoseWithCovarianceStampedToGaussianPointCloud" 
          type="jsk_pcl_ros_utils::PoseWithCovarianceStampedToGaussianPointCloud"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/ColorizeDistanceFromPlane" type="jsk_pcl_ros_utils::ColorizeDistanceFromPlane"
+  <class name="jsk_pcl_utils/ColorizeDistanceFromPlane" type="jsk_pcl_ros_utils::ColorizeDistanceFromPlane"
          base_class_type="nodelet::Nodelet">
     <description>
       colorize pointcloud according to the distance from the nearest plane
     </description>
   </class>
-  <class name="jsk_pcl/ColorizeHeight2DMapping" type="jsk_pcl_ros_utils::ColorizeHeight2DMapping"
+  <class name="jsk_pcl_utils/ColorizeHeight2DMapping" type="jsk_pcl_ros_utils::ColorizeHeight2DMapping"
          base_class_type="nodelet::Nodelet">
     <description>
     </description>
   </class>
-  <class name="jsk_pcl/PolygonPointsSampler"
+  <class name="jsk_pcl_utils/PolygonPointsSampler"
          type="jsk_pcl_ros_utils::PolygonPointsSampler"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/PolygonFlipper"
+  <class name="jsk_pcl_utils/PolygonFlipper"
          type="jsk_pcl_ros_utils::PolygonFlipper"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/PolygonMagnifier"
+  <class name="jsk_pcl_utils/PolygonMagnifier"
          type="jsk_pcl_ros_utils::PolygonMagnifier"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/SphericalPointCloudSimulator"
+  <class name="jsk_pcl_utils/SphericalPointCloudSimulator"
          type="jsk_pcl_ros_utils::SphericalPointCloudSimulator"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/PlanarPointCloudSimulator"
+  <class name="jsk_pcl_utils/PlanarPointCloudSimulator"
          type="jsk_pcl_ros_utils::PlanarPointCloudSimulatorNodelet"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/PolygonArrayWrapper" type="jsk_pcl_ros_utils::PolygonArrayWrapper"
+  <class name="jsk_pcl_utils/PolygonArrayWrapper" type="jsk_pcl_ros_utils::PolygonArrayWrapper"
          base_class_type="nodelet::Nodelet">
     <description>
       wrap geometry_msgs::PolygonStamped and pcl_msgs::ModelCoefficients
       into jsk_pcl_ros_utils::PolygonArray and jsk_pcl_ros_utils::ModelCoefficientsArray
     </description>
   </class>
-  <class name="jsk_pcl/PolygonArrayUnwrapper" type="jsk_pcl_ros_utils::PolygonArrayUnwrapper"
+  <class name="jsk_pcl_utils/PolygonArrayUnwrapper" type="jsk_pcl_ros_utils::PolygonArrayUnwrapper"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/PolygonAppender" type="jsk_pcl_ros_utils::PolygonAppender"
+  <class name="jsk_pcl_utils/PolygonAppender" type="jsk_pcl_ros_utils::PolygonAppender"
          base_class_type="nodelet::Nodelet">
     <description>append jsk_pcl_ros/PolygonArray </description>
   </class>
-  <class name="jsk_pcl/PolygonArrayTransformer" type="jsk_pcl_ros_utils::PolygonArrayTransformer"
+  <class name="jsk_pcl_utils/PolygonArrayTransformer" type="jsk_pcl_ros_utils::PolygonArrayTransformer"
          base_class_type="nodelet::Nodelet">
     <description>transform polygons to the specified tf frame</description>
   </class>
-  <class name="jsk_pcl/StaticPolygonArrayPublisher" type="jsk_pcl_ros_utils::StaticPolygonArrayPublisher"
+  <class name="jsk_pcl_utils/StaticPolygonArrayPublisher" type="jsk_pcl_ros_utils::StaticPolygonArrayPublisher"
          base_class_type="nodelet::Nodelet">
     <description>publish some static polygons as jsk_pcl_ros/PolygonArray message</description>
   </class>
-  <class name="jsk_pcl/PlaneRejector" type="jsk_pcl_ros_utils::PlaneRejector"
+  <class name="jsk_pcl_utils/PlaneRejector" type="jsk_pcl_ros_utils::PlaneRejector"
          base_class_type="nodelet::Nodelet">
     <description>rejects the planes which does not satisfy the parameters</description>
   </class>
-    <class name="jsk_pcl/PlaneReasoner" type="jsk_pcl_ros_utils::PlaneReasoner"
+    <class name="jsk_pcl_utils/PlaneReasoner" type="jsk_pcl_ros_utils::PlaneReasoner"
          base_class_type="nodelet::Nodelet">
     <description>
       group polygons into several groups like vertical planes, horizontal planes.
     </description>
   </class>
-  <class name="jsk_pcl/PlaneConcatenator"
+  <class name="jsk_pcl_utils/PlaneConcatenator"
          type="jsk_pcl_ros_utils::PlaneConcatenator"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/PointCloudToClusterPointIndices"
+  <class name="jsk_pcl_utils/PointCloudToClusterPointIndices"
          type="jsk_pcl_ros_utils::PointCloudToClusterPointIndices"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl/PointCloudToSTL" type="jsk_pcl_ros_utils::PointCloudToSTL"
+  <class name="jsk_pcl_utils/PointCloudToSTL" type="jsk_pcl_ros_utils::PointCloudToSTL"
          base_class_type="nodelet::Nodelet">
     <description>
     </description>
   </class>
-  <class name="jsk_pcl/PointCloudRelativeFromPoseStamped" type="jsk_pcl_ros_utils::PointCloudRelativeFromPoseStamped"
+  <class name="jsk_pcl_utils/PointCloudRelativeFromPoseStamped" type="jsk_pcl_ros_utils::PointCloudRelativeFromPoseStamped"
          base_class_type="nodelet::Nodelet">
     <description>
     </description>


### PR DESCRIPTION
## Problem
When I run nodelets defined in jsk_pcl_ros_utils like colorize_distance_from_plane, nodelets abort with following errors. 
```
$ rosrun jsk_pcl_ros colorize_distance_from_plane
[ INFO] [1453269719.926632252]: Initializing nodelet with 4 worker threads.
[ERROR] [1453269720.344240963]: Failed to load nodelet [/colorize_distance_from_plane] of type [jsk_pcl/ColorizeDistanceFromPlane] even after refreshing the cache: MultiLibraryClassLoader: Could not create object of class type jsk_pcl_ros::ColorizeDistanceFromPlane as no factory exists for it. Make sure that the library exists and was explicitly loaded through MultiLibraryClassLoader::loadLibrary()
[ERROR] [1453269720.344310564]: The error before refreshing the cache was: MultiLibraryClassLoader: Could not create object of class type jsk_pcl_ros::ColorizeDistanceFromPlane as no factory exists for it. Make sure that the library exists and was explicitly loaded through MultiLibraryClassLoader::loadLibrary()
```
This error also occurs when  `rosrun nodelet nodelet standalone colorize_distance_from_plane` and nodelets are defined in launch files.
This error is similar to https://github.com/jsk-ros-pkg/jsk_recognition/issues/1482 , but in this case errors are reproduced whether I wait 60sec or not.

## Environments
This error occured in following environments.
- my laptop (ubuntu14.04 + indigo)
- hrp2007 auditor (ubuntu 12.04 + hydro)

However, this error did not occur in following environments.
- hrp2007v (ubuntu 12.04 + hydro)
- my desktop (ubuntu 12.04 + hydro)

In all environments, `catkin clean -a`, `git pull`  and `catkin bt` are executed in master branch of jsk_recognition.

## Possible solutions
I think this problem is caused by difference of namespace in which nodelets are defined.
In the jsk_pcl_ros_utils package, nodelets are defined in jsk_pcl_ros_utils namespace but in jsk_pcl_nodelets.xml of jsk_pcl_ros, these nodelets are defined as jsk_pcl_ros namespace.
Therefore, I fix this difference in this PR by following solutions:
- Use `jsk_pcl_ros_utils::Hoge` instead of `jsk_pcl_ros::Hoge` for type of nodelets in jsk_pcl_nodelets.xml in jsk_pcl_ros to correct namespace
- Use `jsk_pcl/Hoge` as name of nodelets for backward compatibility in jsk_pcl_ros
- Use `jsk_pcl_utils/Hoge` as name of nodelets in jsk_pcl_ros_utils to avoid collision of name. 
- Use `jsk_pcl_utils/Hoge` to pass single_nodelet_exec.cpp.in in jsk_pcl_ros_utils and `jsk_pcl/Hoge` in jsk_pcl_ros.

In hrp2007 auditor and my laptop, this PR solved above problem.
However, I don't have certainty for this PR and I want for this PR to be checked carefully by exparts.

## Remaining questions
I'm not sure why hrp2007v and my desktop can run `rosrun jsk_pcl_ros colorize_distance_from_plane` without this PR.
One possible answer is order of loading nodelets, which means if `jsk_pcl/Hoge` defined in jsk_pcl_ros_utils is loaded first, it is correctly loaded because its type is `jsk_pcl_ros_utils::Hoge` but if `jsk_pcl/Hoge` defined in jsk_pcl_ros is loaded first, it fails because its type is `jsk_pcl_ros::Hoge`.
However, I could not check this hypothesis because I do not know loading order of nodelets.
