### PR TITLE
[jsk_recognition_msgs] add labeled pose message.

### DIFF
--- a/jsk_recognition_msgs/CMakeLists.txt
+++ b/jsk_recognition_msgs/CMakeLists.txt
@@ -61,6 +61,9 @@ add_message_files(
   Segment.msg
   SegmentStamped.msg
   SegmentArray.msg
+  LabeledPose.msg
+  LabeledPoseArray.msg
+  LabeledPoseStamped.msg
   )
 
 # TODO(wkentaro): Most of srv files are duplicated in jsk_pcl_ros,

--- a/jsk_recognition_msgs/msg/LabeledPose.msg
+++ b/jsk_recognition_msgs/msg/LabeledPose.msg
@@ -1,0 +1,2 @@
+geometry_msgs/Pose pose
+string label

--- a/jsk_recognition_msgs/msg/LabeledPoseArray.msg
+++ b/jsk_recognition_msgs/msg/LabeledPoseArray.msg
@@ -1,0 +1,2 @@
+Header header
+LabeledPose[] poses

--- a/jsk_recognition_msgs/msg/LabeledPoseStamped.msg
+++ b/jsk_recognition_msgs/msg/LabeledPoseStamped.msg
@@ -1,0 +1,2 @@
+Header header
+LabeledPose pose


### PR DESCRIPTION
I need topic message type of pose with string label in element_matching_pose_estimation https://github.com/jsk-ros-pkg/jsk_recognition/pull/2027 
in order to consider the matching of robot hand and object grasping point. (label of pose corresponds to hand name or object grasping point name.)

One solution is this PR and another is https://github.com/jsk-ros-pkg/jsk_recognition/pull/2080 .
Please give opinions.
I'll send PR of rviz plugins for visualizing topic after message is merged.
