### PR TITLE
Fix typo in ColorBasedRegionGrowingSegmentation

### DIFF
--- a/jsk_pcl_ros/cfg/ColorBasedRegionGrowingSegmentation.cfg
+++ b/jsk_pcl_ros/cfg/ColorBasedRegionGrowingSegmentation.cfg
@@ -8,9 +8,9 @@ from dynamic_reconfigure.parameter_generator_catkin import *;
 from math import pi
 
 gen = ParameterGenerator ()
-gen.add("distance_threshould", int_t, 0, "the number used to determine whether the point is neighboring or not", 10, 0, 1000)
-gen.add("point_color_threshould", int_t, 0, "the number used to detemine if the point belongs to cluster", 6, 0, 100)
-gen.add("region_color_threshould", int_t, 0, "the number used when the merging process takes place", 5, 0, 100)
+gen.add("distance_threshold", int_t, 0, "the number used to determine whether the point is neighboring or not", 10, 0, 1000)
+gen.add("point_color_threshold", int_t, 0, "the number used to detemine if the point belongs to cluster", 6, 0, 100)
+gen.add("region_color_threshold", int_t, 0, "the number used when the merging process takes place", 5, 0, 100)
 gen.add("min_cluster_size", int_t, 0, "the min number of the cluster size", 600, 0, 1000)
 
 

--- a/jsk_pcl_ros/include/jsk_pcl_ros/color_based_region_growing_segmentation.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/color_based_region_growing_segmentation.h
@@ -57,9 +57,9 @@ namespace jsk_pcl_ros
   protected:
     ros::Publisher pub_;
     ros::Subscriber sub_;
-    int distance_threshould_;
-    int point_color_threshould_;
-    int region_color_threshould_;
+    int distance_threshold_;
+    int point_color_threshold_;
+    int region_color_threshold_;
     int min_cluster_size_;
     typedef jsk_pcl_ros::ColorBasedRegionGrowingSegmentationConfig Config;
     boost::shared_ptr <dynamic_reconfigure::Server<Config> > srv_;

--- a/jsk_pcl_ros/src/color_based_region_growing_segmentation_nodelet.cpp
+++ b/jsk_pcl_ros/src/color_based_region_growing_segmentation_nodelet.cpp
@@ -69,14 +69,14 @@ namespace jsk_pcl_ros
   {
     boost::mutex::scoped_lock lock(mutex_);
 
-    if (distance_threshould_ != config.distance_threshould) {
-      distance_threshould_ = config.distance_threshould;
+    if (distance_threshold_ != config.distance_threshold) {
+      distance_threshold_ = config.distance_threshold;
     }
-    if (point_color_threshould_ != config.point_color_threshould) {
-      point_color_threshould_ = config.point_color_threshould;
+    if (point_color_threshold_ != config.point_color_threshold) {
+      point_color_threshold_ = config.point_color_threshold;
     }
-    if (region_color_threshould_ != config.region_color_threshould) {
-      region_color_threshould_ = config.region_color_threshould;
+    if (region_color_threshold_ != config.region_color_threshold) {
+      region_color_threshold_ = config.region_color_threshold;
     }
     if (min_cluster_size_ != config.min_cluster_size) {
       min_cluster_size_ = config.min_cluster_size;
@@ -97,9 +97,9 @@ namespace jsk_pcl_ros
     pcl::RegionGrowingRGB<pcl::PointXYZRGB> reg;
     reg.setInputCloud (cloud);
     reg.setSearchMethod (tree);
-    reg.setDistanceThreshold (distance_threshould_);
-    reg.setPointColorThreshold (point_color_threshould_);
-    reg.setRegionColorThreshold (region_color_threshould_);
+    reg.setDistanceThreshold (distance_threshold_);
+    reg.setPointColorThreshold (point_color_threshold_);
+    reg.setRegionColorThreshold (region_color_threshold_);
     reg.setMinClusterSize (min_cluster_size_);
 
     std::vector <pcl::PointIndices> clusters;


### PR DESCRIPTION
Fix typo in ColorBasedRegionGrowingSegmentation's parameters. #2096 

thresho**u**ld  → threshold

Could not test because was having some troubles trying to build from source, but I believe it should be fine.