### PR TITLE
Convert point indices to mask w/o sync if it's static

### DIFF
--- a/doc/jsk_pcl_ros_utils/nodes/point_indices_to_mask_image.md
+++ b/doc/jsk_pcl_ros_utils/nodes/point_indices_to_mask_image.md
@@ -13,7 +13,7 @@ of organized pointcloud and original `sensor_msgs/Image`.
 * `~input/image` (`sensor_msgs/Image`)
 
    In order to know width and height of the original image, jsk\_pcl/PointIndicesToMaskImage requires
-   input image.
+   input image. (**Note** If parameter `~static_image_size` is `True`, this topic is not subscribed.)
 
 ## Publishing Topic
 
@@ -33,3 +33,14 @@ of organized pointcloud and original `sensor_msgs/Image`.
 
   How many messages you allow about the subscriber to keep in the queue.
   This should be big when there is much difference about delay between two topics.
+
+* `~static_image_size` (Bool, default: `false`)
+
+  If this parameter is true, the topic `~input/image` is not used and paramter
+  `~height` and `~width` is used to generate mask image.
+
+**Optional**
+
+* `~height`, `~width` (Int)
+
+  Size of mask image which will be generated.

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/point_indices_to_mask_image.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/point_indices_to_mask_image.h
@@ -67,6 +67,12 @@ namespace jsk_pcl_ros_utils
     virtual void unsubscribe();
     virtual void updateDiagnostic(
       diagnostic_updater::DiagnosticStatusWrapper &stat);
+    virtual void convertAndPublish(
+      const PCLIndicesMsg::ConstPtr& indices_msg,
+      const int width,
+      const int height);
+    virtual void mask(
+      const PCLIndicesMsg::ConstPtr& indices_msg);
     virtual void mask(
       const PCLIndicesMsg::ConstPtr& indices_msg,
       const sensor_msgs::Image::ConstPtr& image_msg);
@@ -76,9 +82,13 @@ namespace jsk_pcl_ros_utils
     ////////////////////////////////////////////////////////
     bool approximate_sync_;
     int queue_size_;
+    bool static_image_size_;
+    int width_;
+    int height_;
     boost::shared_ptr<message_filters::Synchronizer<SyncPolicy> >sync_;
     boost::shared_ptr<message_filters::Synchronizer<ApproximateSyncPolicy> >async_; 
-   message_filters::Subscriber<PCLIndicesMsg> sub_input_;
+    ros::Subscriber sub_input_static_;
+    message_filters::Subscriber<PCLIndicesMsg> sub_input_;
     message_filters::Subscriber<sensor_msgs::Image> sub_image_;
     ros::Publisher pub_;
   private:

--- a/jsk_pcl_ros_utils/test/test_point_indices_to_mask_image.py
+++ b/jsk_pcl_ros_utils/test/test_point_indices_to_mask_image.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+import unittest
+
+import numpy as np
+
+import cv_bridge
+from pcl_msgs.msg import PointIndices
+import rospy
+import rostest
+from sensor_msgs.msg import Image
+
+
+class TestPointIndicesToMaskImage(unittest.TestCase):
+
+    def setUp(self):
+        self.msg = {}
+        self.pub_indices = rospy.Publisher(
+            '~output/indices', PointIndices, queue_size=1)
+        self.pub_img = rospy.Publisher('~output/image', Image, queue_size=1)
+        self.sub_mask1 = rospy.Subscriber(
+            '~input/mask1', Image, self.mask_cb, callback_args='mask1')
+        self.sub_mask2 = rospy.Subscriber(
+            '~input/mask2', Image, self.mask_cb, callback_args='mask2')
+
+    def mask_cb(self, msg, name):
+        self.msg[name] = msg
+
+    def test_conversion(self):
+        for name in ['mask1', 'mask2']:
+            self._test_each_conversion(name)
+
+    def _test_each_conversion(self, name):
+        bridge = cv_bridge.CvBridge()
+
+        imgmsg = bridge.cv2_to_imgmsg(np.zeros((30, 30), dtype=np.uint8),
+                                      encoding='mono8')
+        indices_msg = PointIndices()
+        indices_msg.indices = np.arange(10, 30)
+        while self.msg.get(name) is None:
+            imgmsg.header.stamp = indices_msg.header.stamp = rospy.Time.now()
+            self.pub_indices.publish(indices_msg)
+            self.pub_img.publish(imgmsg)
+            rospy.sleep(0.1)
+
+        mask_in = bridge.imgmsg_to_cv2(
+            self.msg[name], desired_encoding='mono8')
+        mask_in = np.squeeze(mask_in)
+        mask_expected = np.zeros((imgmsg.height, imgmsg.width), dtype=np.uint8)
+        mask_expected.ravel()[np.arange(10, 30)] = 255
+        np.testing.assert_array_equal(mask_in, mask_expected)
+
+
+if __name__ == "__main__":
+    PKG = 'jsk_pcl_ros_utils'
+    ID = 'test_point_indices_to_mask_image'
+    rospy.init_node(ID)
+    rostest.rosrun(PKG, ID, TestPointIndicesToMaskImage)

--- a/jsk_pcl_ros_utils/test/test_point_indices_to_mask_image.test
+++ b/jsk_pcl_ros_utils/test/test_point_indices_to_mask_image.test
@@ -1,0 +1,29 @@
+<launch>
+
+  <test test-name="test_point_indices_to_mask_image"
+        name="test_point_indices_to_mask_image"
+        pkg="jsk_pcl_ros_utils" type="test_point_indices_to_mask_image.py">
+    <remap from="~input/mask1" to="point_indices_to_mask_image/output" />
+    <remap from="~input/mask2" to="point_indices_to_mask_image_static/output" />
+  </test>
+
+  <node name="point_indices_to_mask_image"
+        pkg="jsk_pcl_ros_utils" type="point_indices_to_mask_image">
+    <remap from="~input" to="test_point_indices_to_mask_image/output/indices" />
+    <remap from="~input/image" to="test_point_indices_to_mask_image/output/image" />
+    <rosparam>
+      static_image_size: false
+    </rosparam>
+  </node>
+
+  <node name="point_indices_to_mask_image_static"
+        pkg="jsk_pcl_ros_utils" type="point_indices_to_mask_image">
+    <remap from="~input" to="test_point_indices_to_mask_image/output/indices" />
+    <rosparam>
+      static_image_size: true
+      width: 30
+      height: 30
+    </rosparam>
+  </node>
+
+</launch>


### PR DESCRIPTION
Because synchronization cause trouble sometimes, and in most cases image size is static.