### PR TITLE
[jsk_perception] Call one of find_package or pkg_check_modules for robot_self_filter

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -371,8 +371,12 @@ jsk_pcl_util_nodelet_deprecated(src/pcd_reader_with_pose_nodelet.cpp
   "jsk_pcl/PCDReaderWithPose" "pcd_reader_with_pose")
 jsk_pcl_nodelet(src/octree_voxel_grid_nodelet.cpp
   "jsk_pcl/OctreeVoxelGrid" "octree_voxel_grid")
-# check existence of robot_self_filter package because robot_self_filter is not installed by apt
-pkg_check_modules(robot_self_filter robot_self_filter QUIET)
+# robot_self_filter is released on version greater than indigo
+find_package(robot_self_filter QUIET)
+if(NOT robot_self_filter_FOUND)
+  # check existence of robot_self_filter package because robot_self_filter is not installed by apt on version less than indigo
+  pkg_check_modules(robot_self_filter robot_self_filter QUIET)
+endif()
 if(robot_self_filter_FOUND)
   jsk_pcl_nodelet(src/collision_detector_nodelet.cpp
     "jsk_pcl/CollisionDetector" "collision_detector")

--- a/jsk_perception/CMakeLists.txt
+++ b/jsk_perception/CMakeLists.txt
@@ -40,10 +40,6 @@ execute_process(
   COMMAND python -c "import sys; sys.exit(ord('$ENV{ROS_DISTRO}'[0]) >= ord('indigo'[0]))"
   RESULT_VARIABLE DISTRO_GE_INDIGO
 )
-if(DISTRO_GE_INDIGO)
-  # robot_self_filter is released on version greater than indigo
-  find_package(robot_self_filter)
-endif()
 
 find_package(Boost REQUIRED COMPONENTS filesystem system signals)
 
@@ -189,20 +185,14 @@ jsk_perception_nodelet(src/kmeans.cpp "jsk_perception/KMeans" "kmeans")
 jsk_perception_nodelet(src/tabletop_color_difference_likelihood.cpp "jsk_perception/TabletopColorDifferenceLikelihood" "tabletop_color_difference_likelihood")
 jsk_perception_nodelet(src/saliency_map_generator_node.cpp "jsk_perception/SaliencyMapGenerator" "saliency_map_generator")
 
-# check existence of robot_self_filter package because robot_self_filter is not installed by apt
-find_package(PkgConfig)
-pkg_check_modules(robot_self_filter robot_self_filter QUIET)
-##
-execute_process(COMMAND lsb_release -cs OUTPUT_VARIABLE LSB_RELEASE_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
-if("${LSB_RELESE_VERSION}" STREQUAL "utopic" OR "${LSB_RELESE_VERSION}" STREQUAL "vivid")
-  set(robot_self_filter_LIBRARIES2)
-  foreach(lib ${robot_self_filter_LIBRARIES})
-    string(REPLACE ":/" "/" lib ${lib})
-    list(APPEND robot_self_filter_LIBRARIES2 ${lib})
-  endforeach()
-  set(robot_self_filter_LIBRARIES ${robot_self_filter_LIBRARIES2})
+# robot_self_filter is released on version greater than indigo
+find_package(robot_self_filter QUIET)
+if(NOT robot_self_filter_FOUND)
+  # check existence of robot_self_filter package because robot_self_filter is not installed by apt on version less than indigo
+  find_package(PkgConfig)
+  pkg_check_modules(robot_self_filter robot_self_filter QUIET)
 endif()
-##
+
 if(robot_self_filter_FOUND)
   message(AUTHOR_WARNING "robot_self_filter is found.")
   jsk_perception_nodelet(src/robot_to_mask_image.cpp "jsk_perception/RobotToMaskImage" "robot_to_mask_image")


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/jsk_recognition/pull/1528 を見ていて，
indigo以降では，
`find_package(robot_self_filter)`と`pkg_check_modules(robot_self_filter robot_self_filter QUIET)`が
両方呼ばれるようになってしまっていて，悪さをしている気がしました．
https://github.com/jsk-ros-pkg/jsk_recognition/blob/master/jsk_perception/CMakeLists.txt#L45
https://github.com/jsk-ros-pkg/jsk_recognition/blob/master/jsk_perception/CMakeLists.txt#L194

https://travis-ci.org/mmurooka/jsk_recognition/builds/107934581で
JSKのtravisテストは通ることは確認しましたが，
UとVのdeb用のbuildも確認することはできるでしょうか．