### PR TITLE
Cleanup octomap dependencies of jsk_pcl_ros

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -33,7 +33,6 @@ find_package(catkin REQUIRED COMPONENTS
   laser_assembler
   nodelet
   octomap_msgs
-  octomap_ros
   octomap_server
   pcl_msgs
   pcl_ros

--- a/jsk_pcl_ros/package.xml
+++ b/jsk_pcl_ros/package.xml
@@ -54,7 +54,6 @@
   <build_depend>octomap</build_depend>
   <build_depend>octomap_server</build_depend>
   <build_depend>octomap_msgs</build_depend>
-  <build_depend>octomap_ros</build_depend>
   <build_depend>jsk_pcl_ros_utils</build_depend>
   <build_depend>jsk_data</build_depend>
 
@@ -110,8 +109,6 @@
   <run_depend>nav_msgs</run_depend>
   <run_depend>octomap</run_depend>
   <run_depend>octomap_server</run_depend>
-  <run_depend>octomap_msgs</run_depend>
-  <run_depend>octomap_ros</run_depend>
   <run_depend>jsk_pcl_ros_utils</run_depend>
   <run_depend>jsk_data</run_depend>
   <test_depend>jsk_tools</test_depend>


### PR DESCRIPTION
Following fix in https://github.com/jsk-ros-pkg/jsk_recognition/issues/2087