### PR TITLE
Fix cpp format of consensus_tracking

### DIFF
--- a/jsk_perception/src/consensus_tracking.cpp
+++ b/jsk_perception/src/consensus_tracking.cpp
@@ -94,7 +94,7 @@ namespace jsk_perception
 
     cmt.initialise(gray, initial_top_left, initial_bottom_right);
     window_initialized_ = true;
-    ROS_INFO("A window is initialized. top_left: (%d, %d), bottom_right: (%d, %d)",
+    ROS_INFO("A window is initialized. top_left: (%lf, %lf), bottom_right: (%lf, %lf)",
              initial_top_left.x, initial_top_left.y, initial_bottom_right.x, initial_bottom_right.y);
   }
 


### PR DESCRIPTION
```
22:30:02
/workspace/ros/ws_jsk_recognition/src/jsk_recognition/jsk_perception/src/consensus_tracking.cpp:
In member function 'void
jsk_perception::ConsensusTracking::setInitialWindow(const ConstPtr&,
const ConstPtr&)':

22:30:02
/workspace/ros/ws_jsk_recognition/src/jsk_recognition/jsk_perception/src/consensus_tracking.cpp:97:185:
warning: format '%d' expects argument of type 'int', but argument 8 has
type 'double' [-Wformat=]

22:30:02      ROS_INFO("A window is initialized. top_left: (%d, %d),
bottom_right: (%d, %d)",

22:30:02
^

22:30:02
/workspace/ros/ws_jsk_recognition/src/jsk_recognition/jsk_perception/src/consensus_tracking.cpp:97:185:
warning: format '%d' expects argument of type 'int', but argument 9 has
type 'double' [-Wformat=]

22:30:02
/workspace/ros/ws_jsk_recognition/src/jsk_recognition/jsk_perception/src/consensus_tracking.cpp:97:185:
warning: format '%d' expects argument of type 'int', but argument 10 has
type 'double' [-Wformat=]

22:30:02
/workspace/ros/ws_jsk_recognition/src/jsk_recognition/jsk_perception/src/consensus_tracking.cpp:97:185:
warning: format '%d' expects argument of type 'int', but argument 11 has
type 'double' [-Wformat=]
```