### PR TITLE
[jsk_pcl_ros] Automatically detect point type in OctreeVoxelGrid

### DIFF
--- a/doc/jsk_pcl_ros/nodes/octree_voxel_grid.md
+++ b/doc/jsk_pcl_ros/nodes/octree_voxel_grid.md
@@ -37,10 +37,6 @@ and other voxel filtered functions output the other position such as the centroi
 * `~resolution` (Double, default: `0.1`):
 
    Resolution of voxel grid. If resolution is set as 0, it just relays input pointcloud.
-* `~point_type` (String, default: `xyz`):
-
-  Choose point type from xyz, xyzrgb, xyznormal and xyzrgbnormal.
-
 * `~marker_color` (String, default: `z`)
 
   Method to decide color of marker. z, x, y or flat can be selected.

--- a/jsk_pcl_ros/cfg/OctreeVoxelGrid.cfg
+++ b/jsk_pcl_ros/cfg/OctreeVoxelGrid.cfg
@@ -13,12 +13,6 @@ except:
 
 gen = ParameterGenerator ()
 gen.add("resolution", double_t, 0, "resolution of voxel grid", 0.1, 0.0, 1.0)
-point_enum = gen.enum([gen.const("xyz", str_t, "xyz", "xyz"),
-                       gen.const("xyznormal", str_t, "xyznormal", "xyznormal"),
-                       gen.const("xyzrgb", str_t, "xyzrgb", "xyzrgb"),
-                       gen.const("xyzrgbnornal", str_t, "xyzrgbnornal", "xyzrgbnornal")],
-                      "point")
-gen.add("point_type", str_t, 0, "point type", "xyz", edit_method=point_enum)
 gen.add("publish_marker", bool_t, 0, "publish marker", True)
 marker_color_enum = gen.enum([gen.const("flat", str_t, "flat", "flat"),
                               gen.const("z", str_t, "z", "z"),

--- a/jsk_pcl_ros/include/jsk_pcl_ros/octree_voxel_grid.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/octree_voxel_grid.h
@@ -78,7 +78,6 @@ namespace jsk_pcl_ros
     double marker_color_alpha_;
     
     bool publish_marker_flag_;
-    std::string point_type_;
     std::string marker_color_;
   };
 }

--- a/jsk_pcl_ros/src/octree_voxel_grid_nodelet.cpp
+++ b/jsk_pcl_ros/src/octree_voxel_grid_nodelet.cpp
@@ -38,6 +38,7 @@
 #include <std_msgs/Float32.h>
 #include <jsk_topic_tools/color_utils.h>
 #include <pcl/common/common.h>
+#include <jsk_recognition_utils/pcl_ros_util.h>
 
 namespace jsk_pcl_ros
 {
@@ -121,20 +122,22 @@ namespace jsk_pcl_ros
       
     }
     else {
-      if (point_type_ == "xyz") {
-        generateVoxelCloudImpl<pcl::PointXYZ>(input_msg);
-      }
-      else if (point_type_ == "xyznormal") {
-        generateVoxelCloudImpl<pcl::PointNormal>(input_msg);
-      }
-      else if (point_type_ == "xyzrgb") {
-        generateVoxelCloudImpl<pcl::PointXYZRGB>(input_msg);
-      }
-      else if (point_type_ == "xyzrgbnormal") {
+      if (jsk_recognition_utils::hasField("rgb", *input_msg) &&
+          jsk_recognition_utils::hasField("normal_x", *input_msg) &&
+          jsk_recognition_utils::hasField("normal_y", *input_msg) &&
+          jsk_recognition_utils::hasField("normal_z", *input_msg)) {
         generateVoxelCloudImpl<pcl::PointXYZRGBNormal>(input_msg);
       }
+      else if (jsk_recognition_utils::hasField("rgb", *input_msg)) {
+        generateVoxelCloudImpl<pcl::PointXYZRGB>(input_msg);
+      }
+      else if (jsk_recognition_utils::hasField("normal_x", *input_msg) &&
+               jsk_recognition_utils::hasField("normal_y", *input_msg) &&
+               jsk_recognition_utils::hasField("normal_z", *input_msg)) {
+        generateVoxelCloudImpl<pcl::PointNormal>(input_msg);
+      }
       else {
-        JSK_NODELET_ERROR("unknown point type: %s", point_type_.c_str());
+        generateVoxelCloudImpl<pcl::PointXYZ>(input_msg);
       }
     }
     std_msgs::Float32 resolution;
@@ -156,7 +159,6 @@ namespace jsk_pcl_ros
   {
     boost::mutex::scoped_lock lock(mutex_);
     resolution_ = config.resolution;
-    point_type_ = config.point_type;
     publish_marker_flag_ = config.publish_marker;
     marker_color_ = config.marker_color;
     marker_color_alpha_ = config.marker_color_alpha;

--- a/jsk_recognition_utils/include/jsk_recognition_utils/pcl_ros_util.h
+++ b/jsk_recognition_utils/include/jsk_recognition_utils/pcl_ros_util.h
@@ -46,6 +46,7 @@
 #include <pcl_msgs/PointIndices.h>
 
 #include <pcl/PointIndices.h>
+#include <sensor_msgs/PointCloud2.h>
 
 namespace jsk_recognition_utils
 {
@@ -63,7 +64,12 @@ namespace jsk_recognition_utils
    * Return true if a and b are the same frame_id
    */
   bool isSameFrameId(const std::string& a, const std::string& b);
-                     
+
+  /**
+   * @brief
+   * check if sensor_msgs/PointCloud2 message has the specified field.
+   */
+  bool hasField(const std::string& field_name, const sensor_msgs::PointCloud2& msg);
 }
 
 #endif

--- a/jsk_recognition_utils/src/pcl_ros_util.cpp
+++ b/jsk_recognition_utils/src/pcl_ros_util.cpp
@@ -67,4 +67,15 @@ namespace jsk_recognition_utils
     }
     return aa == bb;
   }
+
+  bool hasField(const std::string& field_name, const sensor_msgs::PointCloud2& msg)
+  {
+    for (size_t i = 0; i < msg.fields.size(); i++) {
+      sensor_msgs::PointField field = msg.fields[i];
+      if (field.name == field_name) {
+        return true;
+      }
+    }
+    return false;
+  }
 }


### PR DESCRIPTION
Modified:
  - doc/jsk_pcl_ros/nodes/octree_voxel_grid.md
  - jsk_pcl_ros/cfg/OctreeVoxelGrid.cfg
  - jsk_pcl_ros/include/jsk_pcl_ros/octree_voxel_grid.h
  - jsk_pcl_ros/src/octree_voxel_grid_nodelet.cpp
  - jsk_recognition_utils/include/jsk_recognition_utils/pcl_ros_util.h
  - jsk_recognition_utils/src/pcl_ros_util.cpp