### PR TITLE
Fix test failures of jsk_perception on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
     - ROS_DISTRO=jade   USE_DEB=false
 matrix:
   allow_failures:
-    - env: ROS_DISTRO=indigo USE_DEB=true BEFORE_SCRIPT="$CI_SOURCE_PATH/.travis_before_script_opencv3.bash"
+    - env: ROS_DISTRO=indigo USE_DEB=true BEFORE_SCRIPT='$CI_SOURCE_PATH/.travis_before_script_opencv3.bash'
 script:
   - source .travis/travis.sh
   - (cd doc && source setup.sh && make html)

--- a/jsk_perception/CMakeLists.txt
+++ b/jsk_perception/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   image_geometry
   image_transport
+  image_view2
   jsk_recognition_msgs
   jsk_recognition_utils
   jsk_topic_tools

--- a/jsk_perception/sample/sample_bing.launch
+++ b/jsk_perception/sample/sample_bing.launch
@@ -1,5 +1,7 @@
 <launch>
 
+  <arg name="gui" default="true" />
+
   <node name="image_publisher"
         pkg="jsk_perception" type="image_publisher.py">
     <rosparam subst_value="true">
@@ -20,20 +22,22 @@
     <remap from="~input/rect_array" to="bing/output" />
   </node>
 
-  <node name="image_view_0"
-        pkg="image_view" type="image_view">
-    <remap from="image" to="image_publisher/output" />
-  </node>
-  <node name="image_view_1"
-        pkg="image_view" type="image_view">
-    <remap from="image" to="bing/output/objectness" />
-    <rosparam>
-      do_dynamic_scaling: true
-    </rosparam>
-  </node>
-  <node name="image_view_2"
-        pkg="image_view" type="image_view">
-    <remap from="image" to="draw_rect_array/output" />
-  </node>
+  <group if="$(arg gui)">
+    <node name="image_view_0"
+          pkg="image_view" type="image_view">
+      <remap from="image" to="image_publisher/output" />
+    </node>
+    <node name="image_view_1"
+          pkg="image_view" type="image_view">
+      <remap from="image" to="bing/output/objectness" />
+      <rosparam>
+        do_dynamic_scaling: true
+      </rosparam>
+    </node>
+    <node name="image_view_2"
+          pkg="image_view" type="image_view">
+      <remap from="image" to="draw_rect_array/output" />
+    </node>
+  </group>
 
 </launch>

--- a/jsk_perception/sample/sample_bof_object_recognition.launch
+++ b/jsk_perception/sample/sample_bof_object_recognition.launch
@@ -1,5 +1,7 @@
 <launch>
 
+  <arg name="gui" default="true" />
+
   <node name="raw_image"
         pkg="jsk_perception" type="image_publisher.py">
     <param name="~file_name" value="$(find jsk_perception)/sample/laugh_out_loud_joke_book.jpg" />
@@ -48,8 +50,10 @@
     <param name="~clf_path" value="$(find jsk_perception)/trained_data/apc2015_sample_clf.pkl.gz" />
   </node>
 
-  <node name="rqt_gui"
-        pkg="rqt_gui" type="rqt_gui"
-        args="--perspective-file $(find jsk_perception)/sample/config/apc2015_object_recognition_sample.perspective" />
+  <group if="$(arg gui)">
+    <node name="rqt_gui"
+          pkg="rqt_gui" type="rqt_gui"
+          args="--perspective-file $(find jsk_perception)/sample/config/apc2015_object_recognition_sample.perspective" />
+  </group>
 
 </launch>

--- a/jsk_perception/test/apply_mask_image.test
+++ b/jsk_perception/test/apply_mask_image.test
@@ -2,30 +2,9 @@
 
   <include file="$(find jsk_perception)/sample/publish_fixed_images.launch" />
 
-  <node name="apply_mask_image_exec"
-        pkg="jsk_perception" type="apply_mask_image">
-    <remap from="~input" to="raw_image_bgr/image_color" />
-    <remap from="~input/mask" to="mask_image/mask" />
-    <rosparam>
-      approximate_sync: true
-    </rosparam>
-  </node>
-
-  <arg name="MANAGER" value="nodelet_manager" />
-  <node name="$(arg MANAGER)"
-        pkg="nodelet" type="nodelet" args="manager" />
-  <node name="apply_mask_image_standalone"
+  <node name="apply_mask_image"
         pkg="nodelet" type="nodelet"
         args="standalone jsk_perception/ApplyMaskImage">
-    <remap from="~input" to="raw_image_bgr/image_color" />
-    <remap from="~input/mask" to="mask_image/mask" />
-    <rosparam>
-      approximate_sync: true
-    </rosparam>
-  </node>
-  <node name="apply_mask_image_nodelet"
-        pkg="nodelet" type="nodelet"
-        args="load jsk_perception/ApplyMaskImage $(arg MANAGER)">
     <remap from="~input" to="raw_image_bgr/image_color" />
     <remap from="~input/mask" to="mask_image/mask" />
     <rosparam>
@@ -36,14 +15,10 @@
   <test test-name="test_apply_mask_image"
         name="test_apply_mask_image"
         pkg="jsk_tools" type="test_topic_published.py"
-        time-limit="360">
+        retry="3">
     <rosparam>
-      topic_0: /apply_mask_image_exec/output
-      timeout_0: 10
-      topic_1: /apply_mask_image_standalone/output
-      timeout_1: 10
-      topic_2: /apply_mask_image_nodelet/output
-      timeout_2: 10
+      topic_0: /apply_mask_image/output
+      timeout_0: 30
     </rosparam>
   </test>
 

--- a/jsk_perception/test/bing.test
+++ b/jsk_perception/test/bing.test
@@ -1,18 +1,18 @@
 <launch>
 
   <include file="$(find jsk_perception)/sample/sample_bing.launch">
-    <env name="DISPLAY" value="" />
+    <arg name="gui" value="false" />
   </include>
 
   <test test-name="test_bing"
         name="test_bing"
         pkg="jsk_tools" type="test_topic_published.py"
-        time-limit="360">
+        retry="3">
     <rosparam>
       topic_0: /bing/output
-      timeout_0: 10
+      timeout_0: 30
       topic_1: /bing/output/objectness
-      timeout_1: 10
+      timeout_1: 30
     </rosparam>
   </test>
 

--- a/jsk_perception/test/bof_object_recognition.test
+++ b/jsk_perception/test/bof_object_recognition.test
@@ -1,7 +1,7 @@
 <launch>
 
   <include file="$(find jsk_perception)/sample/sample_bof_object_recognition.launch">
-    <env name="DISPLAY" value="" />
+    <arg name="gui" value="false" />
   </include>
 
   <test test-name="test_bof_object_recognition"

--- a/jsk_perception/test/colorize_float_image.test
+++ b/jsk_perception/test/colorize_float_image.test
@@ -2,22 +2,9 @@
 
   <include file="$(find jsk_perception)/sample/publish_fixed_images.launch" />
 
-  <node name="colorize_float_image_exec"
-        pkg="jsk_perception" type="colorize_float_image">
-    <remap from="~input" to="depth_image_32fc1/image_depth" />
-  </node>
-
-  <arg name="MANAGER" value="a_manager" />
-  <node name="$(arg MANAGER)"
-        pkg="nodelet" type="nodelet" args="manager" />
-  <node name="colorize_float_image_standalone"
+  <node name="colorize_float_image"
         pkg="nodelet" type="nodelet"
         args="standalone jsk_perception/ColorizeLabels">
-    <remap from="~input" to="depth_image_32fc1/image_depth" />
-  </node>
-  <node name="colorize_float_image_nodelet"
-        pkg="nodelet" type="nodelet"
-        args="load jsk_perception/ColorizeLabels $(arg MANAGER)">
     <remap from="~input" to="depth_image_32fc1/image_depth" />
   </node>
 
@@ -26,12 +13,8 @@
         pkg="jsk_tools" type="test_topic_published.py"
         retry="3">
     <rosparam>
-      topic_0: /colorize_float_image_exec/output
-      timeout_0: 10
-      topic_1: /colorize_float_image_standalone/output
-      timeout_1: 10
-      topic_2: /colorize_float_image_nodelet/output
-      timeout_2: 10
+      topic_0: /colorize_float_image/output
+      timeout_0: 30
     </rosparam>
   </test>
 

--- a/jsk_perception/test/colorize_labels.test
+++ b/jsk_perception/test/colorize_labels.test
@@ -2,36 +2,13 @@
 
   <include file="$(find jsk_perception)/sample/publish_fixed_images.launch" />
 
-  <node name="colorize_labels_exec"
-        pkg="jsk_perception" type="colorize_labels">
-    <remap from="~input" to="label_image/label" />
-  </node>
-
-  <arg name="MANAGER" value="a_manager" />
-  <node name="$(arg MANAGER)"
-        pkg="nodelet" type="nodelet" args="manager" />
-  <node name="colorize_labels_standalone"
-        pkg="nodelet" type="nodelet"
-        args="standalone jsk_perception/ColorizeLabels">
-    <remap from="~input" to="label_image/label" />
-  </node>
-  <node name="colorize_labels_nodelet"
-        pkg="nodelet" type="nodelet"
-        args="load jsk_perception/ColorizeLabels $(arg MANAGER)">
-    <remap from="~input" to="label_image/label" />
-  </node>
-
   <test test-name="test_colorize_labels"
         name="test_colorize_labels"
         pkg="jsk_tools" type="test_topic_published.py"
         retry="3">
     <rosparam>
-      topic_0: /colorize_labels_exec/output
-      timeout_0: 10
-      topic_1: /colorize_labels_standalone/output
-      timeout_1: 10
-      topic_2: /colorize_labels_nodelet/output
-      timeout_2: 10
+      topic_0: /colorize_labels/image
+      timeout_0: 30
     </rosparam>
   </test>
 

--- a/jsk_perception/test/image_cluster_indices_decomposer.test
+++ b/jsk_perception/test/image_cluster_indices_decomposer.test
@@ -6,10 +6,11 @@
 
   <test test-name="test_image_cluster_indices_decomposer"
         name="test_image_cluster_indices_decomposer"
-        pkg="jsk_tools" type="test_topic_published.py">
+        pkg="jsk_tools" type="test_topic_published.py"
+        retry="3">
     <rosparam>
       topic_0: /image_cluster_indices_decomposer/output
-      timeout_0: 10
+      timeout_0: 20
     </rosparam>
   </test>
 

--- a/jsk_perception/test/kmeans.test
+++ b/jsk_perception/test/kmeans.test
@@ -8,36 +8,19 @@
     </rosparam>
   </node>
 
-  <node name="kmeans_exec"
-        pkg="jsk_perception" type="kmeans">
-    <remap from="~input" to="image_publisher/output" />
-  </node>
-
-  <arg name="MANAGER" value="nodelet_manager" />
-  <node name="$(arg MANAGER)"
-        pkg="nodelet" type="nodelet" args="manager" />
-  <node name="kmeans_standalone"
+  <node name="kmeans"
         pkg="nodelet" type="nodelet"
         args="standalone jsk_perception/KMeans">
-    <remap from="~input" to="image_publisher/output" />
-  </node>
-  <node name="kmeans_nodelet"
-        pkg="nodelet" type="nodelet"
-        args="load jsk_perception/KMeans $(arg MANAGER)">
     <remap from="~input" to="image_publisher/output" />
   </node>
 
   <test test-name="test_kmeans"
         name="test_kmeans"
         pkg="jsk_tools" type="test_topic_published.py"
-        time-limit="360">
+        retry="3">
     <rosparam>
-      topic_0: /kmeans_exec/output
-      timeout_0: 10
-      topic_1: /kmeans_standalone/output
-      timeout_1: 10
-      topic_2: /kmeans_nodelet/output
-      timeout_2: 10
+      topic_0: /kmeans/output
+      timeout_0: 30
     </rosparam>
   </test>
 

--- a/jsk_perception/test/selective_search.test
+++ b/jsk_perception/test/selective_search.test
@@ -16,10 +16,10 @@
   <test test-name="test_selective_search"
         name="test_selective_search"
         pkg="jsk_tools" type="test_topic_published.py"
-        time-limit="360">
+        retry="3">
     <rosparam>
       topic_0: /selective_search/output
-      timeout_0: 10
+      timeout_0: 20
     </rosparam>
   </test>
 

--- a/jsk_perception/test/slic_super_pixels.test
+++ b/jsk_perception/test/slic_super_pixels.test
@@ -11,10 +11,11 @@
 
   <test test-name="test_slic_super_pixels"
         name="test_slic_super_pixels"
-        pkg="jsk_tools" type="test_topic_published.py">
+        pkg="jsk_tools" type="test_topic_published.py"
+        retry="3">
     <rosparam>
       topic_0: /slic_super_pixels/output
-      timeout_0: 10
+      timeout_0: 20
     </rosparam>
   </test>
 


### PR DESCRIPTION
Closes #1656

## Why?

This has been overlooked by https://github.com/jsk-ros-pkg/jsk_travis/issues/254 and https://github.com/jsk-ros-pkg/jsk_travis/issues/253 .

## Todo

- [x] Fix build failures of jsk_perception because of unconfigured dependency on image_view2 (58ca9a5) (https://travis-ci.org/jsk-ros-pkg/jsk_recognition/jobs/127032032)
- [x] Fix unstableness of tests in jsk_perception