### PR TITLE
Fix edge distance calculation in duplication check of edge depth refinement

### DIFF
--- a/jsk_pcl_ros/src/edge_depth_refinement_nodelet.cpp
+++ b/jsk_pcl_ros/src/edge_depth_refinement_nodelet.cpp
@@ -226,10 +226,12 @@ namespace jsk_pcl_ros
       for (size_t j = i + 1; j < all_inliers.size(); j++) {
         jsk_recognition_utils::Line::Ptr candidate_line = lines[j];
         jsk_recognition_utils::Segment::Ptr candidate_segment = segments[j];
-        
+        Eigen::Vector3f candidate_midpoint;
+        candidate_segment->midpoint(candidate_midpoint);
+
         double angle_diff = the_line->angle(*candidate_line);
         if (duplication_angle_threshold_ > angle_diff) {
-          double distance_diff = the_line->distance(*candidate_line);
+          double distance_diff = the_segment->distance(candidate_midpoint);
           if (duplication_distance_threshold_ > distance_diff) {
             duplication_map[i].push_back(j);
           }

--- a/jsk_recognition_utils/include/jsk_recognition_utils/geo/segment.h
+++ b/jsk_recognition_utils/include/jsk_recognition_utils/geo/segment.h
@@ -53,6 +53,7 @@ namespace jsk_recognition_utils
     virtual double distance(const Eigen::Vector3f& point) const;
     virtual double distance(const Eigen::Vector3f& point, Eigen::Vector3f& foot_point) const;
     virtual bool intersect(Plane& plane, Eigen::Vector3f& point) const;
+    virtual void midpoint(Eigen::Vector3f& output) const;
     //virtual double distance(const Segment& other);
     friend std::ostream& operator<<(std::ostream& os, const Segment& seg);
   protected:

--- a/jsk_recognition_utils/src/geo/segment.cpp
+++ b/jsk_recognition_utils/src/geo/segment.cpp
@@ -95,6 +95,11 @@ namespace jsk_recognition_utils
     return 0 <= r && r <= 1.0;
   }
 
+  void Segment::midpoint(Eigen::Vector3f& output) const
+  {
+    output = (from_ + to_) * 0.5;
+  }
+
   std::ostream& operator<<(std::ostream& os, const Segment& seg)
   {
     os << "[" << seg.from_[0] << ", " << seg.from_[1] << ", " << seg.from_[2] << "] -- "


### PR DESCRIPTION
This is very complicated bug...
Before PR, the distance of edges are calculated from the distance of nearest points in lines (line has no limitation of length). In that case, two nearly-parallel but little-tilting lines are sometimes calculated to be very near even if they are not.
This PR considers the length of edges, so this bug is fixed.

- Before PR
![before_pr_edited](https://cloud.githubusercontent.com/assets/6636600/22647374/7447fe84-ecb4-11e6-9662-65ff485437da.png)
- After PR
![after_pr_edited](https://cloud.githubusercontent.com/assets/6636600/22647377/79e3bb76-ecb4-11e6-9d99-0f48f54ffdb2.png)
