### PR TITLE
[jsk_pcl_ros] add polygon_array_to_polygon.py

### DIFF
--- a/jsk_pcl_ros/scripts/polygon_array_to_polygon.py
+++ b/jsk_pcl_ros/scripts/polygon_array_to_polygon.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+import rospy
+
+PKG='jsk_pcl_ros'
+
+import imp
+## import message_filters
+try:
+    imp.find_module(PKG)
+except:
+    import roslib;roslib.load_manifest(PKG)
+
+from geometry_msgs.msg import PolygonStamped
+from jsk_recognition_msgs.msg import PolygonArray
+
+def polygon_array_cb(plolygon_array):
+    if (len(plolygon_array.polygons)==0):
+        rospy.loginfo("polygon size 0")
+        return
+    PPub.publish(plolygon_array.polygons[0])
+
+
+if __name__ == "__main__":
+    rospy.init_node('polygon_array_to_polygon', anonymous=True)
+    PPub = rospy.Publisher('polygon', PolygonStamped)
+    rospy.Subscriber("polygon_array", PolygonArray, polygon_array_cb)
+    rospy.spin()


### PR DESCRIPTION
This is polygon version of [box_array_to_box.py](https://github.com/jsk-ros-pkg/jsk_recognition/blob/master/jsk_pcl_ros/scripts/box_array_to_box.py).
I need this script to connect [OrganizedMultiPlaneSegmentation](http://jsk-docs.readthedocs.io/en/latest/jsk_recognition/doc/jsk_pcl_ros/nodes/organized_multi_plane_segmentation.html) which publishes jsk_recognition_msgs/PolygonArray and [PolygonToMaskImage](http://jsk-docs.readthedocs.io/en/latest/jsk_recognition/doc/jsk_perception/nodes/polygon_to_mask_image.html) which subscribes geometry_msgs/PolygonStamped.