### PR TITLE
[jsk_pcl_ros][BugFix] use advertise function defined in ConnectionBasedNodelet class.

### DIFF
--- a/jsk_pcl_ros/src/parallel_edge_finder_nodelet.cpp
+++ b/jsk_pcl_ros/src/parallel_edge_finder_nodelet.cpp
@@ -46,8 +46,8 @@ namespace jsk_pcl_ros
     ////////////////////////////////////////////////////////
     // publishers
     ////////////////////////////////////////////////////////
-    pub_ = pnh_->advertise<jsk_recognition_msgs::ParallelEdgeArray>("output_edges_groups", 1);
-    pub_clusters_ = pnh_->advertise<jsk_recognition_msgs::ClusterPointIndices>("output_clusters", 1);
+    pub_ = advertise<jsk_recognition_msgs::ParallelEdgeArray>(*pnh_, "output_edges_groups", 1);
+    pub_clusters_ = advertise<jsk_recognition_msgs::ClusterPointIndices>(*pnh_, "output_clusters", 1);
 
     ////////////////////////////////////////////////////////
     // dynamic reconfigure


### PR DESCRIPTION
advertise function defined at [here]( https://github.com/jsk-ros-pkg/jsk_common/blob/master/jsk_topic_tools/include/jsk_topic_tools/connection_based_nodelet.h#L154-L156) should be used. Otherwise, topics are never subscribed.