### PR TITLE
Enhance fcn_object_segmentation.py with PyTorch backend

### DIFF
--- a/jsk_perception/node_scripts/fcn_object_segmentation.py
+++ b/jsk_perception/node_scripts/fcn_object_segmentation.py
@@ -47,6 +47,8 @@ class FCNObjectSegmentation(ConnectionBasedTransport):
             self._load_chainer_model()
         elif self.backend == 'torch':
             assert_torch_available()
+            # we assume input data size won't change in dynamic
+            torch.backends.cudnn.benchmark = True
             self._load_torch_model()
         else:
             raise RuntimeError('Unsupported backend: %s', self.backend)
@@ -73,7 +75,7 @@ class FCNObjectSegmentation(ConnectionBasedTransport):
     def _load_torch_model(self):
         try:
             import torchfcn
-        except ImportError as e:
+        except ImportError:
             raise ImportError('Please install torchfcn: pip install torchfcn')
         n_class = len(self.target_names)
         model_file = rospy.get_param('~model_file')
@@ -149,7 +151,6 @@ class FCNObjectSegmentation(ConnectionBasedTransport):
         if self.backend == 'chainer':
             return self._segment_chainer_backend(bgr)
         elif self.backend == 'torch':
-            assert_torch_available()
             return self._segment_torch_backend(bgr)
         raise ValueError('Unsupported backend: {0}'.format(self.backend))
 
@@ -185,9 +186,7 @@ class FCNObjectSegmentation(ConnectionBasedTransport):
         # uncertain because the probability is low
         label[max_proba < self.proba_threshold] = self.bg_label
         # gpu -> cpu
-        score = score.permute(0, 2, 3, 1).data.cpu().numpy()[0]
         proba = proba.permute(0, 2, 3, 1).data.cpu().numpy()[0]
-        max_proba = max_proba.data.cpu().numpy().squeeze((0, 1))
         label = label.data.cpu().numpy().squeeze((0, 1))
         return label, proba
 

--- a/jsk_perception/node_scripts/fcn_object_segmentation.py
+++ b/jsk_perception/node_scripts/fcn_object_segmentation.py
@@ -81,7 +81,7 @@ class FCNObjectSegmentation(ConnectionBasedTransport):
         if model_name == 'fcn32s':
             self.model = torchfcn.models.FCN32s(n_class=n_class)
         elif model_name == 'fcn32s_bilinear':
-            self.model = torchfcn.models.FCN32s(n_class=n_class, deconv=False)
+            self.model = torchfcn.models.FCN32s(n_class=n_class, nodeconv=True)
         else:
             raise ValueError('Unsupported ~model_name: {0}'.format(model_name))
         jsk_loginfo('Loading trained model: %s' % model_file)


### PR DESCRIPTION
- modified: jsk_perception/node_scripts/fcn_object_segmentation.py

## Before

```bash
% rp hz /fcn_object_segmentation/output -w 30 --wall-time
subscribed to [/fcn_object_segmentation/output]
average rate: 5.166
        min: 0.189s max: 0.201s std dev: 0.00433s window: 5
average rate: 5.172
        min: 0.183s max: 0.201s std dev: 0.00550s window: 10
average rate: 5.120
        min: 0.183s max: 0.208s std dev: 0.00661s window: 15
average rate: 5.113
        min: 0.180s max: 0.210s std dev: 0.00752s window: 20
average rate: 5.094
        min: 0.180s max: 0.213s std dev: 0.00776s window: 25
average rate: 5.067
        min: 0.180s max: 0.216s std dev: 0.00895s window: 30
average rate: 5.070
        min: 0.180s max: 0.216s std dev: 0.00915s window: 30
average rate: 5.069
        min: 0.180s max: 0.216s std dev: 0.00896s window: 30
^Caverage rate: 5.059
        min: 0.180s max: 0.216s std dev: 0.00872s window: 30
```

## After

```
% rp hz /fcn_object_segmentation/output -w 30 --wall-time
subscribed to [/fcn_object_segmentation/output]
average rate: 5.977
        min: 0.161s max: 0.178s std dev: 0.00648s window: 5
average rate: 5.968
        min: 0.161s max: 0.178s std dev: 0.00525s window: 11
average rate: 5.976
        min: 0.160s max: 0.179s std dev: 0.00573s window: 17
average rate: 5.955
        min: 0.160s max: 0.179s std dev: 0.00591s window: 23
average rate: 5.966
        min: 0.160s max: 0.179s std dev: 0.00572s window: 29
average rate: 5.949
        min: 0.160s max: 0.181s std dev: 0.00583s window: 30
^Caverage rate: 5.949
        min: 0.160s max: 0.181s std dev: 0.00599s window: 30
```