### PR TITLE
Revert "Remove dependency on jsk_perception for separated build"

### DIFF
--- a/jsk_pcl_ros/package.xml
+++ b/jsk_pcl_ros/package.xml
@@ -98,6 +98,7 @@
   <build_depend>jsk_recognition_msgs</build_depend>
   <run_depend>jsk_recognition_msgs</run_depend>
   <run_depend>jsk_footstep_msgs</run_depend>
+  <run_depend>jsk_perception</run_depend>
   <build_depend>interactive_markers</build_depend>
   <run_depend>interactive_markers</run_depend>
   <run_depend>jsk_recognition_utils</run_depend>


### PR DESCRIPTION
Reverts jsk-ros-pkg/jsk_recognition#1820

But is that ok to merge this before releasing 0.3.22?
It seems better to release this at 0.4.0: #1854