### PR TITLE
[WIP] [checkerboard_detector] warn if error is big

### DIFF
--- a/checkerboard_detector/src/checkerboard_detector.cpp
+++ b/checkerboard_detector/src/checkerboard_detector.cpp
@@ -541,7 +541,7 @@ public:
                                          cv::Size(size,size), cv::Size(-1,-1),
                                          cv::TermCriteria(CV_TERMCRIT_ITER, 50, 1e-2));
                     }
-                    objpose.pose = FindTransformation(cb.corners, cb.grid3d, cb.tlocaltrans, model);
+                    objpose.pose = FindTransformation(cb.corners, cb.grid3d, cb.tlocaltrans, model, size);
                 }
 
 #pragma omp critical
@@ -645,7 +645,8 @@ public:
     geometry_msgs::Pose FindTransformation(
         const vector<cv::Point2f> &imgpts, const vector<cv::Point3f> &objpts,
         const Transform& tlocal,
-        const image_geometry::PinholeCameraModel& model)
+        const image_geometry::PinholeCameraModel& model,
+        double cell_size = 1.0)
     {
         geometry_msgs::Pose pose;
         Transform tchecker;
@@ -665,6 +666,22 @@ public:
         if( fang >= 1e-6 ) {
             double fmult = sin(fang/2)/fang;
             tchecker.rot = Vector(cos(fang/2),fR3[0]*fmult, fR3[1]*fmult, fR3[2]*fmult);
+        }
+
+        // check if points are in truth position
+        cv::Mat projpoints(objpts.size(), 2, CV_32FC1);
+        projectPoints(objpts, R3_mat, T3_mat, model.intrinsicMatrix(), model.distortionCoeffs(), projpoints);
+        const cv::Point2f* projpoints_ptr = projpoints.ptr<cv::Point2f>();
+        float max_diff_norm = -10;
+        for ( size_t i = 0; i < objpts.size(); ++i){
+            float diff_norm = (float)norm(imgpts[i] - projpoints_ptr[i]);
+            if (diff_norm > max_diff_norm) {
+                max_diff_norm = diff_norm;
+            }
+        }
+        ROS_DEBUG("max error of cells: %d", max_diff_norm/cell_size);
+        if (max_diff_norm/cell_size > 0.02) { // 2%
+            ROS_WARN("Large error %f detected, please check (1): checker board is on plane, (2): you uses rectified image", max_diff_norm/cell_size);
         }
 
         Transform tglobal = tchecker*tlocal;


### PR DESCRIPTION
do not merge yet.
I will check parameters tomorrow with other calibrated cameras (I checked only on my astra camera) and 5X4 checkerboard.
any comments are welcome.

With this PR, we can warn dual-rectification of image indicated in #1935 #1937.
However, the error often occurs because of moving cameras or checker board is not in planer place.
