### PR TITLE
Extract indices correctly with empty cloud

### DIFF
--- a/jsk_pcl_ros/src/extract_indices_nodelet.cpp
+++ b/jsk_pcl_ros/src/extract_indices_nodelet.cpp
@@ -99,7 +99,7 @@ namespace jsk_pcl_ros
     extract.filter(output);
 
     sensor_msgs::PointCloud2 out_cloud_msg;
-    if (indices->indices.empty()) {
+    if (indices_msg->indices.empty() || cloud_msg->data.empty()) {
       out_cloud_msg.height = cloud_msg->height;
       out_cloud_msg.width = cloud_msg->width;
     }


### PR DESCRIPTION
Currently the node publishes point cloud with height=0, width=0 with empty point cloud.