### PR TITLE
enlarge euclidean clustering max cluster size

### DIFF
--- a/jsk_pcl_ros/cfg/EuclideanClustering.cfg
+++ b/jsk_pcl_ros/cfg/EuclideanClustering.cfg
@@ -10,7 +10,7 @@ from math import pi
 gen = ParameterGenerator ()
 gen.add("tolerance", double_t, 0, "margin length of each clustering", 0.02, 0.0, 1.0)
 gen.add("label_tracking_tolerance", double_t, 0, "margin length of label tracking", 0.2, 0.0, 1.0)
-gen.add("max_size", int_t, 0, "the max number of the points of each cluster", 25000, 0, 100000)
+gen.add("max_size", int_t, 0, "the max number of the points of each cluster", 25000, 0, 2000000)
 gen.add("min_size", int_t, 0, "the minimum number of the points of each cluster", 20, 0, 1000)
 
 exit (gen.generate (PACKAGE, "jsk_pcl_ros", "EuclideanClustering"))


### PR DESCRIPTION
maximum cluster size 100000 is too small for large image.
For finding large objects from 2K image like ZED, we need more large max_size parameter.