### PR TITLE
incldue flann before any opencv includes, fix #2022

### DIFF
--- a/jsk_pcl_ros/src/geometric_consistency_grouping_nodelet.cpp
+++ b/jsk_pcl_ros/src/geometric_consistency_grouping_nodelet.cpp
@@ -33,11 +33,11 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 #define BOOST_PARAMETER_MAX_ARITY 7
+#include <pcl/kdtree/kdtree_flann.h>
+#include <pcl/kdtree/impl/kdtree_flann.hpp>
 #include "jsk_pcl_ros/geometric_consistency_grouping.h"
 #include "jsk_recognition_utils/pcl_conversion_util.h"
 #include <pcl/recognition/cg/geometric_consistency.h>
-#include <pcl/kdtree/kdtree_flann.h>
-#include <pcl/kdtree/impl/kdtree_flann.hpp>
 
 namespace jsk_pcl_ros
 {


### PR DESCRIPTION
Error reported at #2022
```
/tmp/binarydeb/ros-kinetic-jsk-pcl-ros-1.1.0/src/geometric_consistency_grouping_nodelet.cpp:172:182:   required from here
/usr/include/flann/util/serialization.h:18:9: error: ‘class std::unordered_map<unsigned int, std::vector<unsigned int> >’ has no member named ‘serialize’
         type.serialize(ar);
```
could be fixe by this issue, see https://github.com/mariusmuja/flann/issues/214 for detail

close #2022