### PR TITLE
[jsk_pcl_ros][BugFix] Fix duplication check edge depth refinement

### DIFF
--- a/jsk_pcl_ros/src/edge_depth_refinement_nodelet.cpp
+++ b/jsk_pcl_ros/src/edge_depth_refinement_nodelet.cpp
@@ -242,13 +242,19 @@ namespace jsk_pcl_ros
     ////////////////////////////////////////////////////////
     std::vector<std::set<int> > duplication_set_list;
     std::set<int> duplicated_indices;
-    for (size_t i = 0; i < all_inliers.size() - 1; i++) {
-      std::vector<int> duplication_list = duplication_map[i];
+    for (size_t i = 0; i < all_inliers.size(); i++) {
+      std::vector<int> duplication_list;
+      if (i < all_inliers.size() - 1) {
+        duplication_list = duplication_map[i];
+      }
       if (duplicated_indices.find(i) == duplicated_indices.end()) {
-        if (duplication_list.size() == 0) {
-          // nothing to do...
+        if (i == all_inliers.size() - 1 || duplication_list.size() == 0) { // no duplication found
+          std::set<int> no_duplication_set;
+          no_duplication_set.insert(i);
+          duplication_set_list.push_back(no_duplication_set);
+          jsk_recognition_utils::addSet<int>(duplicated_indices, no_duplication_set);
         }
-        else {
+        else { // some duplication found
           std::set<int> new_duplication_set;
           jsk_recognition_utils::buildGroupFromGraphMap(duplication_map,
                                  i,

--- a/jsk_pcl_ros/src/edge_depth_refinement_nodelet.cpp
+++ b/jsk_pcl_ros/src/edge_depth_refinement_nodelet.cpp
@@ -199,8 +199,6 @@ namespace jsk_pcl_ros
       JSK_NODELET_ERROR("no edges are specified");
       return;
     }
-    std::vector<pcl::PointIndices::Ptr> nonduplicated_inliers;
-    std::vector<pcl::ModelCoefficients::Ptr> cnonduplicated_oefficients;
 
     // buildup Lines and Segments
     std::vector<jsk_recognition_utils::Line::Ptr> lines;


### PR DESCRIPTION
this is very complicated bug..

INPUT (before refining edge)
![input](https://cloud.githubusercontent.com/assets/6636600/17407193/5f21920e-5aa1-11e6-93f5-3ec2f2660b83.png)

OUTPUT (after refining edge) (incorrect: before this PR)
edges which consists of single cluster disappear. this is bug.
![output_incorrect](https://cloud.githubusercontent.com/assets/6636600/17407247/850a3804-5aa1-11e6-9aa4-67b36765aebe.png)

OUTPUT (after refining edge) (correct: after this PR)
bug is fixed.
![output_correct](https://cloud.githubusercontent.com/assets/6636600/17407254/8c8e9020-5aa1-11e6-9975-1058fc31fd02.png)
