### PR TITLE
Specify version of ml_classifiers for travis testing

### DIFF
--- a/.travis.rosinstall.jade
+++ b/.travis.rosinstall.jade
@@ -1,7 +1,7 @@
 - git:
     uri: https://github.com/sniekum/ml_classifiers.git
     local-name: sniekum/ml_classifiers
-    version: master
+    version: ef8fd55e8ce97cbf45e16757c0efa4cdb5693bc8
 - git:
     uri: https://github.com/OctoMap/octomap_mapping.git
     local-name: Octomap/octomap_server


### PR DESCRIPTION
For stable testing.

Modified:
  - .travis.rosinstall.jade