### PR TITLE
Add ~approximate_sync param to ConsensusTracking

### DIFF
--- a/doc/jsk_perception/nodes/consensus_tracking.rst
+++ b/doc/jsk_perception/nodes/consensus_tracking.rst
@@ -41,6 +41,10 @@ Parameters
   How many messages you allow about the subscriber to keep in the queue.
   This should be big when there is much difference about delay between two topics.
 
+* ``~approximate_sync`` (Bool, default: ``False``)
+
+  Whether to use approximate for input topics.
+
 
 Sample
 ------

--- a/jsk_perception/include/jsk_perception/consensus_tracking.h
+++ b/jsk_perception/include/jsk_perception/consensus_tracking.h
@@ -41,6 +41,7 @@
 #include <message_filters/subscriber.h>
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/exact_time.h>
+#include <message_filters/sync_policies/approximate_time.h>
 #include <jsk_topic_tools/diagnostic_nodelet.h>
 #include <sensor_msgs/Image.h>
 
@@ -52,6 +53,9 @@ namespace jsk_perception
     ConsensusTracking() :
       DiagnosticNodelet("ConsensusTracking"),
       window_initialized_(false) {}
+    typedef message_filters::sync_policies::ApproximateTime<
+      sensor_msgs::Image,
+      geometry_msgs::PolygonStamped> ApproximateSyncPolicy;
     typedef message_filters::sync_policies::ExactTime<
       sensor_msgs::Image,
       geometry_msgs::PolygonStamped> ExactSyncPolicy;
@@ -68,6 +72,7 @@ namespace jsk_perception
 
     ros::Subscriber sub_image_;
     boost::shared_ptr<message_filters::Synchronizer<ExactSyncPolicy> > sync_;
+    boost::shared_ptr<message_filters::Synchronizer<ApproximateSyncPolicy> > async_;
     message_filters::Subscriber<sensor_msgs::Image> sub_image_to_init_;
     message_filters::Subscriber<geometry_msgs::PolygonStamped> sub_polygon_to_init_;
 
@@ -75,6 +80,7 @@ namespace jsk_perception
 
     boost::mutex mutex_;
     bool window_initialized_;
+    bool approximate_sync_;
     int queue_size_;
   private:
   };


### PR DESCRIPTION
Modified:
  - doc/jsk_perception/nodes/consensus_tracking.rst
  - jsk_perception/include/jsk_perception/consensus_tracking.h
  - jsk_perception/src/consensus_tracking.cpp