### PR TITLE
Node to apply context to label probability

### DIFF
--- a/jsk_perception/launch/fcn_object_segmentation.launch
+++ b/jsk_perception/launch/fcn_object_segmentation.launch
@@ -43,6 +43,7 @@
     <rosparam>
       queue_size: 100
     </rosparam>
+    <remap from="~label_names" to="fcn_object_segmentation/target_names" />
   </node>
 
 </launch>

--- a/jsk_perception/node_scripts/apply_context_to_label_probability
+++ b/jsk_perception/node_scripts/apply_context_to_label_probability
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+import numpy as np
+
+import cv_bridge
+import dynamic_reconfigure.server
+from jsk_topic_tools import ConnectionBasedTransport
+import rospy
+from sensor_msgs.msg import Image
+
+from jsk_recognition_msgs.srv import SetLabels
+from jsk_recognition_msgs.srv import SetLabelsResponse
+
+
+class ApplyContextToLabelProbability(ConnectionBasedTransport):
+
+    def __init__(self):
+        super(self.__class__, self).__init__()
+        # list of label values
+        self.candidates = rospy.get_param('~candidates', [])
+        if not all(isinstance(lbl, int) and lbl >= 0
+                   for lbl in self.candidates):
+            rospy.logfatal("Elements of '~candidates' must be "
+                           "integer and >=0.")
+            quit(1)
+        rospy.Service(
+            '~update_candidates', SetLabels, self.update_candidates_cb)
+        self.pub_proba = self.advertise('~output', Image, queue_size=1)
+        self.pub_label = self.advertise('~output/label', Image, queue_size=1)
+
+    def update_candidates_cb(self, req):
+        self.candidates = req.labels
+        rospy.set_param('~candidates', self.candidates)
+        return SetLabelsResponse(success=True)
+
+    def subscribe(self):
+        self.sub = rospy.Subscriber('~input', Image, self.apply)
+
+    def unsubscribe(self):
+        self.sub.unregister()
+
+    def apply(self, imgmsg):
+        bridge = cv_bridge.CvBridge()
+
+        proba_img = bridge.imgmsg_to_cv2(imgmsg).copy()  # copy to change it
+        if proba_img.ndim != 3:
+            rospy.logerr('Image shape must be (height, width, channels).')
+            return
+
+        if self.candidates:
+            n_labels = proba_img.shape[2]
+            if self.candidates and max(self.candidates) >= n_labels:
+                rospy.logerr("The max label value in '~candidates' exceeds "
+                            "the number of input labels.")
+                return
+
+            for lbl in range(n_labels):
+                if lbl not in self.candidates:
+                    proba_img[:, :, lbl] = 0.
+
+        # do dynamic scaling for the probability image
+        proba_img /= np.atleast_3d(proba_img.sum(axis=-1))
+
+        out_proba_msg = bridge.cv2_to_imgmsg(proba_img)
+        out_proba_msg.header = imgmsg.header
+        self.pub_proba.publish(out_proba_msg)
+
+        label_img = proba_img.argmax(axis=-1).astype(np.int32)
+        out_label_msg = bridge.cv2_to_imgmsg(label_img, encoding='32SC1')
+        out_label_msg.header = imgmsg.header
+        self.pub_label.publish(out_label_msg)
+
+
+if __name__ == '__main__':
+    rospy.init_node('apply_context_to_label_probablity')
+    ApplyContextToLabelProbability()
+    rospy.spin()

--- a/jsk_perception/sample/sample_apply_context_to_label_probability.launch
+++ b/jsk_perception/sample/sample_apply_context_to_label_probability.launch
@@ -1,0 +1,43 @@
+<launch>
+
+  <arg name="gui" default="true" />
+
+  <include file="$(find jsk_perception)/sample/sample_fcn_object_segmentation.launch">
+    <arg name="gui" value="false" />
+  </include>
+
+  <arg name="INPUT_IMAGE" value="image_publisher/output" />
+  <arg name="INPUT_LABEL_PROBABILITY" value="fcn_object_segmentation/output/proba_image" />
+
+  <node name="apply_context_to_label_probability"
+        pkg="jsk_perception" type="apply_context_to_label_probability">
+    <remap from="~input" to="$(arg INPUT_LABEL_PROBABILITY)" />
+    <rosparam>
+      candidates:
+        - 0   # background
+        - 15  # person
+    </rosparam>
+  </node>
+
+  <node name="label_image_decomposer_with_context"
+        pkg="jsk_perception" type="label_image_decomposer.py">
+    <remap from="~input" to="$(arg INPUT_IMAGE)" />
+    <remap from="~input/label" to="apply_context_to_label_probability/output/label" />
+    <rosparam>
+      queue_size: 100
+    </rosparam>
+    <remap from="~label_names" to="fcn_object_segmentation/target_names" />
+  </node>
+
+  <group if="$(arg gui)">
+    <node name="image_view0"
+          pkg="image_view" type="image_view">
+      <remap from="image" to="label_image_decomposer_with_context/output/label_viz" />
+    </node>
+    <node name="image_view1"
+          pkg="image_view" type="image_view">
+      <remap from="image" to="label_image_decomposer/output/label_viz" />
+    </node>
+  </group>
+
+</launch>

--- a/jsk_perception/sample/sample_fcn_object_segmentation.launch
+++ b/jsk_perception/sample/sample_fcn_object_segmentation.launch
@@ -1,6 +1,7 @@
 <launch>
 
   <arg name="gui" default="true" />
+  <arg name="GPU" default="0" />
 
   <node name="image_publisher"
         pkg="jsk_perception" type="image_publisher.py">
@@ -12,7 +13,7 @@
 
   <include file="$(find jsk_perception)/launch/fcn_object_segmentation.launch">
     <arg name="INPUT_IMAGE" value="image_publisher/output" />
-    <arg name="GPU" value="-1" />
+    <arg name="GPU" value="$(arg GPU)" />
   </include>
 
   <group if="$(arg gui)">

--- a/jsk_recognition_msgs/CMakeLists.txt
+++ b/jsk_recognition_msgs/CMakeLists.txt
@@ -61,6 +61,7 @@ add_message_files(
 
 add_service_files(FILES
   SetPointCloud2.srv
+  SetLabels.srv
   )
 
 generate_messages(

--- a/jsk_recognition_msgs/srv/SetLabels.srv
+++ b/jsk_recognition_msgs/srv/SetLabels.srv
@@ -1,0 +1,3 @@
+int64[] labels
+---
+bool success


### PR DESCRIPTION
We sometimes need to apply context to the object segmentation result.

```
    <rosparam>
      candidates:
        - 0   # background
        - 15  # person
    </rosparam>
```

![sample_apply_context_to_label_probability](https://cloud.githubusercontent.com/assets/4310419/19341659/43273578-9169-11e6-891f-562d931a61b4.png)
