### PR TITLE
[jsk_pcl_ros] List missing PointIndicesToMaskImage as nodelet

### DIFF
--- a/jsk_pcl_ros/jsk_pcl_nodelets.xml
+++ b/jsk_pcl_ros/jsk_pcl_nodelets.xml
@@ -13,6 +13,11 @@
          type="jsk_pcl_ros_utils::MaskImageToPointIndices"
          base_class_type="nodelet::Nodelet">
   </class>
+  <class name="jsk_pcl/PointIndicesToMaskImage"
+         type="jsk_pcl_ros_utils::PointIndicesToMaskImage"
+         base_class_type="nodelet::Nodelet">
+    Generate mask image out of point indices
+  </class>
   <class name="jsk_pcl/MaskImageToDepthConsideredMaskImage"
          type="jsk_pcl_ros_utils::MaskImageToDepthConsideredMaskImage"
          base_class_type="nodelet::Nodelet">


### PR DESCRIPTION
this node is moved to jsk_pcl_ros_utils
but this is necessary for compatibility.

Modified:
  - jsk_pcl_ros/jsk_pcl_nodelets.xml