### PR TITLE
Publish correct size cloud even with empty indices for ExtractIndices

### DIFF
--- a/jsk_pcl_ros/src/extract_indices_nodelet.cpp
+++ b/jsk_pcl_ros/src/extract_indices_nodelet.cpp
@@ -99,6 +99,10 @@ namespace jsk_pcl_ros
     extract.filter(output);
 
     sensor_msgs::PointCloud2 out_cloud_msg;
+    if (indices->indices.empty()) {
+      out_cloud_msg.height = cloud_msg->height;
+      out_cloud_msg.width = cloud_msg->width;
+    }
     pcl_conversions::moveFromPCL(output, out_cloud_msg);
 
     out_cloud_msg.header = cloud_msg->header;


### PR DESCRIPTION
This is necessary in order not to stop the transport pipeline which requires organized point cloud.