### PR TITLE
Stop using deprecated logging func in jsk_topic_tools

### DIFF
--- a/jsk_pcl_ros/scripts/extract_top_polygon_likelihood.py
+++ b/jsk_pcl_ros/scripts/extract_top_polygon_likelihood.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import rospy 
-from jsk_topic_tools import jsk_logdebug, jsk_loginfo, ConnectionBasedTransport
+from jsk_topic_tools import ConnectionBasedTransport
 from jsk_recognition_msgs.msg import PolygonArray, ModelCoefficientsArray
 from pcl_msgs.msg import ModelCoefficients
 from geometry_msgs.msg import PolygonStamped

--- a/jsk_pcl_ros/src/ppf_registration_nodelet.cpp
+++ b/jsk_pcl_ros/src/ppf_registration_nodelet.cpp
@@ -115,7 +115,7 @@ namespace jsk_pcl_ros
     pcl::concatenateFields (*cloud, *cloud_normals, *cloud_calculated);
 
     // DEBUG
-    JSK_NODELET_INFO_STREAM("cloud with normals size:" << cloud_calculated->points.size());
+    NODELET_INFO_STREAM("cloud with normals size:" << cloud_calculated->points.size());
     return cloud_calculated;
   }
 
@@ -173,7 +173,7 @@ namespace jsk_pcl_ros
     Eigen::Affine3f pose (mat);
     // DEBUG
     Eigen::IOFormat CleanFmt(4, 0, ", ", "\n", "[", "]");
-    JSK_NODELET_INFO_STREAM( "Matrix:\n" << mat.format(CleanFmt));
+    NODELET_INFO_STREAM( "Matrix:\n" << mat.format(CleanFmt));
 
     // transform reference
     pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_output (new pcl::PointCloud<pcl::PointXYZ> ());
@@ -254,7 +254,7 @@ namespace jsk_pcl_ros
       Eigen::Affine3f pose (mat);
       // DEBUG
       Eigen::IOFormat CleanFmt(4, 0, ", ", "\n", "[", "]");
-      JSK_NODELET_INFO_STREAM( "Matrix:\n" << mat.format(CleanFmt));
+      NODELET_INFO_STREAM( "Matrix:\n" << mat.format(CleanFmt));
 
       // transform reference
       pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_output (new pcl::PointCloud<pcl::PointXYZ> ());

--- a/jsk_perception/node_scripts/binpack_rect_array.py
+++ b/jsk_perception/node_scripts/binpack_rect_array.py
@@ -4,8 +4,6 @@ import numpy as np
 
 import cv_bridge
 from jsk_recognition_utils.depth import split_fore_background
-from jsk_topic_tools import jsk_logwarn
-from jsk_topic_tools import jsk_logerr
 from jsk_topic_tools import ConnectionBasedTransport
 from jsk_recognition_msgs.msg import RectArray, Rect
 import message_filters

--- a/jsk_perception/node_scripts/bof_histogram_extractor.py
+++ b/jsk_perception/node_scripts/bof_histogram_extractor.py
@@ -15,7 +15,7 @@ from sklearn.preprocessing import normalize
 import cv_bridge
 from jsk_recognition_msgs.msg import VectorArray
 from jsk_recognition_utils import decompose_descriptors_with_label
-from jsk_topic_tools import jsk_logdebug, jsk_loginfo, ConnectionBasedTransport
+from jsk_topic_tools import ConnectionBasedTransport
 import message_filters
 from posedetection_msgs.msg import Feature0D
 from sensor_msgs.msg import Image
@@ -29,7 +29,7 @@ class BoFHistogramExtractor(ConnectionBasedTransport):
         self.queue_size = rospy.get_param('~queue_size', 10)
 
         # load bag of features
-        jsk_loginfo('Loading BoF data')
+        rospy.loginfo('Loading BoF data')
         bof_data = rospy.get_param('~bof_data', None)
         if bof_data is None:
             quit()
@@ -44,7 +44,7 @@ class BoFHistogramExtractor(ConnectionBasedTransport):
                 self.bof.nn.n_jobs = 1
 
         self._pub = self.advertise('~output', VectorArray, queue_size=1)
-        jsk_loginfo('Initialized BoF histogram extractor')
+        rospy.loginfo('Initialized BoF histogram extractor')
 
     def subscribe(self):
         self._sub_feature = message_filters.Subscriber('~input', Feature0D)
@@ -58,7 +58,7 @@ class BoFHistogramExtractor(ConnectionBasedTransport):
             sync = message_filters.TimeSynchronizer(
                 [self._sub_feature, self._sub_label],
                 queue_size=self.queue_size)
-        jsk_logdebug('~approximate_sync: {}'.format(use_async))
+        rospy.logdebug('~approximate_sync: {}'.format(use_async))
         sync.registerCallback(self._apply)
 
     def unsubscribe(self):
@@ -73,7 +73,7 @@ class BoFHistogramExtractor(ConnectionBasedTransport):
         pos = np.array(feature_msg.positions)
         pos = pos.reshape((-1, 2))
         if label.sum() == 0:
-            jsk_logdebug('Skip image with only background label')
+            rospy.logdebug('Skip image with only background label')
             return
         decomposed = decompose_descriptors_with_label(
             descriptors=desc, positions=pos, label_img=label,

--- a/jsk_perception/node_scripts/fast_rcnn.py
+++ b/jsk_perception/node_scripts/fast_rcnn.py
@@ -16,8 +16,6 @@ from jsk_recognition_utils.chainermodels import VGG16FastRCNN
 from jsk_recognition_utils.chainermodels import VGG_CNN_M_1024
 from jsk_recognition_utils.nms import nms
 from jsk_topic_tools import ConnectionBasedTransport
-from jsk_topic_tools.log_utils import jsk_logfatal
-from jsk_topic_tools.log_utils import jsk_loginfo
 import message_filters
 import rospkg
 import rospy
@@ -152,7 +150,7 @@ def main():
 
     # FIXME: In CPU mode, there is no detections.
     if not cuda.available:
-        jsk_logfatal('CUDA environment is required.')
+        rospy.logfatal('CUDA environment is required.')
         sys.exit(1)
     use_gpu = True
 
@@ -169,11 +167,11 @@ def main():
     else:
         rospy.logerr('Unsupported model: {0}'.format(model_name))
         sys.exit(1)
-    jsk_loginfo('Loading chainermodel')
+    rospy.loginfo('Loading chainermodel')
     S.load_hdf5(chainermodel, model)
     if use_gpu:
         model.to_gpu()
-    jsk_loginfo('Finished loading chainermodel')
+    rospy.loginfo('Finished loading chainermodel')
 
     # assumptions
     target_names = [

--- a/jsk_perception/node_scripts/fcn_object_segmentation.py
+++ b/jsk_perception/node_scripts/fcn_object_segmentation.py
@@ -7,7 +7,6 @@ import fcn
 
 import cv_bridge
 from jsk_topic_tools import ConnectionBasedTransport
-from jsk_topic_tools.log_utils import jsk_loginfo
 import message_filters
 import numpy as np
 import rospy
@@ -65,9 +64,9 @@ class FCNObjectSegmentation(ConnectionBasedTransport):
             self.model = fcn.models.FCN8s(n_class=n_class)
         else:
             raise ValueError('Unsupported ~model_name: {}'.format(model_name))
-        jsk_loginfo('Loading trained model: {0}'.format(model_h5))
+        rospy.loginfo('Loading trained model: {0}'.format(model_h5))
         S.load_hdf5(model_h5, self.model)
-        jsk_loginfo('Finished loading trained model: {0}'.format(model_h5))
+        rospy.loginfo('Finished loading trained model: {0}'.format(model_h5))
         if self.gpu != -1:
             self.model.to_gpu(self.gpu)
         self.model.train = False
@@ -86,9 +85,9 @@ class FCNObjectSegmentation(ConnectionBasedTransport):
             self.model = torchfcn.models.FCN32s(n_class=n_class, nodeconv=True)
         else:
             raise ValueError('Unsupported ~model_name: {0}'.format(model_name))
-        jsk_loginfo('Loading trained model: %s' % model_file)
+        rospy.loginfo('Loading trained model: %s' % model_file)
         self.model.load_state_dict(torch.load(model_file))
-        jsk_loginfo('Finished loading trained model: %s' % model_file)
+        rospy.loginfo('Finished loading trained model: %s' % model_file)
         if self.gpu >= 0:
             self.model = self.model.cuda(self.gpu)
         self.model.eval()

--- a/jsk_perception/node_scripts/image_publisher.py
+++ b/jsk_perception/node_scripts/image_publisher.py
@@ -12,9 +12,6 @@ import dynamic_reconfigure.server
 import rospy
 
 from jsk_perception.cfg import ImagePublisherConfig
-from jsk_topic_tools import jsk_logerr
-from jsk_topic_tools import jsk_loginfo
-from jsk_topic_tools import jsk_logwarn
 from sensor_msgs.msg import CameraInfo
 from sensor_msgs.msg import Image
 
@@ -41,11 +38,11 @@ class ImagePublisher(object):
         config['file_name'] = os.path.abspath(file_name)
         img_bgr = cv2.imread(file_name)
         if img_bgr is None:
-            jsk_logwarn('Could not read image file: {}'.format(file_name))
+            rospy.logwarn('Could not read image file: {}'.format(file_name))
             with self.lock:
                 self.imgmsg = None
         else:
-            jsk_loginfo('Read the image file: {}'.format(file_name))
+            rospy.loginfo('Read the image file: {}'.format(file_name))
             with self.lock:
                 self.imgmsg = self.cv2_to_imgmsg(img_bgr, self.encoding)
         return config
@@ -92,7 +89,7 @@ class ImagePublisher(object):
             else:
                 img = img_bgr
         else:
-            jsk_logerr('unsupported encoding: {0}'.format(encoding))
+            rospy.logerr('unsupported encoding: {0}'.format(encoding))
             return
         return bridge.cv2_to_imgmsg(img, encoding=encoding)
 

--- a/jsk_perception/node_scripts/label_image_decomposer.py
+++ b/jsk_perception/node_scripts/label_image_decomposer.py
@@ -11,7 +11,6 @@ from jsk_recognition_utils import bounding_rect_of_mask
 from jsk_recognition_utils import get_tile_image
 from jsk_recognition_utils.color import labelcolormap
 from jsk_topic_tools import ConnectionBasedTransport
-from jsk_topic_tools import jsk_loginfo
 from jsk_topic_tools import warn_no_remap
 import matplotlib
 matplotlib.use('Agg')  # NOQA
@@ -38,7 +37,7 @@ class LabelImageDecomposer(ConnectionBasedTransport):
                                                     queue_size=5)
         # publish each region image. this can take time so optional.
         self._publish_tile = rospy.get_param('~publish_tile', False)
-        jsk_loginfo('~publish_tile: {}'.format(self._publish_tile))
+        rospy.loginfo('~publish_tile: {}'.format(self._publish_tile))
         if self._publish_tile:
             self.pub_tile = self.advertise('~output/tile', Image, queue_size=5)
 
@@ -48,11 +47,11 @@ class LabelImageDecomposer(ConnectionBasedTransport):
         warn_no_remap('~input', '~input/label')
         use_async = rospy.get_param('~approximate_sync', False)
         queue_size = rospy.get_param('~queue_size', 10)
-        jsk_loginfo('~approximate_sync: {}, queue_size: {}'
-                    .format(use_async, queue_size))
+        rospy.loginfo('~approximate_sync: {}, queue_size: {}'
+                      .format(use_async, queue_size))
         if use_async:
             slop = rospy.get_param('~slop', 0.1)
-            jsk_loginfo('~slop: {}'.format(slop))
+            rospy.loginfo('~slop: {}'.format(slop))
             async = message_filters.ApproximateTimeSynchronizer(
                 [self.sub_img, self.sub_label],
                 queue_size=queue_size, slop=slop)

--- a/jsk_perception/node_scripts/mask_image_to_label.py
+++ b/jsk_perception/node_scripts/mask_image_to_label.py
@@ -4,7 +4,6 @@
 import numpy as np
 
 from jsk_topic_tools import ConnectionBasedTransport
-from jsk_topic_tools import jsk_logdebug
 import rospy
 from sensor_msgs.msg import Image
 import cv_bridge
@@ -25,7 +24,7 @@ class MaskImageToLabel(ConnectionBasedTransport):
         bridge = cv_bridge.CvBridge()
         mask = bridge.imgmsg_to_cv2(msg, desired_encoding='mono8')
         if mask.size == 0:
-            jsk_logdebug('Skipping empty image')
+            rospy.logdebug('Skipping empty image')
             return
         label = np.zeros(mask.shape, dtype=np.int32)
         label[mask == 0] = 0

--- a/jsk_perception/node_scripts/solidity_rag_merge.py
+++ b/jsk_perception/node_scripts/solidity_rag_merge.py
@@ -18,7 +18,6 @@ from skimage.util import img_as_uint
 
 import cv_bridge
 from jsk_topic_tools import ConnectionBasedTransport
-from jsk_topic_tools import jsk_loginfo
 from jsk_topic_tools import warn_no_remap
 import message_filters
 import rospy
@@ -154,7 +153,7 @@ class SolidityRagMerge(ConnectionBasedTransport):
         self.sub = message_filters.Subscriber('~input', Image)
         self.sub_mask = message_filters.Subscriber('~input/mask', Image)
         self.use_async = rospy.get_param('~approximate_sync', False)
-        jsk_loginfo('~approximate_sync: {}'.format(self.use_async))
+        rospy.loginfo('~approximate_sync: {}'.format(self.use_async))
         if self.use_async:
             sync = message_filters.ApproximateTimeSynchronizer(
                 [self.sub, self.sub_mask], queue_size=1000, slop=0.1)

--- a/jsk_perception/node_scripts/split_fore_background.py
+++ b/jsk_perception/node_scripts/split_fore_background.py
@@ -6,7 +6,6 @@ import numpy as np
 import cv_bridge
 from jsk_recognition_utils.depth import split_fore_background
 from jsk_topic_tools import ConnectionBasedTransport
-from jsk_topic_tools import jsk_logwarn
 import rospy
 from sensor_msgs.msg import Image
 
@@ -30,8 +29,8 @@ class SplitForeBackground(ConnectionBasedTransport):
         # validation
         supported_encodings = {'16UC1', '32FC1'}
         if depth_msg.encoding not in supported_encodings:
-            jsk_logwarn('Unsupported depth image encoding: {0}'
-                        .format(depth_msg.encoding))
+            rospy.logwarn('Unsupported depth image encoding: {0}'
+                          .format(depth_msg.encoding))
         # split fg/bg and get each mask
         bridge = cv_bridge.CvBridge()
         depth = bridge.imgmsg_to_cv2(depth_msg)

--- a/jsk_perception/node_scripts/unwrap_histogram_with_range_array.py
+++ b/jsk_perception/node_scripts/unwrap_histogram_with_range_array.py
@@ -4,7 +4,7 @@
 Convert HistogramWithRangeArray to HistogramWithRange
 """
 
-from jsk_topic_tools import jsk_logdebug, jsk_loginfo, ConnectionBasedTransport
+from jsk_topic_tools import ConnectionBasedTransport
 from jsk_recognition_msgs.msg import HistogramWithRange, HistogramWithRangeArray
 
 import rospy


### PR DESCRIPTION
Because it is deprecated by https://github.com/jsk-ros-pkg/jsk_common/issues/1461.