### PR TITLE
[doc] add deprecated ImageRotateNodelet doc

### DIFF
--- a/doc/jsk_pcl_ros/nodes/image_rotate_nodelet.rst
+++ b/doc/jsk_pcl_ros/nodes/image_rotate_nodelet.rst
@@ -1,0 +1,10 @@
+ImageRotateNodelet
+==================
+
+@Deprecated
+-----------
+
+image_rotate in jsk_pcl_ros is deprecated.
+
+Please use image_pipeline's image_rotate(http://wiki.ros.org/image_rotate).
+


### PR DESCRIPTION
image_rotate is now merged to ros-perception/image_pipeline
I add doc to guide ros wiki.