### PR TITLE
[jsk_pcl_ros_utils][centroid_publisher_nodelet] support polygon array

### DIFF
--- a/doc/jsk_pcl_ros_utils/nodes/centroid_publisher.md
+++ b/doc/jsk_pcl_ros_utils/nodes/centroid_publisher.md
@@ -1,30 +1,39 @@
 # CentroidPublisher
 ## What Is This
 
-This nodelet will subscribe the sensor\_msgs::PointCloud2, calculate its centroid and
-publish tf, `geometry_msgs/PoseStamped` and `geometry_msgs/PointStamped`.
-The nodelet boardcast the tf whose parent is cloud headers frame\_id and whose child is the new centroid frame_id.
+This nodelet will subscribe the sensor\_msgs::PointCloud2 or jsk\_recognition\_msgs/PolygonArray and calculate its centroid.
+This also boardcasts coodinates of cloud or each polygons as `tf` whose parent is cloud headers frame\_id and whose child is the new centroid frame_id.
 
 ## Subscribing Topics
 * `~input` (`sensor_msgs/PointCloud2`):
 
-   input pointcloud.
+   Input pointcloud.
+* `~input/polygons` (`jsk_recognition_msgs/PolygonArray`):
+
+   Input polygon.
+
 ## Publishing Topics
 * `/tf`
 
    Publish tf of the centroid of the input pointcloud.
 * `~output/pose` (`geometry_msgs/PoseStamped`)
 
-   centroid of the pointcloud as `geometry_msgs/PoseStamped`.
+   Centroid of the pointcloud as `geometry_msgs/PoseStamped`.
 * `~output/point` (`geometry_msgs/PointStamped`)
 
-   centroid of the pointcloud as `geometry_msgs/PointStamped`.
-## Parameters
-* `~frame` (String, required):
+   Centroid of the pointcloud as `geometry_msgs/PointStamped`.
+* `~output/pose_array` (`geometry_msgs/PoseArray`)
 
-   frame_id of centroid tf
+   Centroid poses of each polygons.
+
+## Parameters
+* `~frame` (String, default: node name):
+
+   A frame_id for centroid tf.
+   For polygon array, suffix numbers are appended. (e.g. `frame00`)
 * `~publish_tf` (Boolean, default: `False`)
-  Set this parameter true in order to publish tf frame.
+  Set this parameter to `True` in order to publish tf frame.
+  Note that if this option is `True`, input topics are always subscribed.
 
 ## Sample
 Plug the depth sensor which can be launched by openni.launch and run the below command.

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/centroid_publisher.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/centroid_publisher.h
@@ -37,6 +37,7 @@
 #define JSK_PCL_ROS_UTILS_CENTROID_PUBLISHER_H_
 
 // ros
+#include <jsk_recognition_msgs/PolygonArray.h>
 #include <ros/ros.h>
 #include <ros/names.h>
 #include <sensor_msgs/PointCloud2.h>
@@ -61,12 +62,15 @@ namespace jsk_pcl_ros_utils
     virtual void subscribe();
     virtual void unsubscribe();
     virtual void extract(const sensor_msgs::PointCloud2ConstPtr &input);
+    virtual void extractPolygons(const jsk_recognition_msgs::PolygonArray::ConstPtr &input);
     
-    ros::Subscriber sub_input_;
+    ros::Subscriber sub_cloud_;
+    ros::Subscriber sub_polygons_;
     tf::TransformBroadcaster br_;
     std::string frame_;
     bool publish_tf_;
     ros::Publisher pub_pose_;
+    ros::Publisher pub_pose_array_;
     ros::Publisher pub_point_;
   private:
   };

--- a/jsk_pcl_ros_utils/src/centroid_publisher_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/centroid_publisher_nodelet.cpp
@@ -33,13 +33,17 @@
  *********************************************************************/
 
 #define BOOST_PARAMETER_MAX_ARITY 7
-#include "jsk_pcl_ros_utils/centroid_publisher.h"
+#include <jsk_pcl_ros_utils/centroid_publisher.h>
 
 #include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/PoseArray.h>
 #include <geometry_msgs/PointStamped.h>
 
-#include <pcl/common/centroid.h>
-#include "jsk_recognition_utils/pcl_conversion_util.h"
+#include <algorithm>
+#include <iomanip>
+#include <sstream>
+#include <jsk_recognition_utils/geo_util.h>
+#include <jsk_recognition_utils/pcl_conversion_util.h>
 
 namespace jsk_pcl_ros_utils
 {
@@ -71,14 +75,57 @@ namespace jsk_pcl_ros_utils
     pub_point_.publish(point);
   }
 
+  void CentroidPublisher::extractPolygons(const jsk_recognition_msgs::PolygonArray::ConstPtr& input)
+  {
+    vital_checker_->poke();
+
+    int size = std::min(100, (int)input->polygons.size());
+
+    geometry_msgs::PoseArray pose_array;
+    pose_array.header = input->header;
+    pose_array.poses.resize(size);
+
+    for (size_t i = 0; i < size; ++i) {
+      jsk_recognition_utils::Polygon::Ptr polygon
+        = jsk_recognition_utils::Polygon::fromROSMsgPtr(input->polygons[i].polygon);
+      Eigen::Vector3f c = polygon->centroid(), n = polygon->getNormal();
+      Eigen::Vector3f ez;
+      ez << 0.0f, 0.0f, 1.0f;
+      Eigen::Quaternionf q;
+      q.setFromTwoVectors(ez, n);
+
+      if (publish_tf_) {
+        std::stringstream ss;
+        ss << frame_ << std::setfill('0') << std::setw(2) << std::right << i;
+        tf::Transform transform;
+        transform.setOrigin(tf::Vector3(c.x(), c.y(), c.z()));
+        transform.setRotation(tf::Quaternion(q.x(), q.y(), q.z(), q.w()));
+        br_.sendTransform(tf::StampedTransform(transform, input->header.stamp,
+                                               input->header.frame_id, ss.str()));
+      }
+
+      pose_array.poses[i].position.x = c.x();
+      pose_array.poses[i].position.y = c.y();
+      pose_array.poses[i].position.z = c.z();
+      pose_array.poses[i].orientation.x = q.x();
+      pose_array.poses[i].orientation.y = q.y();
+      pose_array.poses[i].orientation.z = q.z();
+      pose_array.poses[i].orientation.w = q.w();
+    }
+
+    pub_pose_array_.publish(pose_array);
+  }
+
   void CentroidPublisher::subscribe()
   {
-    sub_input_ = pnh_->subscribe("input", 1, &CentroidPublisher::extract, this);
+    sub_cloud_ = pnh_->subscribe("input", 1, &CentroidPublisher::extract, this);
+    sub_polygons_ = pnh_->subscribe("input/polygons", 1, &CentroidPublisher::extractPolygons, this);
   }
 
   void CentroidPublisher::unsubscribe()
   {
-    sub_input_.shutdown();
+    sub_cloud_.shutdown();
+    sub_polygons_.shutdown();
   }
   
   void CentroidPublisher::onInit(void)
@@ -95,12 +142,14 @@ namespace jsk_pcl_ros_utils
       pub_pose_ = pnh_->advertise<geometry_msgs::PoseStamped>("output/pose", 1);
       pub_point_ = pnh_->advertise<geometry_msgs::PointStamped>(
         "output/point", 1);
+      pub_pose_array_ = pnh_->advertise<geometry_msgs::PoseArray>("output/pose_array", 1);
       subscribe();
     }
     else {
       pub_pose_ = advertise<geometry_msgs::PoseStamped>(*pnh_, "output/pose", 1);
       pub_point_ = advertise<geometry_msgs::PointStamped>(
         *pnh_, "output/point", 1);
+      pub_pose_array_ = advertise<geometry_msgs::PoseArray>(*pnh_, "output/pose_array", 1);
     }
   }
 }


### PR DESCRIPTION
This pull request includes a feature to publish centroid pose of polygon in array.

#### Nodelet

- rename variable `sub_input_` to `sub_cloud_`
- add `sub_polygons_` to subscribe `PolygonArray`
- publish pose and tf as `frameXX` (XX is incremental number)

#### Docs

- Cleanup docs
- Update docs for support polygon array input

