### PR TITLE
[jsk_pcl_ros] add approximate_sync parameter to depth_error.launch 

### DIFF
--- a/jsk_pcl_ros/launch/depth_error.launch
+++ b/jsk_pcl_ros/launch/depth_error.launch
@@ -39,6 +39,7 @@
     <remap from="~image" to="$(arg DEPTH_IMAGE)" />
     <remap from="~point" to="/checkerdetector/corner_point" />
     <remap from="~camera_info" to="$(arg CAMERA_INFO_TOPIC)" />
+    <param name="approximate_sync" value="true"/>
   </node>
 
 </launch>

--- a/jsk_pcl_ros/launch/depth_error.launch
+++ b/jsk_pcl_ros/launch/depth_error.launch
@@ -39,7 +39,9 @@
     <remap from="~image" to="$(arg DEPTH_IMAGE)" />
     <remap from="~point" to="/checkerdetector/corner_point" />
     <remap from="~camera_info" to="$(arg CAMERA_INFO_TOPIC)" />
-    <param name="approximate_sync" value="true"/>
+    <rosparam> 
+      approximate_sync: true
+    </rosparam>
   </node>
 
 </launch>


### PR DESCRIPTION
If I set approximate_sync parameter to true, ```/depth_error_image/output``` is published.
I tried it with xtion pro (ID 1d27:0601 ASUS), ubuntu 14.04, ros indigo.
I followed [this tutorial](https://jsk-recognition.readthedocs.io/en/latest/jsk_pcl_ros/calibration.html) to try this program .

I don't know whether setting parameter on roslaunch is better or adding information on doc is better.
If there is any problem, please let me know.