### PR TITLE
sparse_image_encoder.cpp: need to escape %

### DIFF
--- a/jsk_perception/src/sparse_image_encoder.cpp
+++ b/jsk_perception/src/sparse_image_encoder.cpp
@@ -65,7 +65,7 @@ class SparseImageEncoder: public nodelet::Nodelet
         int size = 0;
         if (useData32) size = _spr_img_ptr->data32.size();
         else size = _spr_img_ptr->data16.size();
-        JSK_NODELET_INFO("%d point encoded. encoded area per is %lf%.", size, (100 * ((double) size)/(msg->height* msg->width)));
+        JSK_NODELET_INFO("%d point encoded. encoded area per is %lf%%.", size, (100 * ((double) size)/(msg->height* msg->width)));
       }
 
       // publish sparse image message


### PR DESCRIPTION
to fix
```
In file included from /opt/ros/indigo/include/nodelet/nodelet.h:39:0,
                 from /home/k-okada/catkin_ws/ws_jsk_recognition/src/jsk_recognition/jsk_perception/src/sparse_image_encoder.cpp:7:
/home/k-okada/catkin_ws/ws_jsk_recognition/src/jsk_recognition/jsk_perception/src/sparse_image_encoder.cpp: In member function ‘void jsk_perception::SparseImageEncoder::do_work(const ImageConstPtr&, std::string)’:
/opt/ros/indigo/include/ros/console.h:342:176: warning: unknown conversion type character 0xa in format [-Wformat=]
     ::ros::console::print(filter, __rosconsole_define_location__loc.logger_, __rosconsole_define_location__loc.level_, __FILE__, __LINE__, __ROSCONSOLE_FUNCTION__, __VA_ARGS__)
                                                                                                                                                                                ^
/opt/ros/indigo/include/ros/console.h:345:5: note: in expansion of macro ‘ROSCONSOLE_PRINT_AT_LOCATION_WITH_FILTER’
     ROSCONSOLE_PRINT_AT_LOCATION_WITH_FILTER(0, __VA_ARGS__)
     ^
/opt/ros/indigo/include/ros/console.h:375:7: note: in expansion of macro ‘ROSCONSOLE_PRINT_AT_LOCATION’
       ROSCONSOLE_PRINT_AT_LOCATION(__VA_ARGS__); \
       ^
/opt/ros/indigo/include/ros/console.h:557:35: note: in expansion of macro ‘ROS_LOG_COND’
 #define ROS_LOG(level, name, ...) ROS_LOG_COND(true, level, name, __VA_ARGS__)
                                   ^
/opt/ros/indigo/include/rosconsole/macros_generated.h:112:35: note: in expansion of macro ‘ROS_LOG’
 #define ROS_INFO_NAMED(name, ...) ROS_LOG(::ros::console::levels::Info, std::string(ROSCONSOLE_NAME_PREFIX) + "." + name, __VA_ARGS__)
                                   ^
/opt/ros/indigo/include/nodelet/nodelet.h:59:27: note: in expansion of macro ‘ROS_INFO_NAMED’
 #define NODELET_INFO(...) ROS_INFO_NAMED(getName(), __VA_ARGS__)
                           ^
/opt/ros/indigo/include/jsk_topic_tools/log_utils.h:67:3: note: in expansion of macro ‘NODELET_INFO’
   NODELET_INFO("[%s] " str, jsk_topic_tools::getFunctionName(__PRETTY_FUNCTION__).c_str(), ##__VA_ARGS__)
   ^
/home/k-okada/catkin_ws/ws_jsk_recognition/src/jsk_recognition/jsk_perception/src/sparse_image_encoder.cpp:68:9: note: in expansion of macro ‘JSK_NODELET_INFO’
         JSK_NODELET_INFO("%d point encoded. encoded area per is %f%\n", size, (100 * ((double) size)/(msg->height* msg->width)));
         ^
```