### PR TITLE
Preserve index of cluster_indices even with max/min size

### DIFF
--- a/jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
+++ b/jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
@@ -453,10 +453,14 @@ namespace jsk_pcl_ros
       // skip indices with points size
       if (min_size_ > 0 &&
           indices_input->cluster_indices[i].indices.size() < min_size_) {
+        vindices.reset (new std::vector<int> ());
+        converted_indices.push_back(vindices);
         continue;
       }
       if (max_size_ > 0 &&
           indices_input->cluster_indices[i].indices.size() > max_size_) {
+        vindices.reset (new std::vector<int> ());
+        converted_indices.push_back(vindices);
         continue;
       }
       vindices.reset (new std::vector<int> (indices_input->cluster_indices[i].indices));


### PR DESCRIPTION
Empty indices [] should be inserted when skipping with max/min size rosparam specification,
because skipping removes the information about index which is necessary for example to get label value correctly.