### PR TITLE
Convert cluster indices to point indices with index in rosparam

### DIFF
--- a/doc/jsk_pcl_ros_utils/nodes/cluster_point_indices_to_point_indices.rst
+++ b/doc/jsk_pcl_ros_utils/nodes/cluster_point_indices_to_point_indices.rst
@@ -1,0 +1,32 @@
+ClusterPointIndicesToPointIndices
+=================================
+
+
+What is this?
+-------------
+
+Convert cluster indices to point indices with specified index value.
+
+
+Subscribing Topic
+-----------------
+
+* ``~input`` (``jsk_recognition_msgs/ClusterPointIndices``)
+
+  Cluster indices.
+
+Publishing Topic
+----------------
+
+* ``~output`` (``pcl_msgs/PointIndices``)
+
+  Output point indices.
+
+
+Parameters
+----------
+
+* ``~index`` (Int, default: `-1`)
+
+  Index value where point indices is extracted from cluster indices.
+  Please note that negative index is skipped, and empty indices is published.

--- a/jsk_pcl_ros_utils/CMakeLists.txt
+++ b/jsk_pcl_ros_utils/CMakeLists.txt
@@ -203,8 +203,10 @@ jsk_pcl_util_nodelet(src/planar_pointcloud_simulator_nodelet.cpp
   "jsk_pcl_utils/PlanarPointCloudSimulator" "planar_pointcloud_simulator")
 jsk_pcl_util_nodelet(src/plane_rejector_nodelet.cpp
   "jsk_pcl_utils/PlaneRejector" "plane_rejector")
-jsk_pcl_util_nodelet(src/cluster_point_indices_to_point_indices_nodelet.cpp
-  "jsk_pcl_utils/ClusterPointIndicesToPointIndices" "cluster_point_indices_to_point_indices")
+if("$ENV{ROS_DISTRO}" STRGREATER "hydro")
+  jsk_pcl_util_nodelet(src/cluster_point_indices_to_point_indices_nodelet.cpp
+    "jsk_pcl_utils/ClusterPointIndicesToPointIndices" "cluster_point_indices_to_point_indices")
+endif()
 jsk_pcl_util_nodelet(src/pointcloud_to_cluster_point_indices_nodelet.cpp
   "jsk_pcl_utils/PointCloudToClusterPointIndices" "pointcloud_to_cluster_point_indices")
 jsk_pcl_util_nodelet(src/pointcloud_to_mask_image_nodelet.cpp
@@ -292,8 +294,9 @@ if (CATKIN_ENABLE_TESTING)
   endif()
   # Naming Rule: filename of rostest should be {EXECUTABLE_NAME}.test
   add_rostest(test/point_indices_to_cluster_point_indices.test)
-  add_rostest(test/cluster_point_indices_to_point_indices.test)
   if("$ENV{ROS_DISTRO}" STRGREATER "hydro")
+    # not build on hydro
+    add_rostest(test/cluster_point_indices_to_point_indices.test)
     # unexpected error
     add_rostest(test/point_indices_to_mask_image.test)
     # because of unreleased topic_tools/transform on hydro

--- a/jsk_pcl_ros_utils/CMakeLists.txt
+++ b/jsk_pcl_ros_utils/CMakeLists.txt
@@ -292,6 +292,7 @@ if (CATKIN_ENABLE_TESTING)
   endif()
   # Naming Rule: filename of rostest should be {EXECUTABLE_NAME}.test
   add_rostest(test/point_indices_to_cluster_point_indices.test)
+  add_rostest(test/cluster_point_indices_to_point_indices.test)
   if("$ENV{ROS_DISTRO}" STRGREATER "hydro")
     # unexpected error
     add_rostest(test/point_indices_to_mask_image.test)

--- a/jsk_pcl_ros_utils/CMakeLists.txt
+++ b/jsk_pcl_ros_utils/CMakeLists.txt
@@ -83,6 +83,7 @@ generate_dynamic_reconfigure_options(
   #   cfg/VoxelGridLargeScale.cfg
   cfg/BoundingBoxArrayToBoundingBox.cfg
   cfg/CloudOnPlane.cfg
+  cfg/ClusterPointIndicesToPointIndices.cfg
   cfg/PolygonArrayAreaLikelihood.cfg
 #   cfg/PlaneSupportedCuboidEstimator.cfg
 #   cfg/InteractiveCuboidLikelihood.cfg
@@ -202,6 +203,8 @@ jsk_pcl_util_nodelet(src/planar_pointcloud_simulator_nodelet.cpp
   "jsk_pcl_utils/PlanarPointCloudSimulator" "planar_pointcloud_simulator")
 jsk_pcl_util_nodelet(src/plane_rejector_nodelet.cpp
   "jsk_pcl_utils/PlaneRejector" "plane_rejector")
+jsk_pcl_util_nodelet(src/cluster_point_indices_to_point_indices_nodelet.cpp
+  "jsk_pcl_utils/ClusterPointIndicesToPointIndices" "cluster_point_indices_to_point_indices")
 jsk_pcl_util_nodelet(src/pointcloud_to_cluster_point_indices_nodelet.cpp
   "jsk_pcl_utils/PointCloudToClusterPointIndices" "pointcloud_to_cluster_point_indices")
 jsk_pcl_util_nodelet(src/pointcloud_to_mask_image_nodelet.cpp

--- a/jsk_pcl_ros_utils/cfg/ClusterPointIndicesToPointIndices.cfg
+++ b/jsk_pcl_ros_utils/cfg/ClusterPointIndicesToPointIndices.cfg
@@ -1,0 +1,12 @@
+#! /usr/bin/env python
+
+PACKAGE = 'jsk_pcl_ros_utils'
+ID = 'ClusterPointIndicesToPointIndices'
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+gen.add('index', int_t, 0, 'Index value where the cluster indices to be converted to point indices', default=-1)
+
+exit(gen.generate(PACKAGE, PACKAGE, ID))

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/cluster_point_indices_to_point_indices.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/cluster_point_indices_to_point_indices.h
@@ -1,0 +1,71 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+
+#ifndef JSK_PCL_ROS_UTILS_CLUSTER_POINT_INDICES_TO_POINT_INDICES_H_
+#define JSK_PCL_ROS_UTILS_CLUSTER_POINT_INDICES_TO_POINT_INDICES_H_
+
+#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <dynamic_reconfigure/server.h>
+#include <jsk_pcl_ros_utils/ClusterPointIndicesToPointIndicesConfig.h>
+#include <jsk_recognition_msgs/ClusterPointIndices.h>
+
+namespace jsk_pcl_ros_utils
+{
+
+class ClusterPointIndicesToPointIndices: public jsk_topic_tools::DiagnosticNodelet
+{
+public:
+  typedef jsk_pcl_ros_utils::ClusterPointIndicesToPointIndicesConfig Config;
+  ClusterPointIndicesToPointIndices(): DiagnosticNodelet("ClusterPointIndicesToPointIndices") { }
+protected:
+  virtual void onInit();
+  virtual void subscribe();
+  virtual void unsubscribe();
+  virtual void convert(const jsk_recognition_msgs::ClusterPointIndices::ConstPtr& cluster_indices_msg);
+  virtual void configCallback(Config &config, uint32_t level);
+
+  boost::mutex mutex_;
+
+  ros::Subscriber sub_;
+  ros::Publisher pub_;
+  boost::shared_ptr<dynamic_reconfigure::Server<Config> > srv_;
+  int index_;
+private:
+};
+
+}  // namespace jsk_pcl_ros_utils
+
+#endif  // JSK_PCL_ROS_UTILS_CLUSTER_POINT_INDICES_TO_POINT_INDICES_H_

--- a/jsk_pcl_ros_utils/jsk_pcl_nodelets.xml
+++ b/jsk_pcl_ros_utils/jsk_pcl_nodelets.xml
@@ -177,6 +177,12 @@
       Convert point cloud to mask image with skipping nan region of xyz.
     </description>
   </class>
+  <class name="jsk_pcl_utils/ClusterPointIndicesToPointIndices" type="jsk_pcl_ros_utils::ClusterPointIndicesToPointIndices"
+         base_class_type="nodelet::Nodelet">
+    <description>
+      Convert cluster indices to point indices for specified index value with ROS param.
+    </description>
+  </class>
   <class name="jsk_pcl_utils/PointCloudToPointIndices" type="jsk_pcl_ros_utils::PointCloudToPointIndices"
          base_class_type="nodelet::Nodelet">
     <description>

--- a/jsk_pcl_ros_utils/src/cluster_point_indices_to_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/cluster_point_indices_to_point_indices_nodelet.cpp
@@ -1,0 +1,99 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+#include "jsk_pcl_ros_utils/cluster_point_indices_to_point_indices.h"
+#include <jsk_recognition_utils/pcl_conversion_util.h>
+#include <jsk_topic_tools/log_utils.h>
+#include <jsk_recognition_msgs/ClusterPointIndices.h>
+#include <boost/assign.hpp>
+
+namespace jsk_pcl_ros_utils
+{
+
+  void ClusterPointIndicesToPointIndices::onInit()
+  {
+    DiagnosticNodelet::onInit();
+    // dynamic_reconfigure
+    srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
+    dynamic_reconfigure::Server<Config>::CallbackType f =
+      boost::bind(&ClusterPointIndicesToPointIndices::configCallback, this, _1, _2);
+    srv_->setCallback(f);
+
+    pub_ = advertise<PCLIndicesMsg>(*pnh_, "output", 1);
+    onInitPostProcess();
+  }
+
+  void ClusterPointIndicesToPointIndices::configCallback(
+    Config &config, uint32_t level)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+    index_ = config.index;
+  }
+
+  void ClusterPointIndicesToPointIndices::subscribe()
+  {
+    sub_ = pnh_->subscribe("input", 1,
+                           &ClusterPointIndicesToPointIndices::convert,
+                           this);
+    ros::V_string names = boost::assign::list_of("~input");
+    jsk_topic_tools::warnNoRemap(names);
+  }
+
+  void ClusterPointIndicesToPointIndices::unsubscribe()
+  {
+    sub_.shutdown();
+  }
+
+  void ClusterPointIndicesToPointIndices::convert(
+    const jsk_recognition_msgs::ClusterPointIndices::ConstPtr& cluster_indices_msg)
+  {
+    PCLIndicesMsg indices_msg;
+    indices_msg.header = cluster_indices_msg->header;
+
+    int cluster_size = cluster_indices_msg->cluster_indices.size();
+    if (index_ < 0) {
+      // skipped silently
+      return;
+    } else if (index_ < cluster_size) {
+      indices_msg.indices = cluster_indices_msg->cluster_indices[index_].indices;
+    } else {
+      NODELET_ERROR_THROTTLE(10, "Invalid ~index %d is specified for cluster size %d.", index_, cluster_size);
+    }
+    pub_.publish(indices_msg);
+  }
+
+}  // namespace jsk_pcl_ros_utils
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(jsk_pcl_ros_utils::ClusterPointIndicesToPointIndices, nodelet::Nodelet);

--- a/jsk_pcl_ros_utils/test/cluster_point_indices_to_point_indices.test
+++ b/jsk_pcl_ros_utils/test/cluster_point_indices_to_point_indices.test
@@ -1,0 +1,17 @@
+<launch>
+
+  <arg name="INPUT_CLUSTER_INDICES" value="test_cluster_point_indices_to_point_indices/output" />
+
+  <test test-name="test_cluster_point_indices_to_point_indices"
+        name="test_cluster_point_indices_to_point_indices"
+        pkg="jsk_pcl_ros_utils" type="test_cluster_point_indices_to_point_indices.py"
+        time-limit="360" retry="3">
+    <remap from="~input" to="cluster_point_indices_to_point_indices/output" />
+  </test>
+
+  <node name="cluster_point_indices_to_point_indices"
+        pkg="jsk_pcl_ros_utils" type="cluster_point_indices_to_point_indices">
+    <remap from="~input" to="$(arg INPUT_CLUSTER_INDICES)" />
+  </node>
+
+</launch>

--- a/jsk_pcl_ros_utils/test/test_cluster_point_indices_to_point_indices.py
+++ b/jsk_pcl_ros_utils/test/test_cluster_point_indices_to_point_indices.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+import unittest
+
+import numpy as np
+
+from jsk_recognition_msgs.msg import ClusterPointIndices
+from pcl_msgs.msg import PointIndices
+import dynamic_reconfigure.client
+import rospy
+import rostest
+
+
+class TestClusterPointIndicesToPointIndices(unittest.TestCase):
+
+    def setUp(self):
+        self.msg = None
+        self.cluster_indices = ((0, 10, 20, 30), (5, 15, 25, 35))
+        self.dynparam = dynamic_reconfigure.client.Client(
+            'cluster_point_indices_to_point_indices')
+        self.pub = rospy.Publisher('~output', ClusterPointIndices,
+                                   queue_size=1)
+        self.sub = rospy.Subscriber('~input', PointIndices, self.cb)
+
+    def cb(self, msg):
+        self.msg = msg
+
+    def test_conversion(self):
+        self.dynparam.update_configuration({'index': 1})
+
+        cluster_indices_msg = ClusterPointIndices()
+        while self.msg is None:
+            cluster_indices_msg.header.stamp = rospy.Time.now()
+            for indices in self.cluster_indices:
+                cluster_indices_msg.cluster_indices.append(
+                    PointIndices(
+                        header=cluster_indices_msg.header,
+                        indices=indices,
+                    )
+                )
+            self.pub.publish(cluster_indices_msg)
+            rospy.sleep(0.1)
+
+        self.assertTupleEqual(self.msg.indices, self.cluster_indices[1])
+
+
+if __name__ == '__main__':
+    PKG = 'jsk_pcl_ros_utils'
+    ID = 'test_cluster_point_indices_to_point_indices'
+    rospy.init_node(ID)
+    rostest.rosrun(PKG, ID, TestClusterPointIndicesToPointIndices)


### PR DESCRIPTION
This node is required to get specified cluster's point cloud for later processing.
like

clusters -> point indices with index 1 -> multi plane extraction -> place can on the plane.

cc @furushchev 