### PR TITLE
Install missing dirs for jsk_pcl_ros

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -438,7 +438,10 @@ install(DIRECTORY scripts/
 )
 
 install(FILES jsk_pcl_nodelets.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-install(DIRECTORY launch
+install(DIRECTORY
+  config
+  launch
+  sample
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 if (CATKIN_ENABLE_TESTING)


### PR DESCRIPTION
The missing dirs are: config, launch, sample.