### PR TITLE
failing at build firm

### DIFF
--- a/jsk_perception/CMakeLists.txt
+++ b/jsk_perception/CMakeLists.txt
@@ -74,13 +74,6 @@ add_custom_target(install_sample_data ALL COMMAND ${PROJECT_SOURCE_DIR}/scripts/
 # download and install trained data
 add_custom_target(install_trained_data ALL COMMAND ${PROJECT_SOURCE_DIR}/scripts/install_trained_data.py)
 
-execute_process(
-  COMMAND cmake -E chdir ${CMAKE_CURRENT_BINARY_DIR}
-  make -f ${PROJECT_SOURCE_DIR}/Makefile.slic
-  INSTALL_DIR=${CATKIN_DEVEL_PREFIX}
-  MK_DIR=${mk_PREFIX}/share/mk installed
-  RESULT_VARIABLE _make_failed)
-
 # ------------------------------------------------------------------------------------
 # Catkin setup
 # ------------------------------------------------------------------------------------
@@ -150,7 +143,7 @@ catkin_package(
 # ------------------------------------------------------------------------------------
 # Build
 # ------------------------------------------------------------------------------------
-if(NOT EXISTS slic/slic.cpp)
+if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/slic/slic.cpp)
   message(WARNING "slic/slic.cpp is not exists, download this")
   execute_process(COMMAND git submodule init slic   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   execute_process(COMMAND git submodule update slic WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/jsk_perception/euslisp/eusmodel_template_gen_utils.l
+++ b/jsk_perception/euslisp/eusmodel_template_gen_utils.l
@@ -36,6 +36,8 @@
 	(setq template (ros::resolve-ros-path
 			(format nil "package://~A/template/~A.~A" *pkgname* (send path :name) (send path :type))))
 	(when (or (not (probe-file template)) (file-newer imgfile template))
+          (if (null (probe-file (send (pathname template) :directory-string)))
+              (unix::mkdir (send (pathname template) :directory-string)))
 	  (unix::system (format nil "cp -f ~a ~a" imgfile template)))
 	(list template width height trans)
 	))))


### PR DESCRIPTION
http://build.ros.org/job/Jbin_uT64__jsk_perception__ubuntu_trusty_amd64__binary/49/console
```
09:27:16 Scanning dependencies of target eusmodel_template
09:27:16 make[4]: Leaving directory `/tmp/binarydeb/ros-jade-jsk-perception-0.3.22/obj-x86_64-linux-gnu'
09:27:16 make -f CMakeFiles/eusmodel_template.dir/build.make CMakeFiles/eusmodel_template.dir/build
09:27:16 make[4]: Entering directory `/tmp/binarydeb/ros-jade-jsk-perception-0.3.22/obj-x86_64-linux-gnu'
09:27:16 /usr/bin/cmake -E cmake_progress_report /tmp/binarydeb/ros-jade-jsk-perception-0.3.22/obj-x86_64-linux-gnu/CMakeFiles 
09:27:16 [ 31%] Generating ../sample/rimokon-pose.launch, ../sample/milktea-box.launch
09:27:16 cd /tmp/binarydeb/ros-jade-jsk-perception-0.3.22/sample && ROS_PACKAGE_PATH=/tmp/binarydeb/ros-jade-jsk-perception-0.3.22:/opt/ros/jade/share:/opt/ros/jade/stacks roseus ./pose_detector_auto_gen_sample.l
09:27:16 
```

null tepmlate directory is not copied to the release repository (cf. https://github.com/jsk-ros-pkg/jsk_common/pull/1455)