### PR TITLE
forget to convert form jsk_pcl_ros to jsk_recognition_msgs

### DIFF
--- a/jsk_pcl_ros/scripts/check_depth_error/depth_error_calibration.py
+++ b/jsk_pcl_ros/scripts/check_depth_error/depth_error_calibration.py
@@ -13,7 +13,7 @@ import argparse
 import csv
 import math
 import datetime
-from jsk_pcl_ros.srv import SetDepthCalibrationParameter
+from jsk_recognition_msgs.srv import SetDepthCalibrationParameter
 from jsk_recognition_msgs.msg import DepthCalibrationParameter
 from sensor_msgs.msg import Image
 from cv_bridge import CvBridge, CvBridgeError


### PR DESCRIPTION
Forget to change source code at https://github.com/jsk-ros-pkg/jsk_recognition/pull/1917 ?

```
Hi,

I am trying to calibrate the depth on a primensense 1.09, following the
steps described here:
https://jsk-recognition.readthedocs.io/en/latest/jsk_pcl_ros/calibration.html.

However when I run the command rosrun jsk_pcl_ros
depth_error_calibration.py --model quadratic-uv-quadratic-abs I get an
error (bellow) and are not able to proceed.

Can you let me know if you have any idea on what is the issue?

roliveira@ThinkPad-T440p:/opt/ros/indigo/share/jsk_pcl_ros/launch$
rosrun jsk_pcl_ros depth_error_calibration.py --model
quadratic-uv-quadratic-abs
Traceback (most recent call last):
  File
  "/opt/ros/indigo/lib/jsk_pcl_ros/check_depth_error/depth_error_calibration.py",
  line 16, in <module>
    from jsk_pcl_ros.srv import SetDepthCalibrationParameter
ImportError: No module named srv

many thanks
```