### PR TITLE
[jsk_recognition_utils] add default constructor to geometry classes.

### DIFF
--- a/jsk_recognition_utils/include/jsk_recognition_utils/geo/convex_polygon.h
+++ b/jsk_recognition_utils/include/jsk_recognition_utils/geo/convex_polygon.h
@@ -53,6 +53,7 @@ namespace jsk_recognition_utils
     typedef std::vector<Eigen::Vector3f,
                         Eigen::aligned_allocator<Eigen::Vector3f> > Vertices;
     // vertices should be CW
+    ConvexPolygon();
     ConvexPolygon(const Vertices& vertices);
     ConvexPolygon(const Vertices& vertices,
                   const std::vector<float>& coefficients);

--- a/jsk_recognition_utils/include/jsk_recognition_utils/geo/cube.h
+++ b/jsk_recognition_utils/include/jsk_recognition_utils/geo/cube.h
@@ -46,6 +46,7 @@ namespace jsk_recognition_utils
   {
   public:
     typedef boost::shared_ptr<Cube> Ptr;
+    Cube();
     Cube(const Eigen::Vector3f& pos, const Eigen::Quaternionf& rot);
     Cube(const Eigen::Vector3f& pos, const Eigen::Quaternionf& rot,
          const std::vector<double>& dimensions);

--- a/jsk_recognition_utils/include/jsk_recognition_utils/geo/cylinder.h
+++ b/jsk_recognition_utils/include/jsk_recognition_utils/geo/cylinder.h
@@ -48,6 +48,7 @@ namespace jsk_recognition_utils
   {
   public:
     typedef boost::shared_ptr<Cylinder> Ptr;
+    Cylinder();
     Cylinder(Eigen::Vector3f point, Eigen::Vector3f direction, double radius);
 
     virtual void filterPointCloud(const pcl::PointCloud<pcl::PointXYZ>& cloud,

--- a/jsk_recognition_utils/include/jsk_recognition_utils/geo/grid_plane.h
+++ b/jsk_recognition_utils/include/jsk_recognition_utils/geo/grid_plane.h
@@ -76,6 +76,7 @@ namespace jsk_recognition_utils
     typedef boost::shared_ptr<GridPlane> Ptr;
     typedef boost::tuple<int, int> IndexPair;
     typedef std::set<IndexPair> IndexPairSet;
+    GridPlane();
     GridPlane(ConvexPolygon::Ptr plane, const double resolution);
     virtual ~GridPlane();
     virtual GridPlane::Ptr clone(); // shallow copy

--- a/jsk_recognition_utils/include/jsk_recognition_utils/geo/line.h
+++ b/jsk_recognition_utils/include/jsk_recognition_utils/geo/line.h
@@ -50,7 +50,13 @@ namespace jsk_recognition_utils
   {
   public:
     typedef boost::shared_ptr<Line> Ptr;
-    
+
+    /**
+     * @brief
+     * Construct a line.
+     */
+    Line();
+
     /**
      * @brief
      * Construct a line from direction vector and a point on the line.

--- a/jsk_recognition_utils/include/jsk_recognition_utils/geo/plane.h
+++ b/jsk_recognition_utils/include/jsk_recognition_utils/geo/plane.h
@@ -48,6 +48,7 @@ namespace jsk_recognition_utils
   {
   public:
     typedef boost::shared_ptr<Plane> Ptr;
+    Plane();
     Plane(const std::vector<float>& coefficients);
     Plane(const boost::array<float, 4>& coefficients);
     Plane(Eigen::Vector3f normal, double d);

--- a/jsk_recognition_utils/include/jsk_recognition_utils/geo/polygon.h
+++ b/jsk_recognition_utils/include/jsk_recognition_utils/geo/polygon.h
@@ -57,6 +57,7 @@ namespace jsk_recognition_utils
   public:
     typedef boost::shared_ptr<Polygon> Ptr;
     typedef boost::tuple<Ptr, Ptr> PtrPair;
+    Polygon();
     Polygon(const Vertices& vertices);
     Polygon(const Vertices& vertices,
             const std::vector<float>& coefficients);

--- a/jsk_recognition_utils/include/jsk_recognition_utils/geo/segment.h
+++ b/jsk_recognition_utils/include/jsk_recognition_utils/geo/segment.h
@@ -47,6 +47,7 @@ namespace jsk_recognition_utils
   {
   public:
     typedef boost::shared_ptr<Segment> Ptr;
+    Segment();
     Segment(const Eigen::Vector3f& from, const Eigen::Vector3f to);
     virtual void foot(const Eigen::Vector3f& point, Eigen::Vector3f& output) const;
     virtual double dividingRatio(const Eigen::Vector3f& point) const;

--- a/jsk_recognition_utils/src/geo/convex_polygon.cpp
+++ b/jsk_recognition_utils/src/geo/convex_polygon.cpp
@@ -40,6 +40,10 @@
 
 namespace jsk_recognition_utils
 {
+  ConvexPolygon::ConvexPolygon()
+  {
+  }
+
   ConvexPolygon::ConvexPolygon(const Vertices& vertices):
     Polygon(vertices)
   {

--- a/jsk_recognition_utils/src/geo/cube.cpp
+++ b/jsk_recognition_utils/src/geo/cube.cpp
@@ -39,7 +39,11 @@
 
 namespace jsk_recognition_utils
 {
-    Cube::Cube(const Eigen::Vector3f& pos, const Eigen::Quaternionf& rot):
+  Cube::Cube()
+  {
+  }
+
+  Cube::Cube(const Eigen::Vector3f& pos, const Eigen::Quaternionf& rot):
     pos_(pos), rot_(rot)
   {
     dimensions_.resize(3);

--- a/jsk_recognition_utils/src/geo/cylinder.cpp
+++ b/jsk_recognition_utils/src/geo/cylinder.cpp
@@ -40,6 +40,10 @@
 
 namespace jsk_recognition_utils
 {
+  Cylinder::Cylinder()
+  {
+  }
+
   Cylinder::Cylinder(Eigen::Vector3f point, Eigen::Vector3f direction, double radius):
     point_(point), direction_(direction), radius_(radius)
   {

--- a/jsk_recognition_utils/src/geo/grid_plane.cpp
+++ b/jsk_recognition_utils/src/geo/grid_plane.cpp
@@ -40,6 +40,10 @@
 
 namespace jsk_recognition_utils
 {
+  GridPlane::GridPlane()
+  {
+  }
+
   GridPlane::GridPlane(ConvexPolygon::Ptr plane, const double resolution):
     convex_(plane), resolution_(resolution)
   {

--- a/jsk_recognition_utils/src/geo/line.cpp
+++ b/jsk_recognition_utils/src/geo/line.cpp
@@ -40,6 +40,10 @@
 
 namespace jsk_recognition_utils
 {
+  Line::Line()
+  {
+  }
+
   Line::Line(const Eigen::Vector3f& direction, const Eigen::Vector3f& origin)
     : direction_ (direction.normalized()), origin_(origin)
   {

--- a/jsk_recognition_utils/src/geo/plane.cpp
+++ b/jsk_recognition_utils/src/geo/plane.cpp
@@ -41,6 +41,10 @@
 
 namespace jsk_recognition_utils
 {
+  Plane::Plane()
+  {
+  }
+
   Plane::Plane(const std::vector<float>& coefficients)
   {
     normal_ = Eigen::Vector3f(coefficients[0], coefficients[1], coefficients[2]);

--- a/jsk_recognition_utils/src/geo/polygon.cpp
+++ b/jsk_recognition_utils/src/geo/polygon.cpp
@@ -84,6 +84,10 @@ namespace jsk_recognition_utils
   }
   
   
+  Polygon::Polygon()
+  {
+  }
+
   Polygon::Polygon(const Vertices& vertices):
     Plane((vertices[1] - vertices[0]).cross(vertices[2] - vertices[0]).normalized(), vertices[0]),
     vertices_(vertices)

--- a/jsk_recognition_utils/src/geo/segment.cpp
+++ b/jsk_recognition_utils/src/geo/segment.cpp
@@ -39,6 +39,10 @@
 #include "jsk_recognition_utils/geo_util.h"
 namespace jsk_recognition_utils
 {
+  Segment::Segment()
+  {
+  }
+
   Segment::Segment(const Eigen::Vector3f& from, const Eigen::Vector3f to):
     Line(from - to, from), from_(from), to_(to)
   {


### PR DESCRIPTION
If I understand C++ correctly, this PR is necessary to use instance of jsk_recognition_utils/geometry classes as member variable of the other class.

For example, the following code becomes error without this PR.
https://github.com/mmurooka/euslib/blob/murooka-branch/demo/murooka/wholebody_manipulation_planner/em_motion_estimation/include/em_motion_estimation/pcl/point_element.h#L16-L17
