### PR TITLE
[jsk_pcl_ros][ColorHistogramMatcher] add skip_compare option

### DIFF
--- a/doc/jsk_pcl_ros/nodes/color_histogram_matcher.md
+++ b/doc/jsk_pcl_ros/nodes/color_histogram_matcher.md
@@ -32,6 +32,10 @@ Finds objects similar to a selected object as reference based on bhattacharyya d
 
 ## Parameters
 
+- `skip_compare` (Bool, default: `False`)
+
+  If this value is `true`, only `~output_histogram` is published and skip comparison with reference.
+
 - `coefficient_threshold` (Double, default: `0.9`)
 
   Threshold for determining color histogram similarity

--- a/jsk_pcl_ros/cfg/ColorHistogramMatcher.cfg
+++ b/jsk_pcl_ros/cfg/ColorHistogramMatcher.cfg
@@ -29,4 +29,6 @@ show_method_enum = gen.enum([gen.const("blue_to_red", int_t, 0, "simple"),
                                   "show_method to be used")
 gen.add("show_method", int_t, 0, "show method", 0, 0, 1, 
         edit_method = show_method_enum)
+gen.add("skip_compare", bool_t, 0, "Skip compare and only publish histogram of input clouds", False)
+
 exit (gen.generate (PACKAGE, "jsk_pcl_ros", "ColorHistogramMatcher"))

--- a/jsk_pcl_ros/include/jsk_pcl_ros/color_histogram_matcher.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/color_histogram_matcher.h
@@ -104,6 +104,7 @@ namespace jsk_pcl_ros
     double color_min_coefficient_;
     double color_max_coefficient_;
     int show_method_;
+    bool skip_compare_;
     // must be exclusive
     ComparePolicy policy_;
   private:

--- a/jsk_pcl_ros/src/color_histogram_matcher_nodelet.cpp
+++ b/jsk_pcl_ros/src/color_histogram_matcher_nodelet.cpp
@@ -33,7 +33,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "jsk_pcl_ros/color_histogram_matcher.h"
+#include <jsk_pcl_ros/color_histogram_matcher.h>
 #include <pluginlib/class_list_macros.h>
 #include <pcl/filters/extract_indices.h>
 #include <pcl/point_types_conversion.h>
@@ -102,6 +102,8 @@ namespace jsk_pcl_ros
     color_min_coefficient_ = config.color_min_coefficient;
     color_max_coefficient_ = config.color_max_coefficient;
     show_method_ = config.show_method;
+    skip_compare_ = config.skip_compare;
+
     ComparePolicy new_histogram;
     if (config.histogram_method == 0) {
       new_histogram = USE_HUE;
@@ -132,7 +134,7 @@ namespace jsk_pcl_ros
       const jsk_recognition_msgs::ClusterPointIndices::ConstPtr& input_indices)
   {
     boost::mutex::scoped_lock lock(mutex_);
-    if (!reference_set_) {
+    if (!reference_set_ && !skip_compare_) {
       NODELET_WARN("reference histogram is not available yet");
       return;
     }
@@ -171,6 +173,7 @@ namespace jsk_pcl_ros
       histogram_array.histograms.push_back(ros_histogram);
     }
     all_histogram_pub_.publish(histogram_array);
+    if (skip_compare_) return;
 
     // compare histograms
     jsk_recognition_msgs::ClusterPointIndices result;


### PR DESCRIPTION
I'd like to only use the result of processing (histogram) and not to match with any references.
If `skip_compare` is set to `true`, matching will be disabled.