### PR TITLE
[jsk_recognition_utils/geo/Polygon] add distance method.

### DIFF
--- a/jsk_recognition_utils/include/jsk_recognition_utils/geo/polygon.h
+++ b/jsk_recognition_utils/include/jsk_recognition_utils/geo/polygon.h
@@ -120,6 +120,20 @@ namespace jsk_recognition_utils
     
     /**
      * @brief
+     * Compute distance between point and this polygon.
+     */
+    double distance(const Eigen::Vector3f& point);
+
+    /**
+     * @brief
+     * Compute distance between point and this polygon.
+     * Nearest point on this polygon can be gotten.
+     */
+    double distance(const Eigen::Vector3f& point,
+                    Eigen::Vector3f& nearest_point);
+
+    /**
+     * @brief
      * Compute nearest point from p on this polygon.
      * 
      * This method first project p onth the polygon and

--- a/jsk_recognition_utils/src/geo/polygon.cpp
+++ b/jsk_recognition_utils/src/geo/polygon.cpp
@@ -222,6 +222,20 @@ namespace jsk_recognition_utils
     return ret;
   }
   
+  double Polygon::distance(const Eigen::Vector3f& point)
+  {
+    Eigen::Vector3f nearest_point;
+    return Polygon::distance(point, nearest_point);
+  }
+
+  double Polygon::distance(const Eigen::Vector3f& point,
+                           Eigen::Vector3f& nearest_point)
+  {
+    double distance;
+    nearest_point = Polygon::nearestPoint(point, distance);
+    return distance;
+  }
+
   Eigen::Vector3f Polygon::nearestPoint(const Eigen::Vector3f& p,
                                         double& distance)
   {


### PR DESCRIPTION
part of #2027

distance between polygon and point.
segment version is here:
https://github.com/jsk-ros-pkg/jsk_recognition/blob/master/jsk_recognition_utils/src/geo/segment.cpp#L76-L87

I use this in https://github.com/mmurooka/jsk_recognition/blob/26d2ab230c8fd27d7e455f8be993641e45e6bda4/jsk_pcl_ros/include/jsk_pcl_ros/pcl/transformation_estimation_point_to_element.h#L134 .