### PR TITLE
[jsk_pcl_ros_utils] ensure super class functionality works

### DIFF
--- a/jsk_pcl_ros_utils/src/add_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/add_point_indices_nodelet.cpp
@@ -44,6 +44,7 @@ namespace jsk_pcl_ros_utils
     DiagnosticNodelet::onInit();
     pnh_->param("approximate_sync", approximate_sync_, false);
     pub_ = advertise<PCLIndicesMsg>(*pnh_, "output", 1);
+    onInitPostProcess();
   }
 
   void AddPointIndices::subscribe()

--- a/jsk_pcl_ros_utils/src/add_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/add_point_indices_nodelet.cpp
@@ -76,6 +76,7 @@ namespace jsk_pcl_ros_utils
     const PCLIndicesMsg::ConstPtr& src1,
     const PCLIndicesMsg::ConstPtr& src2)
   {
+    vital_checker_->poke();
     pcl::PointIndices a, b;
     pcl_conversions::toPCL(*src1, a);
     pcl_conversions::toPCL(*src2, b);

--- a/jsk_pcl_ros_utils/src/centroid_publisher_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/centroid_publisher_nodelet.cpp
@@ -45,6 +45,7 @@ namespace jsk_pcl_ros_utils
 {
   void CentroidPublisher::extract(const sensor_msgs::PointCloud2ConstPtr& input)
   {
+    vital_checker_->poke();
     pcl::PointCloud<pcl::PointXYZ> cloud_xyz;
     pcl::fromROSMsg(*input, cloud_xyz);
     Eigen::Vector4f center;

--- a/jsk_pcl_ros_utils/src/centroid_publisher_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/centroid_publisher_nodelet.cpp
@@ -103,6 +103,8 @@ namespace jsk_pcl_ros_utils
       pub_point_ = advertise<geometry_msgs::PointStamped>(
         *pnh_, "output/point", 1);
     }
+
+    onInitPostProcess();
   }
 }
 

--- a/jsk_pcl_ros_utils/src/cloud_on_plane_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/cloud_on_plane_nodelet.cpp
@@ -81,6 +81,7 @@ namespace jsk_pcl_ros_utils
                                const jsk_recognition_msgs::PolygonArray::ConstPtr& polygon_msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+    vital_checker_->poke();
     // check header
     if (!jsk_recognition_utils::isSameFrameId(*cloud_msg, *polygon_msg)) {
       NODELET_ERROR("frame_id does not match: cloud: %s, polygon: %s",

--- a/jsk_pcl_ros_utils/src/cloud_on_plane_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/cloud_on_plane_nodelet.cpp
@@ -51,6 +51,8 @@ namespace jsk_pcl_ros_utils
     srv_->setCallback (f);
 
     pub_ = advertise<jsk_recognition_msgs::BoolStamped>(*pnh_, "output", 1);
+
+    onInitPostProcess();
   }
 
   void CloudOnPlane::subscribe()

--- a/jsk_pcl_ros_utils/src/cluster_point_indices_to_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/cluster_point_indices_to_point_indices_nodelet.cpp
@@ -78,6 +78,7 @@ namespace jsk_pcl_ros_utils
   void ClusterPointIndicesToPointIndices::convert(
     const jsk_recognition_msgs::ClusterPointIndices::ConstPtr& cluster_indices_msg)
   {
+    vital_checker_->poke();
     PCLIndicesMsg indices_msg;
     indices_msg.header = cluster_indices_msg->header;
 

--- a/jsk_pcl_ros_utils/src/colorize_height_2d_mapping_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/colorize_height_2d_mapping_nodelet.cpp
@@ -45,6 +45,7 @@ namespace jsk_pcl_ros_utils
   {
     DiagnosticNodelet::onInit();
     pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);
+    onInitPostProcess();
   }
 
   void ColorizeHeight2DMapping::subscribe()

--- a/jsk_pcl_ros_utils/src/label_to_cluster_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/label_to_cluster_point_indices_nodelet.cpp
@@ -68,6 +68,7 @@ namespace jsk_pcl_ros_utils
   void LabelToClusterPointIndices::convert(
     const sensor_msgs::Image::ConstPtr& label_msg)
   {
+    vital_checker_->poke();
     cv_bridge::CvImagePtr label_img_ptr = cv_bridge::toCvCopy(
       label_msg, sensor_msgs::image_encodings::TYPE_32SC1);
     // collect indices for each labels

--- a/jsk_pcl_ros_utils/src/mask_image_to_depth_considered_mask_image_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/mask_image_to_depth_considered_mask_image_nodelet.cpp
@@ -57,6 +57,8 @@ namespace jsk_pcl_ros_utils
     region_height_ = 0;
     region_x_off_ = 0;
     region_y_off_ = 0;
+
+    onInitPostProcess();
   }
 
   void MaskImageToDepthConsideredMaskImage::configCallback(Config &config, uint32_t level){

--- a/jsk_pcl_ros_utils/src/mask_image_to_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/mask_image_to_point_indices_nodelet.cpp
@@ -74,6 +74,7 @@ namespace jsk_pcl_ros_utils
   void MaskImageToPointIndices::indices(
     const sensor_msgs::Image::ConstPtr& image_msg)
   {
+    vital_checker_->poke();
     cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(
       image_msg, sensor_msgs::image_encodings::MONO8);
     cv::Mat image = cv_ptr->image;

--- a/jsk_pcl_ros_utils/src/mask_image_to_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/mask_image_to_point_indices_nodelet.cpp
@@ -44,6 +44,7 @@ namespace jsk_pcl_ros_utils
   {
     DiagnosticNodelet::onInit();
     pub_ = advertise<PCLIndicesMsg>(*pnh_, "output", 1);
+    onInitPostProcess();
   }
 
   void MaskImageToPointIndices::subscribe()

--- a/jsk_pcl_ros_utils/src/normal_flip_to_frame_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/normal_flip_to_frame_nodelet.cpp
@@ -51,6 +51,7 @@ namespace jsk_pcl_ros_utils
     }
     pnh_->param("strict_tf", strict_tf_, false);
     pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);
+    onInitPostProcess();
   }
 
   void NormalFlipToFrame::subscribe()

--- a/jsk_pcl_ros_utils/src/pcd_reader_with_pose_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/pcd_reader_with_pose_nodelet.cpp
@@ -53,8 +53,9 @@ namespace jsk_pcl_ros_utils
       NODELET_FATAL("cannot read pcd file %s", file_name.c_str());
       return;
     }
-    pub_cloud_ = advertise<sensor_msgs::PointCloud2>(*pnh_,
-                                                       "output", 1);    
+    pub_cloud_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);
+
+    onInitPostProcess();
   }
   void PCDReaderWithPose::subscribe()
   {

--- a/jsk_pcl_ros_utils/src/pcd_reader_with_pose_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/pcd_reader_with_pose_nodelet.cpp
@@ -68,6 +68,7 @@ namespace jsk_pcl_ros_utils
   void PCDReaderWithPose::poseCallback(
     const geometry_msgs::PoseStamped::ConstPtr& pose_stamped)
   {
+    vital_checker_->poke();
     ros::Time now = ros::Time::now();
     Eigen::Affine3f pose_eigen;
     tf::poseMsgToEigen(pose_stamped->pose, pose_eigen);

--- a/jsk_pcl_ros_utils/src/planar_pointcloud_simulator_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/planar_pointcloud_simulator_nodelet.cpp
@@ -80,6 +80,8 @@ namespace jsk_pcl_ros_utils
 
     pub_ = advertise<sensor_msgs::PointCloud2>(
       *pnh_, "output", 1);
+
+    onInitPostProcess();
   }
 
   void PlanarPointCloudSimulatorNodelet::subscribe()

--- a/jsk_pcl_ros_utils/src/planar_pointcloud_simulator_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/planar_pointcloud_simulator_nodelet.cpp
@@ -104,6 +104,7 @@ namespace jsk_pcl_ros_utils
     const sensor_msgs::CameraInfo::ConstPtr& info_msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+    vital_checker_->poke();
     pcl::PointCloud<pcl::PointXYZ>::Ptr
       cloud(new pcl::PointCloud<pcl::PointXYZ>);
     impl_.generate(*info_msg, distance_, *cloud);

--- a/jsk_pcl_ros_utils/src/plane_concatenator_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/plane_concatenator_nodelet.cpp
@@ -59,6 +59,8 @@ namespace jsk_pcl_ros_utils
       *pnh_, "output/polygons", 1);
     pub_coefficients_ = advertise<jsk_recognition_msgs::ModelCoefficientsArray>(
       *pnh_, "output/coefficients", 1);
+
+    onInitPostProcess();
   }
 
   void PlaneConcatenator::subscribe()

--- a/jsk_pcl_ros_utils/src/plane_reasoner_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/plane_reasoner_nodelet.cpp
@@ -71,6 +71,8 @@ namespace jsk_pcl_ros_utils
       = advertise<jsk_recognition_msgs::ModelCoefficientsArray>(*pnh_, "output/horizontal/coefficients", 1);
     pub_horizontal_polygons_
       = advertise<jsk_recognition_msgs::PolygonArray>(*pnh_, "output/horizontal/polygons", 1);
+
+    onInitPostProcess();
   }
 
   void PlaneReasoner::subscribe()

--- a/jsk_pcl_ros_utils/src/point_indices_to_cluster_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/point_indices_to_cluster_point_indices_nodelet.cpp
@@ -42,6 +42,7 @@ namespace jsk_pcl_ros_utils
   {
     DiagnosticNodelet::onInit();
     pub_ = advertise<jsk_recognition_msgs::ClusterPointIndices>(*pnh_, "output", 1);
+    onInitPostProcess();
   }
 
   void PointIndicesToClusterPointIndices::subscribe()

--- a/jsk_pcl_ros_utils/src/point_indices_to_cluster_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/point_indices_to_cluster_point_indices_nodelet.cpp
@@ -58,6 +58,7 @@ namespace jsk_pcl_ros_utils
   void PointIndicesToClusterPointIndices::convert(
     const PCLIndicesMsg::ConstPtr& indices_msg)
   {
+    vital_checker_->poke();
     jsk_recognition_msgs::ClusterPointIndices cluster_indices_msg;
     cluster_indices_msg.header = indices_msg->header;
     cluster_indices_msg.cluster_indices.push_back(*indices_msg);

--- a/jsk_pcl_ros_utils/src/point_indices_to_mask_image_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/point_indices_to_mask_image_nodelet.cpp
@@ -47,6 +47,7 @@ namespace jsk_pcl_ros_utils
     pnh_->param("queue_size", queue_size_, 100);
     pnh_->param("static_image_size", static_image_size_, false);
     pub_ = advertise<sensor_msgs::Image>(*pnh_, "output", 1);
+    onInitPostProcess();
   }
 
   void PointIndicesToMaskImage::subscribe()

--- a/jsk_pcl_ros_utils/src/pointcloud_relative_from_pose_stamped_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/pointcloud_relative_from_pose_stamped_nodelet.cpp
@@ -67,6 +67,7 @@ namespace jsk_pcl_ros_utils
   void PointCloudRelativeFromPoseStamped::transform(const sensor_msgs::PointCloud2::ConstPtr& cloud_msg,
                                                     const geometry_msgs::PoseStamped::ConstPtr& pose_msg)
   {
+    vital_checker_->poke();
     if (!jsk_recognition_utils::isSameFrameId(cloud_msg->header.frame_id,
                                              pose_msg->header.frame_id)) {
       NODELET_ERROR("frame_id does not match. cloud: %s, pose: %s",

--- a/jsk_pcl_ros_utils/src/pointcloud_relative_from_pose_stamped_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/pointcloud_relative_from_pose_stamped_nodelet.cpp
@@ -47,6 +47,7 @@ namespace jsk_pcl_ros_utils
   {
     DiagnosticNodelet::onInit();
     pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);
+    onInitPostProcess();
   }
   
   void PointCloudRelativeFromPoseStamped::subscribe()

--- a/jsk_pcl_ros_utils/src/pointcloud_to_cluster_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/pointcloud_to_cluster_point_indices_nodelet.cpp
@@ -41,6 +41,7 @@ namespace jsk_pcl_ros_utils
   {
     DiagnosticNodelet::onInit();
     pub_ = advertise<jsk_recognition_msgs::ClusterPointIndices>(*pnh_, "output", 1);
+    onInitPostProcess();
   }
 
   void PointCloudToClusterPointIndices::subscribe()

--- a/jsk_pcl_ros_utils/src/pointcloud_to_cluster_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/pointcloud_to_cluster_point_indices_nodelet.cpp
@@ -57,6 +57,7 @@ namespace jsk_pcl_ros_utils
   void PointCloudToClusterPointIndices::convert(
     const sensor_msgs::PointCloud2::ConstPtr& msg)
   {
+    vital_checker_->poke();
     int point_num = msg->width * msg->height;
     pcl_msgs::PointIndices indices;
     jsk_recognition_msgs::ClusterPointIndices cluster_indices;

--- a/jsk_pcl_ros_utils/src/pointcloud_to_mask_image_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/pointcloud_to_mask_image_nodelet.cpp
@@ -71,6 +71,7 @@ namespace jsk_pcl_ros_utils
 
   void PointCloudToMaskImage::convert(const sensor_msgs::PointCloud2::ConstPtr& cloud_msg)
   {
+    vital_checker_->poke();
     pcl::PointCloud<pcl::PointXYZ>::Ptr pc(new pcl::PointCloud<pcl::PointXYZ>);
     pcl::fromROSMsg(*cloud_msg, *pc);
 

--- a/jsk_pcl_ros_utils/src/pointcloud_to_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/pointcloud_to_point_indices_nodelet.cpp
@@ -71,6 +71,7 @@ namespace jsk_pcl_ros_utils
 
   void PointCloudToPointIndices::convert(const sensor_msgs::PointCloud2::ConstPtr& cloud_msg)
   {
+    vital_checker_->poke();
     pcl::PointCloud<pcl::PointXYZ>::Ptr pc(new pcl::PointCloud<pcl::PointXYZ>);
     pcl::fromROSMsg(*cloud_msg, *pc);
     PCLIndicesMsg indices_msg;

--- a/jsk_pcl_ros_utils/src/polygon_array_angle_likelihood_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_array_angle_likelihood_nodelet.cpp
@@ -85,6 +85,7 @@ namespace jsk_pcl_ros_utils
     const jsk_recognition_msgs::PolygonArray::ConstPtr& msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+    vital_checker_->poke();
     jsk_recognition_msgs::PolygonArray new_msg(*msg);
 
     try

--- a/jsk_pcl_ros_utils/src/polygon_array_angle_likelihood_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_array_angle_likelihood_nodelet.cpp
@@ -62,6 +62,7 @@ namespace jsk_pcl_ros_utils
     axis_[2] = axis[2];
     tf_listener_ = jsk_recognition_utils::TfListenerSingleton::getInstance();
     pub_ = advertise<jsk_recognition_msgs::PolygonArray>(*pnh_, "output", 1);
+    onInitPostProcess();
   }
 
   void PolygonArrayAngleLikelihood::subscribe()

--- a/jsk_pcl_ros_utils/src/polygon_array_area_likelihood_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_array_area_likelihood_nodelet.cpp
@@ -67,6 +67,7 @@ namespace jsk_pcl_ros_utils
     const jsk_recognition_msgs::PolygonArray::ConstPtr& msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+    vital_checker_->poke();
     jsk_recognition_msgs::PolygonArray new_msg(*msg);
 
     double min_area = DBL_MAX;

--- a/jsk_pcl_ros_utils/src/polygon_array_area_likelihood_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_array_area_likelihood_nodelet.cpp
@@ -50,6 +50,7 @@ namespace jsk_pcl_ros_utils
       boost::bind (&PolygonArrayAreaLikelihood::configCallback, this, _1, _2);
     srv_->setCallback (f);
     pub_ = advertise<jsk_recognition_msgs::PolygonArray>(*pnh_, "output", 1);
+    onInitPostProcess();
   }
 
   void PolygonArrayAreaLikelihood::subscribe()

--- a/jsk_pcl_ros_utils/src/polygon_array_distance_likelihood_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_array_distance_likelihood_nodelet.cpp
@@ -75,6 +75,7 @@ namespace jsk_pcl_ros_utils
     const jsk_recognition_msgs::PolygonArray::ConstPtr& msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+    vital_checker_->poke();
     jsk_recognition_msgs::PolygonArray new_msg(*msg);
 
     try

--- a/jsk_pcl_ros_utils/src/polygon_array_distance_likelihood_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_array_distance_likelihood_nodelet.cpp
@@ -52,6 +52,8 @@ namespace jsk_pcl_ros_utils
     pnh_->param("tf_queue_size", tf_queue_size_, 10);
     tf_listener_ = jsk_recognition_utils::TfListenerSingleton::getInstance();
     pub_ = advertise<jsk_recognition_msgs::PolygonArray>(*pnh_, "output", 1);
+
+    onInitPostProcess();
   }
 
   void PolygonArrayDistanceLikelihood::subscribe()

--- a/jsk_pcl_ros_utils/src/polygon_array_foot_angle_likelihood_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_array_foot_angle_likelihood_nodelet.cpp
@@ -85,6 +85,7 @@ namespace jsk_pcl_ros_utils
     const jsk_recognition_msgs::PolygonArray::ConstPtr& msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+    vital_checker_->poke();
     jsk_recognition_msgs::PolygonArray new_msg(*msg);
 
     try

--- a/jsk_pcl_ros_utils/src/polygon_array_foot_angle_likelihood_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_array_foot_angle_likelihood_nodelet.cpp
@@ -62,6 +62,8 @@ namespace jsk_pcl_ros_utils
     axis_[2] = axis[2];
     tf_listener_ = jsk_recognition_utils::TfListenerSingleton::getInstance();
     pub_ = advertise<jsk_recognition_msgs::PolygonArray>(*pnh_, "output", 1);
+
+    onInitPostProcess();
   }
 
   void PolygonArrayFootAngleLikelihood::subscribe()

--- a/jsk_pcl_ros_utils/src/polygon_flipper_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_flipper_nodelet.cpp
@@ -55,6 +55,8 @@ namespace jsk_pcl_ros_utils
       *pnh_, "output/indices", 1);
     pub_coefficients_ = advertise<jsk_recognition_msgs::ModelCoefficientsArray>(
       *pnh_, "output/coefficients", 1);
+
+    onInitPostProcess();
   }
 
   void PolygonFlipper::subscribe()

--- a/jsk_pcl_ros_utils/src/polygon_magnifier_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_magnifier_nodelet.cpp
@@ -48,6 +48,7 @@ namespace jsk_pcl_ros_utils
     srv_->setCallback (f);
 
     pub_ = advertise<jsk_recognition_msgs::PolygonArray>(*pnh_, "output", 1);
+    onInitPostProcess();
   }
 
   void PolygonMagnifier::subscribe()

--- a/jsk_pcl_ros_utils/src/polygon_points_sampler_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_points_sampler_nodelet.cpp
@@ -104,6 +104,7 @@ namespace jsk_pcl_ros_utils
     const jsk_recognition_msgs::ModelCoefficientsArray::ConstPtr& coefficients_msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+    vital_checker_->poke();
     // check frame_ids
     if (!isValidMessage(polygon_msg, coefficients_msg)) {
       return;

--- a/jsk_pcl_ros_utils/src/polygon_points_sampler_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_points_sampler_nodelet.cpp
@@ -49,6 +49,8 @@ namespace jsk_pcl_ros_utils
 
     pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);
     pub_xyz_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output_xyz", 1);
+
+    onInitPostProcess();
   }
 
   void PolygonPointsSampler::subscribe()

--- a/jsk_pcl_ros_utils/src/pose_with_covariance_stamped_to_gaussian_pointcloud_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/pose_with_covariance_stamped_to_gaussian_pointcloud_nodelet.cpp
@@ -50,6 +50,8 @@ namespace jsk_pcl_ros_utils
     srv_->setCallback (f);
 
     pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);
+
+    onInitPostProcess();
   }
 
   void PoseWithCovarianceStampedToGaussianPointCloud::subscribe()

--- a/jsk_pcl_ros_utils/src/pose_with_covariance_stamped_to_gaussian_pointcloud_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/pose_with_covariance_stamped_to_gaussian_pointcloud_nodelet.cpp
@@ -79,6 +79,7 @@ namespace jsk_pcl_ros_utils
   void PoseWithCovarianceStampedToGaussianPointCloud::convert(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr& msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+    vital_checker_->poke();
     pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
     Eigen::Vector2f mean;
     Eigen::Matrix2f S;
@@ -162,7 +163,6 @@ namespace jsk_pcl_ros_utils
     normalize_value_ = config.normalize_value;
     normalize_method_ = config.normalize_method;
   }
-                                                                     
 }
 
 #include <pluginlib/class_list_macros.h>

--- a/jsk_pcl_ros_utils/src/spherical_pointcloud_simulator_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/spherical_pointcloud_simulator_nodelet.cpp
@@ -57,6 +57,7 @@ namespace jsk_pcl_ros_utils
     }
     pub_ = advertise<sensor_msgs::PointCloud2>(
       *pnh_, "output", 1);
+    onInitPostProcess();
   }
 
   void SphericalPointCloudSimulator::subscribe()

--- a/jsk_pcl_ros_utils/src/spherical_pointcloud_simulator_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/spherical_pointcloud_simulator_nodelet.cpp
@@ -96,6 +96,7 @@ namespace jsk_pcl_ros_utils
     const sensor_msgs::PointCloud2::ConstPtr& msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+    vital_checker_->poke();
     pcl::PointCloud<pcl::PointXYZ>::Ptr
       cloud (new pcl::PointCloud<pcl::PointXYZ>);
     // 40fps 

--- a/jsk_pcl_ros_utils/src/subtract_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/subtract_point_indices_nodelet.cpp
@@ -44,6 +44,7 @@ namespace jsk_pcl_ros_utils
     DiagnosticNodelet::onInit();
     pnh_->param("approximate_sync", approximate_sync_, false);
     pub_ = advertise<PCLIndicesMsg>(*pnh_, "output", 1);
+    onInitPostProcess();
   }
 
   void SubtractPointIndices::subscribe()

--- a/jsk_pcl_ros_utils/src/subtract_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/subtract_point_indices_nodelet.cpp
@@ -76,6 +76,7 @@ namespace jsk_pcl_ros_utils
     const PCLIndicesMsg::ConstPtr& src1,
     const PCLIndicesMsg::ConstPtr& src2)
   {
+    vital_checker_->poke();
     pcl::PointIndices a, b;
     pcl_conversions::toPCL(*src1, a);
     pcl_conversions::toPCL(*src2, b);

--- a/jsk_pcl_ros_utils/src/tf_transform_bounding_box_array_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/tf_transform_bounding_box_array_nodelet.cpp
@@ -52,6 +52,8 @@ namespace jsk_pcl_ros_utils
     pnh_->param("tf_queue_size", tf_queue_size_, 10);
     tf_listener_ = jsk_recognition_utils::TfListenerSingleton::getInstance();
     pub_ = advertise<jsk_recognition_msgs::BoundingBoxArray>(*pnh_, "output", 1);
+
+    onInitPostProcess();
   }
 
   void TfTransformBoundingBoxArray::subscribe()

--- a/jsk_pcl_ros_utils/src/tf_transform_bounding_box_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/tf_transform_bounding_box_nodelet.cpp
@@ -52,6 +52,7 @@ namespace jsk_pcl_ros_utils
     pnh_->param("tf_queue_size", tf_queue_size_, 10);
     tf_listener_ = jsk_recognition_utils::TfListenerSingleton::getInstance();
     pub_ = advertise<jsk_recognition_msgs::BoundingBox>(*pnh_, "output", 1);
+    onInitPostProcess();
   }
 
   void TfTransformBoundingBox::subscribe()

--- a/jsk_pcl_ros_utils/src/tf_transform_cloud_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/tf_transform_cloud_nodelet.cpp
@@ -90,6 +90,8 @@ namespace jsk_pcl_ros_utils
     pnh_->param("tf_queue_size", tf_queue_size_, 10);
     tf_listener_ = jsk_recognition_utils::TfListenerSingleton::getInstance();
     pub_cloud_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);
+
+    onInitPostProcess();
   }
 
   void TfTransformCloud::subscribe()


### PR DESCRIPTION
Some nodelet forgot to enable super class functionality:

- Forgot to call `vital_checker_->poke()`

Without calling this method on callback, runtime_monitor displays error state on the nodelet and it is very confusing on debugging.

- Forgot to call `onInitPostProcess()`

Without calling this method on `onInit()` method, nodelet does not subscribe on start even if param `always_subscribe` is set to `true`.