### PR TITLE
Add PointCloudXYZToXYZRGB utility nodelet

### DIFF
--- a/doc/jsk_pcl_ros_utils/nodes/pointcloud_xyz_to_xyzrgb.md
+++ b/doc/jsk_pcl_ros_utils/nodes/pointcloud_xyz_to_xyzrgb.md
@@ -1,0 +1,17 @@
+# PointCloudXYZToXYZRGB
+
+## What is this?
+
+Node to convert fields of `sensor_msgs/PointCloud2` from `XYZ` to `XYZRGB`.
+
+## Subscribing Topic
+
+* `~input` (`sensor_msgs/PointCloud2`)
+
+  Input cloud whose field is `XYZ`.
+
+## Publishing Topic
+
+* `~output` (`sensor_msgs/PointCloud2`)
+
+  Output cloud whose field is `XYZRGB`.

--- a/jsk_pcl_ros_utils/CMakeLists.txt
+++ b/jsk_pcl_ros_utils/CMakeLists.txt
@@ -216,6 +216,8 @@ if("$ENV{ROS_DISTRO}" STRGREATER "hydro")
   jsk_pcl_util_nodelet(src/cluster_point_indices_to_point_indices_nodelet.cpp
     "jsk_pcl_utils/ClusterPointIndicesToPointIndices" "cluster_point_indices_to_point_indices")
 endif()
+jsk_pcl_util_nodelet(src/pointcloud_xyz_to_xyzrgb_nodelet.cpp
+  "jsk_pcl_utils/PointCloudXYZToXYZRGB" "pointcloud_xyz_to_xyzrgb")
 jsk_pcl_util_nodelet(src/pointcloud_to_cluster_point_indices_nodelet.cpp
   "jsk_pcl_utils/PointCloudToClusterPointIndices" "pointcloud_to_cluster_point_indices")
 jsk_pcl_util_nodelet(src/pointcloud_to_mask_image_nodelet.cpp

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pointcloud_xyz_to_xyzrgb.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pointcloud_xyz_to_xyzrgb.h
@@ -1,0 +1,62 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#ifndef JSK_PCL_ROS_UTILS_POINTCLOUD_XYZ_TO_XYZRGB_H_
+#define JSK_PCL_ROS_UTILS_POINTCLOUD_XYZ_TO_XYZRGB_H_
+
+#include <jsk_topic_tools/diagnostic_nodelet.h>
+
+#include <sensor_msgs/PointCloud2.h>
+
+namespace jsk_pcl_ros_utils
+{
+
+class PointCloudXYZToXYZRGB: public jsk_topic_tools::DiagnosticNodelet
+{
+public:
+  PointCloudXYZToXYZRGB(): DiagnosticNodelet("PointCloudXYZToXYZRGB") { }
+protected:
+  virtual void onInit();
+  virtual void subscribe();
+  virtual void unsubscribe();
+  virtual void convert(const sensor_msgs::PointCloud2::ConstPtr& cloud_msg);
+
+  ros::Subscriber sub_;
+  ros::Publisher pub_;
+private:
+};
+
+}  // namespace jsk_pcl_ros_utils
+
+#endif  // JSK_PCL_ROS_UTILS_POINTCLOUD_XYZ_TO_XYZRGB_H_

--- a/jsk_pcl_ros_utils/jsk_pcl_nodelets.xml
+++ b/jsk_pcl_ros_utils/jsk_pcl_nodelets.xml
@@ -166,6 +166,10 @@
          type="jsk_pcl_ros_utils::PlaneConcatenator"
          base_class_type="nodelet::Nodelet">
   </class>
+  <class name="jsk_pcl_utils/PointCloudXYZToXYZRGB"
+         type="jsk_pcl_ros_utils::PointCloudXYZToXYZRGB"
+         base_class_type="nodelet::Nodelet">
+  </class>
   <class name="jsk_pcl_utils/PointCloudToClusterPointIndices"
          type="jsk_pcl_ros_utils::PointCloudToClusterPointIndices"
          base_class_type="nodelet::Nodelet">

--- a/jsk_pcl_ros_utils/sample/config/sample_pointcloud_xyz_to_xyzrgb.rviz
+++ b/jsk_pcl_ros_utils/sample/config/sample_pointcloud_xyz_to_xyzrgb.rviz
@@ -1,0 +1,170 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /PointCloud22
+      Splitter Ratio: 0.5
+    Tree Height: 566
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.588679
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: PointCloud2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: false
+      Line Style:
+        Line Width: 0.03
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: false
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: Intensity
+      Decay Time: 0
+      Enabled: false
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: PointCloud2
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.01
+      Style: Flat Squares
+      Topic: /pcd_to_pointcloud/output
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: false
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: PointCloud2
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 10
+      Size (m): 0.01
+      Style: Points
+      Topic: /pointcloud_xyz_to_xyzrgb/output
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: base_link
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Topic: /initialpose
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 0.590395
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.06
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: -0.00164918
+        Y: 0.101333
+        Z: 0.021624
+      Name: Current View
+      Near Clip Distance: 0.01
+      Pitch: 1.5398
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 4.69859
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 846
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000016a000002c5fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006400fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000028000002c5000000dd00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002c5fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730100000028000002c5000000b000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004b00000003efc0100000002fb0000000800540069006d00650100000000000004b0000002d800fffffffb0000000800540069006d006501000000000000045000000000000000000000022b000002c500000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1200
+  X: 30
+  Y: 30

--- a/jsk_pcl_ros_utils/sample/sample_pointcloud_xyz_to_xyzrgb.launch
+++ b/jsk_pcl_ros_utils/sample/sample_pointcloud_xyz_to_xyzrgb.launch
@@ -1,0 +1,23 @@
+<launch>
+
+  <arg name="gui" default="true" />
+
+  <node name="pcd_to_pointcloud"
+        pkg="pcl_ros" type="pcd_to_pointcloud"
+        args="$(find jsk_pcl_ros_utils)/sample/data/bunny.pcd 10">
+    <remap from="cloud_pcd" to="~output" />
+  </node>
+
+  <node name="pointcloud_xyz_to_xyzrgb"
+        pkg="jsk_pcl_ros_utils" type="pointcloud_xyz_to_xyzrgb">
+    <remap from="~input" to="pcd_to_pointcloud/output" />
+  </node>
+
+  <group if="$(arg gui)">
+    <node name="rviz"
+          pkg="rviz" type="rviz"
+          args="-d $(find jsk_pcl_ros_utils)/sample/config/sample_pointcloud_xyz_to_xyzrgb.rviz">
+    </node>
+  </group>
+
+</launch>

--- a/jsk_pcl_ros_utils/scripts/install_sample_data.py
+++ b/jsk_pcl_ros_utils/scripts/install_sample_data.py
@@ -17,6 +17,13 @@ def main():
         ],
     )
 
+    download_data(
+        pkg_name=PKG,
+        path='sample/data/bunny.pcd',
+        url='https://raw.githubusercontent.com/PointCloudLibrary/pcl/pcl-1.8.0/test/bunny.pcd',
+        md5='a4e58778ba12d3f26304127f6be82897',
+    )
+
 
 if __name__ == '__main__':
     main()

--- a/jsk_pcl_ros_utils/src/pointcloud_xyz_to_xyzrgb_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/pointcloud_xyz_to_xyzrgb_nodelet.cpp
@@ -1,0 +1,92 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#define BOOST_PARAMETER_MAX_ARITY 7
+
+#include <pcl_conversions/pcl_conversions.h>
+
+#include "jsk_pcl_ros_utils/pointcloud_xyz_to_xyzrgb.h"
+
+namespace jsk_pcl_ros_utils
+{
+
+void PointCloudXYZToXYZRGB::onInit()
+{
+  DiagnosticNodelet::onInit();
+  pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);
+  onInitPostProcess();
+}
+
+void PointCloudXYZToXYZRGB::subscribe()
+{
+  sub_ = pnh_->subscribe("input", 1, &PointCloudXYZToXYZRGB::convert, this);
+}
+
+void PointCloudXYZToXYZRGB::unsubscribe()
+{
+  sub_.shutdown();
+}
+
+void PointCloudXYZToXYZRGB::convert(const sensor_msgs::PointCloud2::ConstPtr& cloud_msg)
+{
+  vital_checker_->poke();
+  pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_xyz(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::fromROSMsg(*cloud_msg, *cloud_xyz);
+
+  pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud_xyzrgb(new pcl::PointCloud<pcl::PointXYZRGB>);
+  cloud_xyzrgb->points.resize(cloud_xyz->points.size());
+  cloud_xyzrgb->is_dense = cloud_xyz->is_dense;
+  cloud_xyzrgb->width = cloud_xyz->width;
+  cloud_xyzrgb->height = cloud_xyz->height;
+  for (size_t i = 0; i < cloud_xyz->points.size(); i++) {
+    pcl::PointXYZRGB p;
+    p.x = cloud_xyz->points[i].x;
+    p.y = cloud_xyz->points[i].y;
+    p.z = cloud_xyz->points[i].z;
+    p.r = 0;
+    p.g = 0;
+    p.b = 0;
+    cloud_xyzrgb->points[i] = p;
+  }
+  sensor_msgs::PointCloud2 out_cloud_msg;
+  pcl::toROSMsg(*cloud_xyzrgb, out_cloud_msg);
+  out_cloud_msg.header = cloud_msg->header;
+  pub_.publish(out_cloud_msg);
+}
+
+}  // namespace jsk_pcl_ros_utils
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(jsk_pcl_ros_utils::PointCloudXYZToXYZRGB, nodelet::Nodelet);

--- a/jsk_pcl_ros_utils/test/pointcloud_xyz_to_xyzrgb.test
+++ b/jsk_pcl_ros_utils/test/pointcloud_xyz_to_xyzrgb.test
@@ -1,0 +1,17 @@
+<launch>
+
+  <include file="$(find jsk_pcl_ros_utils)/sample/sample_pointcloud_xyz_to_xyzrgb.launch">
+    <arg name="gui" value="false" />
+  </include>
+
+  <test test-name="test_pointcloud_xyz_to_xyzrgb"
+        name="test_pointcloud_xyz_to_xyzrgb"
+        pkg="jsk_tools" type="test_topic_published.py"
+        time-limit="60" retry="3">
+    <rosparam>
+      topic_0: /pointcloud_xyz_to_xyzrgb/output
+      timeout_0: 30
+    </rosparam>
+  </test>
+
+</launch>


### PR DESCRIPTION
For https://github.com/jsk-ros-pkg/jsk_recognition/issues/1966

## Why?

`ClusterPointIndicesDecomposer` requires `PointXYZRGB` to visualize, but cloud from lasor does not have rgb.