### PR TITLE
Remove octomap_mapping from rosinstall on travis testing

### DIFF
--- a/.travis.rosinstall.jade
+++ b/.travis.rosinstall.jade
@@ -2,7 +2,3 @@
     uri: https://github.com/sniekum/ml_classifiers.git
     local-name: sniekum/ml_classifiers
     version: master
-- git:
-    uri: https://github.com/OctoMap/octomap_mapping.git
-    local-name: Octomap/octomap_server
-    version: master


### PR DESCRIPTION
Closes #1414

Because ros-jade-octomap-mapping and ros-jade-octomap-server is
released.

Modified:
  - .travis.rosinstall.jade