### PR TITLE
[jsk_pcl_ros] fix typo in jsk_pcl_nodelets.xml

### DIFF
--- a/jsk_pcl_ros/jsk_pcl_nodelets.xml
+++ b/jsk_pcl_ros/jsk_pcl_nodelets.xml
@@ -631,6 +631,7 @@
   <class name="jsk_pcl/CollisionDetector"
          type="jsk_pcl_ros::CollisionDetector"
          base_class_type="nodelet::Nodelet">
+  </class>
 
   <class name="jsk_pcl/TargetAdaptiveTracking" type="jsk_pcl_ros::TargetAdaptiveTracking"
          base_class_type="nodelet::Nodelet">


### PR DESCRIPTION
we can compile jsk_pcl_ros but we cannot load nodelets written after this typo