### PR TITLE
[jsk_perception] Improve the generality of the fisheye rectification process

### DIFF
--- a/jsk_perception/cfg/Fisheye.cfg
+++ b/jsk_perception/cfg/Fisheye.cfg
@@ -10,5 +10,6 @@ gen.add("degree", double_t,    0, "the size of the degree", 60, 10, 80)
 gen.add("scale", double_t,    0, "the size of the output image", 0.2, 0.01, 3)
 gen.add("upside_down", bool_t,    0, " upside down the image", False)
 gen.add("offset_degree", double_t,    0, "offset degree for panorama view", 180, 0, 360)
+gen.add("k", double_t,    0, "focal length", 280, 0, 600)
 
 exit(gen.generate(PACKAGE, "fisheye", "Fisheye"))

--- a/jsk_perception/include/jsk_perception/fisheye_to_panorama.h
+++ b/jsk_perception/include/jsk_perception/fisheye_to_panorama.h
@@ -79,8 +79,9 @@ namespace jsk_perception
     bool simple_panorama_;
     float max_degree_;
     float scale_;
-    float upside_down_;
+    bool upside_down_;
     double offset_degree_;
+    float  k_;
   private:
     
   };

--- a/jsk_perception/launch/rectified_fisheye_image.launch
+++ b/jsk_perception/launch/rectified_fisheye_image.launch
@@ -1,0 +1,16 @@
+<launch>
+  <node type="nodelet" pkg="nodelet" name="fisheye_manager" args="manager" output="screen"/>
+  <node type="nodelet" pkg="nodelet" name="fisheye_to_panorama"
+        args="load jsk_perception/FisheyeToPanorama fisheye_manager" output="screen">
+    <remap from="~input" to="/camera/image_raw"/>
+    <param name="use_panorama" value="false"/>
+  </node>
+
+  <node type="image_view" pkg="image_view" name="fisheye_image_view">
+    <remap from="image" to="/camera/image_raw"/>
+  </node>
+
+  <node type="image_view" pkg="image_view" name="undistorted_image_view">
+    <remap from="image" to="/fisheye_to_panorama/output"/>
+  </node>
+</launch>


### PR DESCRIPTION
1. Use the encoding variable of sensor_msgs:image while subscribing,and same depth for undistorted image. The previous fixed sensor_msgs::image_encodings(BGR8) is not compatible with mono-scale image
2. Add configurable for the variable k, which was fixed for prosillica.