### PR TITLE
[jsk_perception] add warning message when no camera info is available.

### DIFF
--- a/jsk_perception/src/polygon_to_mask_image.cpp
+++ b/jsk_perception/src/polygon_to_mask_image.cpp
@@ -98,6 +98,9 @@ namespace jsk_perception
                                       sensor_msgs::image_encodings::MONO8,
                                       mask_image).toImageMsg());
     }
+    else {
+      JSK_NODELET_WARN("no camera info is available");
+    }
   }
 
 }


### PR DESCRIPTION
same with https://github.com/jsk-ros-pkg/jsk_recognition/blob/master/jsk_perception/src/polygon_array_to_label_image.cpp#L113-L115 .