### PR TITLE
[checkerboard_detector] enable to select option for cv::findChessboardCorners from dynamic reconfigure

### DIFF
--- a/checkerboard_detector/CMakeLists.txt
+++ b/checkerboard_detector/CMakeLists.txt
@@ -2,11 +2,13 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(checkerboard_detector)
 
-find_package(catkin REQUIRED COMPONENTS roscpp rosconsole cv_bridge sensor_msgs image_geometry
+find_package(catkin REQUIRED COMPONENTS roscpp rosconsole dynamic_reconfigure cv_bridge sensor_msgs image_geometry
   posedetection_msgs eigen_conversions message_filters tf tf2 jsk_recognition_msgs jsk_recognition_msgs
 )
 find_package(OpenMP)
 find_package(posedetection_msgs)
+
+generate_dynamic_reconfigure_options(cfg/CheckerboardDetector.cfg)
 
 catkin_package(
     CATKIN_DEPENDS roscpp rosconsole cv_bridge sensor_msgs posedetection_msgs image_geometry jsk_recognition_msgs

--- a/checkerboard_detector/cfg/CheckerboardDetector.cfg
+++ b/checkerboard_detector/cfg/CheckerboardDetector.cfg
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+# set up parameters that we care about
+PACKAGE = 'checkerboard_detector'
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator ()
+
+gen.add("adaptive_thresh", bool_t, 0, "use adaptive thresholding to convert the image to black and white.", False)
+gen.add("normalize_image", bool_t, 0, "normalize the image gamma before applying thresholding.", False)
+gen.add("filter_quads", bool_t, 0, "use additional criteria to filter out false quads extracted at the contour retrieval stage.", False)
+gen.add("fast_check", bool_t, 0, "shortcut the call if none is found.", False)
+exit (gen.generate (PACKAGE, 'checkerboard_detector', "CheckerboardDetector"))

--- a/checkerboard_detector/package.xml
+++ b/checkerboard_detector/package.xml
@@ -21,6 +21,7 @@
 
   <build_depend>roscpp</build_depend>
   <build_depend>rosconsole</build_depend>
+  <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>posedetection_msgs</build_depend>
@@ -29,6 +30,7 @@
   <run_depend>roscpp</run_depend>
   <run_depend>dynamic_tf_publisher</run_depend>
   <run_depend>rosconsole</run_depend>
+  <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>posedetection_msgs</run_depend>

--- a/checkerboard_detector/src/checkerboard_detector.cpp
+++ b/checkerboard_detector/src/checkerboard_detector.cpp
@@ -96,7 +96,7 @@ public:
     vector< string > vstrtypes; // type names for every grid point
     map<string,int> maptypes;
     ros::Time lasttime;
-    boost::mutex mutexcalib;
+    boost::mutex mutex;
     ros::NodeHandle _node;
     int dimx, dimy;
     bool use_P;
@@ -262,7 +262,7 @@ public:
     // Camera info callback
     void caminfo_cb(const sensor_msgs::CameraInfoConstPtr &msg)
     {
-        boost::mutex::scoped_lock lock(this->mutexcalib);
+        boost::mutex::scoped_lock lock(this->mutex);
 
         this->_camInfoMsg = *msg;
 
@@ -311,7 +311,7 @@ public:
     void image_cb2(const sensor_msgs::ImageConstPtr &msg)
     {
         ROS_WARN("The topic Image has been deprecated.  Please change your launch file to use image instead.");
-        boost::mutex::scoped_lock lock(this->mutexcalib);
+        boost::mutex::scoped_lock lock(this->mutex);
         ++message_throttle_counter_;
         if (message_throttle_counter_ % message_throttle_ == 0) {
             message_throttle_counter_ = 0;
@@ -332,7 +332,7 @@ public:
     // Image data callback
     void image_cb(const sensor_msgs::ImageConstPtr &msg)
     {
-        boost::mutex::scoped_lock lock(this->mutexcalib);
+        boost::mutex::scoped_lock lock(this->mutex);
         ++message_throttle_counter_;
         if (message_throttle_counter_ % message_throttle_ == 0) {
             message_throttle_counter_ = 0;
@@ -379,7 +379,7 @@ public:
     
     void connectCb( )
     {
-      boost::mutex::scoped_lock lock(this->mutexcalib);
+      boost::mutex::scoped_lock lock(this->mutex);
       if (_pubDetection.getNumSubscribers() == 0 && _pubCornerPoint.getNumSubscribers() == 0 &&
           _pubPoseStamped.getNumSubscribers() == 0 && _pubPolygonArray.getNumSubscribers() == 0)
         {
@@ -682,7 +682,7 @@ public:
     // Dynamic Reconfigure
     void configCallback(Config &config, uint32_t level)
     {
-        boost::mutex::scoped_lock lock(this->mutexcalib);
+        boost::mutex::scoped_lock lock(this->mutex);
         adaptive_thresh_flag = config.adaptive_thresh;
         normalize_image_flag = config.normalize_image;
         filter_quads_flag = config.filter_quads;


### PR DESCRIPTION
cv::CALIB_CB_ADAPTIVE_THRESH was effective.
http://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html#findchessboardcorners

![screenshot from 2016-10-05 17 01 57](https://cloud.githubusercontent.com/assets/6636600/19105586/ba1b37ee-8b1d-11e6-8692-f270875988a3.png)
![screenshot from 2016-10-05 17 01 23](https://cloud.githubusercontent.com/assets/6636600/19105587/ba84e806-8b1d-11e6-9d11-a365fa051bca.png)
