### PR TITLE
[jsk_perception] add nodelet for darknet yolo object segmentation

### DIFF
--- a/jsk_perception/CMakeLists.txt
+++ b/jsk_perception/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(catkin REQUIRED COMPONENTS
   angles
   cmake_modules
   cv_bridge
+  darknet
   driver_base
   dynamic_reconfigure
   geometry_msgs
@@ -228,6 +229,7 @@ jsk_add_nodelet(src/project_image_point.cpp "jsk_perception/ProjectImagePoint" "
 jsk_add_nodelet(src/sliding_window_object_detector.cpp "jsk_perception/SlidingWindowObjectDetector" "sliding_window_object_detector")
 jsk_add_nodelet(src/gaussian_blur.cpp "jsk_perception/GaussianBlur" "gaussian_blur")
 jsk_add_nodelet(src/kmeans.cpp "jsk_perception/KMeans" "kmeans")
+jsk_add_nodelet(src/darknet_object_detection "jsk_perception/DarknetObjectDetection" "darknet_object_detection")
 if("${OpenCV_VERSION}" VERSION_GREATER "2.9.9")  # >= 3.0.0
   jsk_add_nodelet(src/bing.cpp "jsk_perception/Bing" "bing")
 endif()
@@ -258,6 +260,8 @@ add_library(${PROJECT_NAME} SHARED ${jsk_perception_nodelet_sources}
   slic/slic.cpp
   src/histogram_of_oriented_gradients.cpp
   )
+# add definitions for darknet to keep compatibility to darknet library
+add_darknet_definitions(${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${robot_self_filter_LIBRARIES} ${libcmt_LIBRARIES} yaml-cpp)
 if(robot_self_filter_FOUND)

--- a/jsk_perception/include/jsk_perception/darknet_object_detection.h
+++ b/jsk_perception/include/jsk_perception/darknet_object_detection.h
@@ -1,0 +1,145 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+ *
+ *********************************************************************/
+
+
+#ifndef JSK_PERCEPTION_DARKNET_OBJECT_DETECTION_H__
+#define JSK_PERCEPTION_DARKNET_OBJECT_DETECTION_H__
+
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <memory>
+#include <vector>
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/thread.hpp>
+#include <jsk_topic_tools/connection_based_nodelet.h>
+#include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
+#include <image_transport/image_transport.h>
+#include <image_transport/subscriber_filter.h>
+
+#include <jsk_recognition_msgs/LabeledRectArray.h>
+
+extern "C" {
+#ifdef __cplusplus
+#define ___cplusplus __cplusplus
+#undef __cplusplus
+#endif
+#include <darknet/box.h>
+#include <darknet/network.h>
+#include <darknet/cost_layer.h>
+#include <darknet/region_layer.h>
+#include <darknet/image.h>
+#include <darknet/parser.h>
+#include <darknet/utils.h>
+#ifdef ___cplusplus
+#define __cplusplus ___cplusplus
+#undef ___cplusplus
+#endif
+}
+
+extern "C" image ipl_to_image(IplImage* src);
+
+
+namespace jsk_perception
+{
+
+class AverageArray {
+  float ** arr;
+  bool valid;
+  int n, e, c;
+public:
+  AverageArray(int n, int e) : n(n), e(e), c(0), valid(false) {
+    arr = (float**)calloc(n, sizeof(float*));
+    for (int i = 0; i < n; ++i) arr[i] = (float*)calloc(e, sizeof(float));
+  }
+  ~AverageArray() {
+    for (int i = 0; i < n; ++i) free(arr[i]);
+    free(arr);
+  }
+  void add(float *in) {
+    std::memcpy(arr[c], in, e * sizeof(float));
+    ++c;
+    if (c >= n) c = 0;
+    if (c == n) valid = true;
+  }
+  bool canAverage() { return valid; }
+  void averageArray(float* ret) {
+    for (int j = 0; j < e; ++j) {
+      float v = 0.0f;
+      for (int i = 0; i < n; ++i) v += arr[i][j];
+      ret[j] = v / n;
+    }
+  }
+};
+
+class DarknetObjectDetection : public jsk_topic_tools::ConnectionBasedNodelet
+{
+public:
+  std::vector<std::string> labels_;
+  boost::shared_ptr<image_transport::ImageTransport> it_;
+  boost::shared_ptr<ros::NodeHandle> nh_, pnh_;
+  image_transport::Subscriber sub_image_;
+  ros::Publisher pub_rects_;
+
+  // darknet
+  network network_;
+  int max_box_num_;
+  int mean_;
+  boost::shared_ptr<AverageArray> average_pred_;
+  float detection_threshold_;
+  float nms_;
+  box* boxes_;
+  float** probs_;
+
+  virtual ~DarknetObjectDetection();
+
+  virtual void onInit();
+  virtual void subscribe();
+  virtual void unsubscribe();
+  virtual void imageCb(const sensor_msgs::Image::ConstPtr &msg);
+
+  virtual void processResult(image* dn_img, box* boxes, float** probs, jsk_recognition_msgs::LabeledRectArray &msg);
+}; // class DarknetObjectDetection
+} // namespace jsk_perception
+
+
+#endif // JSK_PERCEPTION_DARKNET_OBJECT_DETECTION_H__

--- a/jsk_perception/launch/darknet_yolo_object_segmentation.launch
+++ b/jsk_perception/launch/darknet_yolo_object_segmentation.launch
@@ -1,0 +1,12 @@
+<launch>
+  <arg name="input_image" default="/camera/rgb/image_rect_color" />
+
+  <node name="darknet_yolo_object_detection"
+        pkg="jsk_perception" type="darknet_object_detection"
+        output="screen">
+    <param name="network_weight_path" value="$(find darknet)/weights/yolo.weights" />
+    <param name="network_config_path" value="$(find darknet)/cfg/yolo.cfg" />
+    <param name="label_path" value="$(find darknet)/data/coco.names" />
+    <remap from="~input" to="$(arg input_image)" />
+  </node>
+</launch>

--- a/jsk_perception/plugins/nodelet/libjsk_perception.xml
+++ b/jsk_perception/plugins/nodelet/libjsk_perception.xml
@@ -257,4 +257,8 @@
          type="jsk_perception::ConsensusTracking"
          base_class_type="nodelet::Nodelet">
   </class>
+  <class name="jsk_perception/DarknetObjectDetection"
+         type="jsk_perception::DarknetObjectDetection"
+         base_class_type="nodelet::Nodelet">
+  </class>
 </library>

--- a/jsk_perception/sample/sample_darknet_object_detection.launch
+++ b/jsk_perception/sample/sample_darknet_object_detection.launch
@@ -1,0 +1,18 @@
+<launch>
+  <arg name="launch_camera" default="true" />
+  <node name="uvc_camera" pkg="uvc_camera" type="uvc_camera_node"
+        if="$(arg launch_camera)"/>
+  <node name="image_publisher"
+        pkg="jsk_perception" type="image_publisher.py"
+        unless="$(arg launch_camera)">
+    <rosparam subst_value="true">
+      file_name: $(find darknet)/data/dog.jpg
+      publish_info: false
+      encoding: bgr8
+    </rosparam>
+    <remap from="~output" to="/image_raw" />
+  </node>
+  <include file="$(find jsk_perception)/launch/darknet_yolo_object_segmentation.launch">
+    <arg name="input_image" value="/image_raw" />
+  </include>
+</launch>

--- a/jsk_perception/src/darknet_object_detection.cpp
+++ b/jsk_perception/src/darknet_object_detection.cpp
@@ -1,0 +1,194 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+ *
+ *********************************************************************/
+
+#include <jsk_perception/darknet_object_detection.h>
+
+namespace enc = sensor_msgs::image_encodings;
+
+namespace jsk_perception {
+
+  DarknetObjectDetection::~DarknetObjectDetection()
+  {
+    free_network(network_);
+    free(boxes_);
+    free_ptrs((void**)probs_, max_box_num_);
+  }
+
+  void DarknetObjectDetection::onInit()
+  {
+    ConnectionBasedNodelet::onInit();
+
+    pnh_.reset(new ros::NodeHandle(getMTPrivateNodeHandle()));
+
+    std::string weight_path, config_path, label_path;
+    pnh_->param<std::string>("network_weight_path", weight_path, "");
+    pnh_->param<std::string>("network_config_path", config_path, "");
+    pnh_->param<std::string>("label_path", label_path, "");
+
+    pnh_->param<float>("detection_threshold", detection_threshold_, 0.2f);
+    pnh_->param<float>("nms", nms_, 0.4f);
+    pnh_->param<int>("mean", mean_, 3);
+
+    // load labels if available
+    if (boost::filesystem::exists(boost::filesystem::path(label_path)))
+    {
+      std::ifstream ifs(label_path.c_str());
+      std::string buf;
+      while(ifs && std::getline(ifs, buf))
+        labels_.push_back(buf);
+      ROS_INFO_STREAM(labels_.size() << " labels loaded.");
+    }
+
+    // initialize darknet
+    if (!boost::filesystem::exists(boost::filesystem::path(weight_path)))
+    {
+      ROS_FATAL("No network weight file found at '%s'.", weight_path.c_str());
+      return;
+    }
+
+    if (!boost::filesystem::exists(boost::filesystem::path(config_path)))
+    {
+      ROS_FATAL("No network config file found at '%s'.", config_path.c_str());
+      return;
+    }
+
+    char* cpath = (char*)calloc(std::strlen(config_path.c_str())+1, sizeof(char));
+    char* wpath = (char*)calloc(std::strlen(weight_path.c_str())+1, sizeof(char));
+    std::strcpy(cpath, config_path.c_str());
+    std::strcpy(wpath, weight_path.c_str());
+
+    ROS_INFO_STREAM(">>> Network initializing...");
+
+    network_ = parse_network_cfg(cpath);
+    load_weights(&network_, wpath);
+    free(cpath);
+    free(wpath);
+    layer layer = network_.layers[network_.n-1];
+    set_batch_network(&network_, 1);
+    srand(2222222);
+    max_box_num_ = layer.w * layer.h * layer.n;
+
+    boxes_ = (box*)calloc(max_box_num_, sizeof(box));
+    probs_ = (float**)calloc(max_box_num_, sizeof(float*));
+    for (int i = 0; i < max_box_num_; ++i) {
+      probs_[i] = (float*)calloc(layer.classes, sizeof(float));
+    }
+
+    ROS_INFO_STREAM("<<< Network initialized");
+
+    average_pred_.reset(new AverageArray(mean_, layer.classes));
+
+    it_.reset(new image_transport::ImageTransport(*pnh_));
+
+    pub_rects_ = advertise<jsk_recognition_msgs::LabeledRectArray>(*pnh_, "output", 1);
+
+    onInitPostProcess();
+  }
+
+  void DarknetObjectDetection::subscribe()
+  {
+    sub_image_ = it_->subscribe("input", 1, &DarknetObjectDetection::imageCb, this);
+  }
+
+  void DarknetObjectDetection::unsubscribe()
+  {
+    sub_image_.shutdown();
+  }
+
+  void DarknetObjectDetection::imageCb(const sensor_msgs::Image::ConstPtr &msg)
+  {
+    layer layer = network_.layers[network_.n-1];
+
+    IplImage cv_img;
+
+    try {
+      cv_img = cv_bridge::toCvShare(msg, enc::RGB8)->image;
+    } catch (cv_bridge::Exception &e) {
+      ROS_ERROR("Failed to convert image to IplImage");
+      return;
+    }
+    image dn_img = ipl_to_image(&cv_img);
+    image dn_resized = resize_image(dn_img, network_.w, network_.h);
+    float *pred = network_predict(network_, (float*)dn_resized.data);
+
+    average_pred_->add(pred);
+    if (average_pred_->canAverage()) {
+      average_pred_->averageArray(pred);
+      layer.output = pred;
+    }
+
+    get_region_boxes(layer, 1, 1, detection_threshold_,
+                     probs_, boxes_, 0, 0);
+
+    if (nms_) {
+      do_nms_sort(boxes_, probs_, max_box_num_, layer.classes, nms_);
+    }
+
+    jsk_recognition_msgs::LabeledRectArray pub_msg;
+    pub_msg.header = msg->header;
+    processResult(&dn_img, boxes_, probs_, pub_msg);
+    pub_rects_.publish(pub_msg);
+    free_image(dn_img);
+    free_image(dn_resized);
+  }
+
+  void DarknetObjectDetection::processResult(image* dn_img, box* boxes, float** probs, jsk_recognition_msgs::LabeledRectArray &msg)
+  {
+    for (int i = 0; i < max_box_num_; ++i)
+    {
+      jsk_recognition_msgs::LabeledRect rect;
+      int label = max_index(probs[i], (int)sizeof(probs[i]));
+      float prob = probs[i][label];
+
+      if (prob < detection_threshold_) continue;
+
+      rect.label.index = (uint32_t)label;
+      rect.label.likelihood = prob;
+      if (label < labels_.size())
+        rect.label.name = labels_[label];
+      rect.rect.x = (boxes[i].x - boxes[i].w / 2) * dn_img->w;
+      rect.rect.y = (boxes[i].y - boxes[i].h / 2) * dn_img->h;
+      rect.rect.width = boxes[i].w * dn_img->w;
+      rect.rect.height = boxes[i].h * dn_img->h;
+      msg.rects.push_back(rect);
+    }
+  }
+} // namespace jsk_perception
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(jsk_perception::DarknetObjectDetection, nodelet::Nodelet)

--- a/jsk_recognition_msgs/CMakeLists.txt
+++ b/jsk_recognition_msgs/CMakeLists.txt
@@ -24,6 +24,9 @@ add_message_files(
   ICPResult.msg
   ImageDifferenceValue.msg
   Int32Stamped.msg
+  Label.msg
+  LabeledRect.msg
+  LabeledRectArray.msg
   LineArray.msg
   Line.msg
   ModelCoefficientsArray.msg

--- a/jsk_recognition_msgs/msg/Label.msg
+++ b/jsk_recognition_msgs/msg/Label.msg
@@ -1,0 +1,3 @@
+int32 index
+string name
+float32 likelihood

--- a/jsk_recognition_msgs/msg/LabeledRect.msg
+++ b/jsk_recognition_msgs/msg/LabeledRect.msg
@@ -1,0 +1,2 @@
+Rect rect
+Label label

--- a/jsk_recognition_msgs/msg/LabeledRectArray.msg
+++ b/jsk_recognition_msgs/msg/LabeledRectArray.msg
@@ -1,0 +1,2 @@
+Header header
+LabeledRect[] rects


### PR DESCRIPTION
- todo
  - test code
  - refactor sample file
  - better visualization

- memo
  - depends https://github.com/jsk-ros-pkg/jsk_3rdparty/pull/83
  - https://github.com/jsk-ros-pkg/jsk_recognition/pull/1975
  - darknet package and this package must be compiled on the same architecture. (cuda, cudnn, opencv)