### PR TITLE
[jsk_pcl_ros/organized_edge_detector] wait initialization

### DIFF
--- a/jsk_pcl_ros/src/organized_edge_detector_nodelet.cpp
+++ b/jsk_pcl_ros/src/organized_edge_detector_nodelet.cpp
@@ -49,6 +49,8 @@ namespace jsk_pcl_ros
 {
   void OrganizedEdgeDetector::onInit()
   {
+    boost::mutex::scoped_lock lock(mutex_);
+
     ConnectionBasedNodelet::onInit();
 
     ////////////////////////////////////////////////////////


### PR DESCRIPTION
sometimes (randomly) I get the following error, and that's because the subscribe callback function is called before initialization.
```
[FATAL] [1486125390.124755479]: unknown estimation method: 26639744
OpenCV Error: Assertion failed (s >= 0) in setSize, file /build/buildd/opencv-2.4.8+dfsg1/modules/core/src/matrix.cpp, line 116
terminate called after throwing an instance of 'cv::Exception'
  what():  /build/buildd/opencv-2.4.8+dfsg1/modules/core/src/matrix.cpp:116: error: (-215) s >= 0 in function setSize
```

@wkentaro , cloud you review this?