### PR TITLE
Fix deprecation warning on RearrangeBoundingBox

### DIFF
--- a/jsk_pcl_ros/src/rearrange_bounding_box_nodelet.cpp
+++ b/jsk_pcl_ros/src/rearrange_bounding_box_nodelet.cpp
@@ -48,7 +48,8 @@ namespace jsk_pcl_ros
     pnh_->param("rotate_x", rotate_x_, 0.0);
     pnh_->param("rotate_y", rotate_y_, 0.0);
     pnh_->param("rotate_z", rotate_z_, 0.0);
-    q_ = tf2::Quaternion(rotate_y_, rotate_x_, rotate_z_);
+    q_ = tf2::Quaternion();
+    q_.setEuler(rotate_y_, rotate_x_, rotate_z_);
 
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
@@ -70,7 +71,8 @@ namespace jsk_pcl_ros
     rotate_x_ = config.rotate_x;
     rotate_y_ = config.rotate_y;
     rotate_z_ = config.rotate_z;
-    q_ = tf2::Quaternion(rotate_y_, rotate_x_, rotate_z_);
+    q_ = tf2::Quaternion();
+    q_.setEuler(rotate_y_, rotate_x_, rotate_z_);
   }
 
   void RearrangeBoundingBox::subscribe() {


### PR DESCRIPTION

To fix
```
WARNING: '/home/wkentaro/Projects/label_octomap/src/jsk-ros-pkg/jsk_recognition/jsk_pcl_ros/sample/data/sample_add_color_from_image_20170319.bag' exists
/home/wkentaro/Projects/label_octomap/src/jsk-ros-pkg/jsk_recognition/jsk_pcl_ros/src/rearrange_bounding_box_nodelet.cpp: In member function ‘virtual void jsk_pcl_ros::RearrangeBoundingBox::onInit()’:
/home/wkentaro/Projects/label_octomap/src/jsk-ros-pkg/jsk_recognition/jsk_pcl_ros/src/rearrange_bounding_box_nodelet.cpp:51:57: warning: ‘tf2::Quaternion::Quaternion(const tf2Scalar&, const tf2Scalar&, const tf2Scalar&)’ is deprecated (declared at /opt/ros/indigo/include/tf2/LinearMath/Quaternion.h:50) [-Wdeprecated-declarations]
     q_ = tf2::Quaternion(rotate_y_, rotate_x_, rotate_z_);
                                                         ^
/home/wkentaro/Projects/label_octomap/src/jsk-ros-pkg/jsk_recognition/jsk_pcl_ros/src/rearrange_bounding_box_nodelet.cpp: In member function ‘void jsk_pcl_ros::RearrangeBoundingBox::configCallback(jsk_pcl_ros::RearrangeBoundingBox::Config&, uint32_t)’:
/home/wkentaro/Projects/label_octomap/src/jsk-ros-pkg/jsk_recognition/jsk_pcl_ros/src/rearrange_bounding_box_nodelet.cpp:73:57: warning: ‘tf2::Quaternion::Quaternion(const tf2Scalar&, const tf2Scalar&, const tf2Scalar&)’ is deprecated (declared at /opt/ros/indigo/include/tf2/LinearMath/Quaternion.h:50) [-Wdeprecated-declarations]
     q_ = tf2::Quaternion(rotate_y_, rotate_x_, rotate_z_);
```