### PR TITLE
CMakeLists.txt : jsk_data is required in build time, used in scripts/install_sample_data

### DIFF
--- a/jsk_perception/package.xml
+++ b/jsk_perception/package.xml
@@ -29,6 +29,7 @@
   <build_depend>image_geometry</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>image_view2</build_depend>
+  <build_depend>jsk_data</build_depend>
   <build_depend>jsk_recognition_msgs</build_depend>
   <build_depend>jsk_recognition_utils</build_depend>
   <build_depend>jsk_topic_tools</build_depend>


### PR DESCRIPTION
http://build.ros.org/job/Jbin_uV32__jsk_perception__ubuntu_vivid_i386__binary/56/console