### PR TITLE
Specify version of jsk_common==2.0.11 for stable testing

### DIFF
--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,7 +1,7 @@
 - git:
     uri: https://github.com/jsk-ros-pkg/jsk_common.git
     local-name: jsk-ros-pkg/jsk_common
-    version: master
+    version: 2.0.11
 # - git:
 #     uri: https://github.com/jsk-ros-pkg/jsk_roseus.git
 #     local-name: jsk-ros-pkg/jsk_roseus


### PR DESCRIPTION
Modified:
  - .travis.rosinstall