### PR TITLE
[jsk_pcl_ros_utils] Add nodelet for computing & comparing color histogram

### DIFF
--- a/doc/jsk_pcl_ros/nodes/color_histogram.md
+++ b/doc/jsk_pcl_ros/nodes/color_histogram.md
@@ -1,0 +1,47 @@
+ColorHistogram
+==============
+
+![hue_sat](https://user-images.githubusercontent.com/1901008/26964249-a3a89382-4d2b-11e7-8ce1-c4a12f57ee06.gif)
+
+Compute color histogram for each cluster point indices.
+
+## Subscribing Topics
+
+* `~input` (`sensor_msgs/PointCloud2`)
+
+    Input point cloud
+
+* `~input/indices` (`jsk_recognition_msgs/ClusterPointIndices`)
+
+    Input point indices
+
+## Publishing Topics
+
+* `~output` (`jsk_recognition_msgs/ColorHistogramArray`)
+
+    Color histogram for each point indices
+    Each histogram contains either Hue, Saturation (as 1-d vector) or both of two values (as 2-d matrix). (configurable by parameter `~histogram_policy`)
+    Bin size is also configurable by parameter `~bin_size`.
+
+## Parameters
+
+* `~queue_size` (`Int`, default: `100`)
+
+    Queue size for message synchronization
+
+* `~bin_size` (`Int`, default: `100`)
+
+    Bin size for histogram  
+    If a parameter `~histogram_policy` is set as `HUE_AND_SATURATION`, actual vector length of each histogram is `bin_size * bin_size`, otherwise `bin_size`.
+
+* `~histogram_policy` (`Enum[Int]`, default: `HUE_AND_SATURATION`)
+
+    Policy for histogram values to accumulate
+
+    - 0: `HUE`
+        - Use hue only
+    - 1: `SATURATION`
+        - Use saturation only
+    - 2: `HUE_AND_SATURATION`
+        - Use both hue and saturation as 2-d matrix
+

--- a/doc/jsk_pcl_ros/nodes/color_histogram_classifier.md
+++ b/doc/jsk_pcl_ros/nodes/color_histogram_classifier.md
@@ -1,0 +1,67 @@
+ColorHistogramClassifier
+==============
+
+![detect_cans](https://user-images.githubusercontent.com/1901008/26961630-2ff9326c-4d1b-11e7-9a6e-2e149ae4ffca.png)
+
+Classify point indices using color histogram by comparing with reference histogram array
+
+Methods for histogram comparison is configurable from multiple methods. (See parameter `~compare_policy`)
+After computing distance between input histograms and reference, classify by their labels (See parameter `~detection_threshold`)
+Reference histograms are loaded from rosparam on start.
+
+## Subscribing Topics
+
+* `~input` (`jsk_recognition_msgs/ColorHistogram`)
+
+    Input color histogram to be classified  
+
+* `~input/array` (`jsk_recognition_msgs/ColorHistogramArray`)
+
+    Input color histogram array to be classified
+
+## Publishing Topics
+
+* `~output` (`jsk_recognition_msgs/ColorHistogramArray`)
+
+    Filtered color histogram array
+
+* `~output/indices` (`jsk_recognition_msgs/ClusterPointIndices`)
+
+    Filtered cluster point indices
+
+## Parameters
+
+* `~queue_size` (`Int`, default: `100`)
+
+    Queue size for message synchronization
+
+* `~compare_policy` (`Enum[Int]`, default: `CORRELATION`)
+
+    Policy for histogram values to compare
+
+    - 0: `CORRELATION`
+        - Use correlation
+    - 1: `BHATTACHARYYA`
+        - Use bhattacharyya distance
+    - 2: `INTERSECTION`
+        - Use vector intersection
+    - 3: `CHISQUARE`
+        - Use chi-square between two vectors
+    - 4: `KL_DIVERGENCE`
+        - Use Kullback-Leibler divergence for comparing two vectors
+
+* `~label_names` (`String[]`, required)
+
+    Reference class names
+
+    This parameter is required on start
+
+* `~histograms/<label name>` (`Double[]`, required)
+
+    Reference histogram vector for each class
+
+    Length of all histograms must be the same.
+
+* `~detection_threshold` (`Double`, default: `0.8`)
+
+    Color histograms and point cloud indices whose similarities are above this value are published as filtered topics.

--- a/doc/jsk_pcl_ros/nodes/color_histogram_filter.md
+++ b/doc/jsk_pcl_ros/nodes/color_histogram_filter.md
@@ -1,0 +1,77 @@
+ColorHistogramFilter
+==============
+
+![color_histogram](https://cloud.githubusercontent.com/assets/1901008/26710312/f1343f54-4793-11e7-8848-9a2f31e4b5d5.png)
+
+Filter point indices using color histogram by comparing with reference histogram
+
+Methods for histogram comparison is configurable from multiple methods. (See parameter `~compare_policy`)
+After computing distance between input histograms and reference, filter by thresholding (See parameter `~distance_threshold`)
+Reference histogram can be set as `~reference` topic or as a parameter `~reference_histogram`.
+
+## Subscribing Topics
+
+* `~input` (`jsk_recognition_msgs/ColorHistogramArray`)
+
+    Input color histogram array  
+    The order of each histograms must be the same as the order of input cluster point indices.
+
+* `~input/indices` (`jsk_recognition_msgs/ClusterPointIndices`)
+
+    Input point indices
+
+* `~input/reference` (`jsk_recognition_msgs/ColorHistogram`)
+
+    Reference histogram
+
+    It can be set as a parameter. See parameter `~reference_histogram`.
+
+## Publishing Topics
+
+* `~output` (`jsk_recognition_msgs/ColorHistogramArray`)
+
+    Filtered color histogram array
+
+* `~output/indices` (`jsk_recognition_msgs/ClusterPointIndices`)
+
+    Filtered cluster point indices
+
+## Parameters
+
+* `~queue_size` (`Int`, default: `100`)
+
+    Queue size for message synchronization
+
+* `~bin_size` (`Int`, default: `100`)
+
+    Bin size for histogram
+
+* `~compare_policy` (`Enum[Int]`, default: `CORRELATION`)
+
+    Policy for histogram values to compare
+
+    - 0: `CORRELATION`
+        - Use correlation
+    - 1: `BHATTACHARYYA`
+        - Use bhattacharyya distance
+    - 2: `INTERSECTION`
+        - Use vector intersection
+    - 3: `CHISQUARE`
+        - Use chi-square between two vectors
+    - 4: `KL_DIVERGENCE`
+        - Use Kullback-Leibler divergence for comparing two vectors
+
+* `~distance_threshold` (`Double`, default: `0.6`)
+
+    Color histograms and point cloud indices whose similarities are above this value are published as filtered topics.
+
+* `~flip_threshold` (`Bool`, default: `false`)
+
+    Publish indices whose distance from reference is higher than `~distance_threshold` if this value is `false`.
+    If this value is `true`, publish indices whose is lower than threshold.
+
+* `~reference_histogram` (`Float[]`)
+
+    Reference histogram
+
+    It can also be set as topic. See `~input/reference` topic.

--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -4,8 +4,8 @@ project(jsk_pcl_ros)
 
 # check c++11 / c++0x
 include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
+check_cxx_compiler_flag("-std=c++11" COMPILER_SUPPORTS_CXX11)
+check_cxx_compiler_flag("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
 if(COMPILER_SUPPORTS_CXX11)
   set(CMAKE_CXX_FLAGS "-std=c++11")
 elseif(COMPILER_SUPPORTS_CXX0X)
@@ -54,10 +54,10 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}
 find_package(PCL QUIET COMPONENTS gpu_kinfu_large_scale)
 
 pkg_check_modules(yaml_cpp yaml-cpp REQUIRED)
-IF(${yaml_cpp_VERSION} VERSION_LESS "0.5.0")
+if(${yaml_cpp_VERSION} VERSION_LESS "0.5.0")
 ## indigo yaml-cpp : 0.5.0 /  hydro yaml-cpp : 0.3.0
   add_definitions("-DUSE_OLD_YAML")
-ENDIF()
+endif()
 
 # generate the dynamic_reconfigure config file
 generate_dynamic_reconfigure_options(
@@ -94,7 +94,11 @@ generate_dynamic_reconfigure_options(
   cfg/MultiPlaneExtraction.cfg
   cfg/NormalEstimationIntegralImage.cfg
   cfg/EnvironmentPlaneModeling.cfg
+  cfg/ColorHistogram.cfg
+  cfg/ColorHistogramClassifier.cfg
+  cfg/ColorHistogramFilter.cfg
   cfg/ColorHistogramMatcher.cfg
+  cfg/ColorHistogramVisualizer.cfg
   cfg/ClusterPointIndicesDecomposer.cfg
   cfg/GridSampler.cfg
   cfg/OrganizedEdgeDetector.cfg
@@ -222,6 +226,13 @@ if(ml_classifiers_FOUND)
 endif(ml_classifiers_FOUND)
 jsk_pcl_nodelet(src/environment_plane_modeling_nodelet.cpp
   "jsk_pcl/EnvironmentPlaneModeling" "environment_plane_modeling")
+if(jsk_topic_tools_VERSION VERSION_LESS 2.2.4)
+  message(WARNING "ColorHistogram requires jsk_topic_tools >= 2.2.4")
+else()
+  jsk_pcl_nodelet(src/color_histogram_nodelet.cpp "jsk_pcl/ColorHistogram" "color_histogram")
+  jsk_pcl_nodelet(src/color_histogram_classifier_nodelet.cpp "jsk_pcl/ColorHistogramClassifier" "color_histogram_classifier")
+  jsk_pcl_nodelet(src/color_histogram_filter_nodelet.cpp "jsk_pcl/ColorHistogramFilter" "color_histogram_filter")
+endif()
 jsk_pcl_nodelet(src/color_histogram_matcher_nodelet.cpp
   "jsk_pcl/ColorHistogramMatcher" "color_histogram_matcher")
 jsk_pcl_nodelet_upstream(jsk_pcl_ros_utils "jsk_pcl/PolygonAppender" "polygon_appender")
@@ -244,10 +255,10 @@ jsk_pcl_nodelet(src/region_growing_multiple_plane_segmentation_nodelet.cpp
   "jsk_pcl/RegionGrowingMultiplePlaneSegmentation"
   "region_growing_multiple_plane_segmentation")
 
-IF(${PCL_VERSION} VERSION_GREATER "1.7.2")
+if(${PCL_VERSION} VERSION_GREATER "1.7.2")
   jsk_pcl_nodelet(src/organized_edge_detector_nodelet.cpp
     "jsk_pcl/OrganizedEdgeDetector" "organized_edge_detector")
-ENDIF(${PCL_VERSION} VERSION_GREATER "1.7.2")
+endif(${PCL_VERSION} VERSION_GREATER "1.7.2")
 
 jsk_pcl_nodelet(src/edge_depth_refinement_nodelet.cpp
   "jsk_pcl/EdgeDepthRefinement" "edge_depth_refinement")
@@ -489,6 +500,11 @@ if (CATKIN_ENABLE_TESTING)
     add_rostest(test/test_organized_pointcloud_to_point_indices.test)
     add_rostest(test/test_rearrange_bounding_box.test)
     add_rostest(test/test_color_based_region_growing_segmentation.test)
+    if(jsk_topic_tools_VERSION VERSION_LESS 2.2.4)
+      message(WARNING "ColorHistogram requires jsk_topic_tools >= 2.2.4")
+    else()
+      add_rostest(test/color_histogram.test)
+    endif()
   endif()
   roslaunch_add_file_check(launch/openni_local.launch)
   roslaunch_add_file_check(launch/openni2_local.launch)

--- a/jsk_pcl_ros/cfg/ColorHistogram.cfg
+++ b/jsk_pcl_ros/cfg/ColorHistogram.cfg
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+# set up parameters that we care about
+PACKAGE = 'jsk_pcl_ros'
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+gen.add("bin_size", int_t, 0, "bin size of color histogram", 20, 1, 256)
+gen.add("queue_size", int_t, 0, "queue size of message", 100, 1, 1000)
+gen.add("white_threshold", double_t, 0, "white threshold", 0.1, 0.0, 1.0)
+gen.add("black_threshold", double_t, 0, "black threshold", 0.1, 0.0, 1.0)
+
+histogram_policy_enum = gen.enum([gen.const("HUE", int_t, 0, "use hue only"),
+                                  gen.const("HUE_AND_SATURATION", int_t, 1, "use hue and saturation")],
+                                 "histogram policy")
+gen.add("histogram_policy", int_t, 0, "histogram policy", 0, 0, 1,
+        edit_method=histogram_policy_enum)
+
+exit(gen.generate(PACKAGE, PACKAGE, "ColorHistogram"))

--- a/jsk_pcl_ros/cfg/ColorHistogramClassifier.cfg
+++ b/jsk_pcl_ros/cfg/ColorHistogramClassifier.cfg
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+# set up parameters that we care about
+PACKAGE = 'jsk_pcl_ros'
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+gen.add("queue_size", int_t, 0, "queue size of message", 100, 1, 1000)
+gen.add("detection_threshold", double_t, 0, "filtering threshold", 0.8, 0.0, 1.0)
+
+compare_policy_enum = gen.enum([gen.const("CORRELATION", int_t, 0, "use correlation"),
+                                gen.const("BHATTACHARYYA", int_t, 1, "use bhattacharyya distance"),
+                                gen.const("INTERSECTION", int_t, 2, "use histogram intersection"),
+                                gen.const("CHISQUARE", int_t, 3, "use chi square function"),
+                                gen.const("KL_DIVERGENCE", int_t, 4, "use KL divergence"),],
+                               "histogram compare policy")
+gen.add("compare_policy", int_t, 0, "compare policy", 0, 0, 4,
+        edit_method=compare_policy_enum)
+
+exit(gen.generate(PACKAGE, PACKAGE, "ColorHistogramClassifier"))

--- a/jsk_pcl_ros/cfg/ColorHistogramFilter.cfg
+++ b/jsk_pcl_ros/cfg/ColorHistogramFilter.cfg
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+# set up parameters that we care about
+PACKAGE = 'jsk_pcl_ros'
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+gen.add("bin_size", int_t, 0, "bin size of histogram", 100, 1, 256)
+gen.add("queue_size", int_t, 0, "queue size of message", 100, 1, 1000)
+gen.add("distance_threshold", double_t, 0, "filtering threshold", 0.6, 0.0, 1.0)
+gen.add("flip_threshold", bool_t, 0, "flip threshold", False)
+
+compare_policy_enum = gen.enum([gen.const("CORRELATION", int_t, 0, "use correlation"),
+                                gen.const("BHATTACHARYYA", int_t, 1, "use bhattacharyya distance"),
+                                gen.const("INTERSECTION", int_t, 2, "use histogram intersection"),
+                                gen.const("CHISQUARE", int_t, 3, "use chi square function"),
+                                gen.const("KL_DIVERGENCE", int_t, 4, "use KL divergence"),],
+                               "histogram compare policy")
+gen.add("compare_policy", int_t, 0, "compare policy", 0, 0, 4,
+        edit_method=compare_policy_enum)
+
+exit(gen.generate(PACKAGE, PACKAGE, "ColorHistogramFilter"))

--- a/jsk_pcl_ros/cfg/ColorHistogramVisualizer.cfg
+++ b/jsk_pcl_ros/cfg/ColorHistogramVisualizer.cfg
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+# set up parameters that we care about
+PACKAGE = 'jsk_pcl_ros'
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+histogram_policy_enum = gen.enum([gen.const("HUE", int_t, 0, "use hue only"),
+                                  gen.const("HUE_AND_SATURATION", int_t, 1, "use hue and saturation")],
+                                 "histogram policy")
+gen.add("histogram_policy", int_t, 0, "histogram policy", 0, 0, 1,
+        edit_method=histogram_policy_enum)
+gen.add("histogram_index", int_t, 0, "index of histogram array to visualize", 0, 0, 100)
+gen.add("histogram_scale", double_t, 0, "scale factor of histogram values", 1.0, 0.01, 1000.0)
+
+exit(gen.generate(PACKAGE, PACKAGE, "ColorHistogramVisualizer"))

--- a/jsk_pcl_ros/include/jsk_pcl_ros/color_histogram.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/color_histogram.h
@@ -1,0 +1,93 @@
+// -*- mode: C++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+/*
+ * color_histogram.h
+ * Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+ */
+
+#ifndef JSK_PCL_ROS_COLOR_HISTOGRAM_H__
+#define JSK_PCL_ROS_COLOR_HISTOGRAM_H__
+
+#include <dynamic_reconfigure/server.h>
+#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_msgs/ColorHistogram.h>
+#include <jsk_recognition_msgs/ColorHistogramArray.h>
+#include <jsk_recognition_msgs/ClusterPointIndices.h>
+#include <jsk_recognition_utils/pcl/color_histogram.h>
+#include <message_filters/subscriber.h>
+#include <message_filters/time_synchronizer.h>
+#include <message_filters/synchronizer.h>
+#include <pcl_ros/pcl_nodelet.h>
+#include <sensor_msgs/PointCloud2.h>
+
+#include <jsk_pcl_ros/ColorHistogramConfig.h>
+
+
+namespace jsk_pcl_ros
+{
+  class ColorHistogram : public jsk_topic_tools::DiagnosticNodelet
+  {
+  public:
+    typedef message_filters::sync_policies::ExactTime<sensor_msgs::PointCloud2,
+                                                      jsk_recognition_msgs::ClusterPointIndices> SyncPolicy;
+    typedef ColorHistogramConfig Config;
+
+    ColorHistogram() : DiagnosticNodelet("ColorHistogram") {}
+  protected:
+    virtual void onInit();
+    virtual void configCallback(Config& config, uint32_t level);
+    virtual void subscribe();
+    virtual void unsubscribe();
+    virtual void feature(
+      const sensor_msgs::PointCloud2::ConstPtr& input_cloud,
+      const jsk_recognition_msgs::ClusterPointIndices::ConstPtr& input_indices);
+
+    // properties
+    boost::mutex mutex_;
+    boost::shared_ptr<dynamic_reconfigure::Server<Config> > srv_;
+    message_filters::Subscriber<sensor_msgs::PointCloud2> sub_cloud_;
+    message_filters::Subscriber<jsk_recognition_msgs::ClusterPointIndices> sub_indices_;
+    boost::shared_ptr<message_filters::Synchronizer<SyncPolicy> > sync_;
+    ros::Publisher pub_histogram_;
+
+    // parameters
+    int queue_size_;
+    int bin_size_;
+    double white_threshold_, black_threshold_;
+    jsk_recognition_utils::HistogramPolicy histogram_policy_;
+  };
+}
+
+#endif // JSK_PCL_ROS_COLOR_HISTOGRAM_H__

--- a/jsk_pcl_ros/include/jsk_pcl_ros/color_histogram_classifier.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/color_histogram_classifier.h
@@ -1,0 +1,93 @@
+// -*- mode: C++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+/*
+ * color_histogram_classifier.h
+ * Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+ */
+
+#ifndef JSK_PCL_ROS_COLOR_HISTOGRAM_CLASSIFIER_H__
+#define JSK_PCL_ROS_COLOR_HISTOGRAM_CLASSIFIER_H__
+
+#include <dynamic_reconfigure/server.h>
+#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_msgs/ClusterPointIndices.h>
+#include <jsk_recognition_msgs/ColorHistogram.h>
+#include <jsk_recognition_msgs/ColorHistogramArray.h>
+#include <jsk_recognition_utils/pcl/color_histogram.h>
+#include <message_filters/subscriber.h>
+#include <message_filters/time_synchronizer.h>
+#include <message_filters/synchronizer.h>
+#include <jsk_pcl_ros/ColorHistogramClassifierConfig.h>
+
+
+namespace jsk_pcl_ros
+{
+  class ColorHistogramClassifier : public jsk_topic_tools::DiagnosticNodelet
+  {
+  public:
+    typedef ColorHistogramClassifierConfig Config;
+
+    ColorHistogramClassifier() : DiagnosticNodelet("ColorHistogramClassifier"){}
+  protected:
+    virtual void onInit();
+    virtual void configCallback(Config & config, uint32_t level);
+    virtual void subscribe();
+    virtual void unsubscribe();
+    virtual bool loadReference();
+    virtual void computeDistance(const std::vector<float>& histogram,
+                                 std::vector<double>& distance);
+    virtual void feature(const jsk_recognition_msgs::ColorHistogram::ConstPtr& histogram);
+    virtual void features(const jsk_recognition_msgs::ColorHistogramArray::ConstPtr& histograms);
+
+    // properties
+    boost::mutex mutex_;
+    boost::shared_ptr<dynamic_reconfigure::Server<Config> > srv_;
+    ros::Subscriber sub_hist_, sub_hists_;
+    ros::Publisher pub_class_;
+
+    // parameters
+    int queue_size_;
+    int bin_size_;
+    double detection_threshold_;
+    jsk_recognition_utils::ComparePolicy compare_policy_;
+    jsk_recognition_msgs::ColorHistogram reference_histogram_;
+
+    std::string classifier_name_;
+    std::vector<std::string> label_names_;
+    std::vector<std::vector<float> > reference_histograms_;
+  };
+}
+
+#endif // JSK_PCL_ROS_COLOR_HISTOGRAM_CLASSIFIER_H__

--- a/jsk_pcl_ros/include/jsk_pcl_ros/color_histogram_filter.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/color_histogram_filter.h
@@ -1,0 +1,94 @@
+// -*- mode: C++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+/*
+ * color_histogram_filter.h
+ * Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+ */
+
+#ifndef JSK_PCL_ROS_COLOR_HISTOGRAM_FILTER_H__
+#define JSK_PCL_ROS_COLOR_HISTOGRAM_FILTER_H__
+
+#include <dynamic_reconfigure/server.h>
+#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_msgs/ClusterPointIndices.h>
+#include <jsk_recognition_msgs/ColorHistogram.h>
+#include <jsk_recognition_msgs/ColorHistogramArray.h>
+#include <jsk_recognition_utils/pcl/color_histogram.h>
+#include <message_filters/subscriber.h>
+#include <message_filters/time_synchronizer.h>
+#include <message_filters/synchronizer.h>
+#include <jsk_pcl_ros/ColorHistogramFilterConfig.h>
+
+
+namespace jsk_pcl_ros
+{
+  class ColorHistogramFilter : public jsk_topic_tools::DiagnosticNodelet
+  {
+  public:
+    typedef message_filters::sync_policies::ExactTime<jsk_recognition_msgs::ColorHistogramArray,
+                                                      jsk_recognition_msgs::ClusterPointIndices> SyncPolicy;
+    typedef ColorHistogramFilterConfig Config;
+
+    ColorHistogramFilter() : DiagnosticNodelet("ColorHistogramFilter"){}
+  protected:
+    virtual void onInit();
+    virtual void configCallback(Config & config, uint32_t level);
+    virtual void subscribe();
+    virtual void unsubscribe();
+    virtual void feature(const jsk_recognition_msgs::ColorHistogramArray::ConstPtr &input_histogram,
+                         const jsk_recognition_msgs::ClusterPointIndices::ConstPtr &input_indices);
+    virtual void reference(const jsk_recognition_msgs::ColorHistogram::ConstPtr &input);
+
+    // properties
+    boost::mutex mutex_;
+    boost::shared_ptr<dynamic_reconfigure::Server<Config> > srv_;
+    ros::Subscriber sub_reference_;
+    message_filters::Subscriber<jsk_recognition_msgs::ColorHistogramArray> sub_histogram_;
+    message_filters::Subscriber<jsk_recognition_msgs::ClusterPointIndices> sub_indices_;
+    boost::shared_ptr<message_filters::Synchronizer<SyncPolicy> > sync_;
+    ros::Publisher pub_indices_;
+    ros::Publisher pub_histogram_;
+
+    // parameters
+    int queue_size_;
+    int bin_size_;
+    bool flip_threshold_;
+    double distance_threshold_;
+    jsk_recognition_utils::ComparePolicy compare_policy_;
+    std::vector<float> reference_histogram_;
+  };
+}
+
+#endif // JSK_PCL_ROS_COLOR_HISTOGRAM_FILTER_H__

--- a/jsk_pcl_ros/include/jsk_pcl_ros/pcl/point_types_conversion.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/pcl/point_types_conversion.h
@@ -1,0 +1,395 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2010-2011, Willow Garage, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $Id$
+ */
+
+#ifndef PCL_TYPE_CONVERSIONS_H
+#define PCL_TYPE_CONVERSIONS_H
+
+#include <limits>
+
+namespace pcl
+{
+  // r,g,b, i values are from 0 to 1
+  // h = [0,360]
+  // s, v values are from 0 to 1
+  // if s = 0 > h = -1 (undefined)
+
+  /** \brief Convert a XYZRGB point type to a XYZI
+    * \param[in] in the input XYZRGB point 
+    * \param[out] out the output XYZI point
+    */
+  inline void 
+  PointXYZRGBtoXYZI (PointXYZRGB&  in,
+                     PointXYZI&    out)
+  {
+    out.x = in.x; out.y = in.y; out.z = in.z;
+    out.intensity = 0.299f * static_cast <float> (in.r) + 0.587f * static_cast <float> (in.g) + 0.114f * static_cast <float> (in.b);
+  }
+
+  /** \brief Convert a RGB point type to a I
+    * \param[in] in the input RGB point
+    * \param[out] out the output Intensity point
+    */
+  inline void
+  PointRGBtoI (RGB&          in,
+               Intensity&    out)
+  {
+    out.intensity = 0.299f * static_cast <float> (in.r) + 0.587f * static_cast <float> (in.g) + 0.114f * static_cast <float> (in.b);
+  }
+
+  /** \brief Convert a RGB point type to a I
+    * \param[in] in the input RGB point
+    * \param[out] out the output Intensity point
+    */
+  inline void
+  PointRGBtoI (RGB&          in,
+               Intensity8u&  out)
+  {
+    out.intensity = static_cast<uint8_t>(std::numeric_limits<uint8_t>::max() * 0.299f * static_cast <float> (in.r)
+                      + 0.587f * static_cast <float> (in.g) + 0.114f * static_cast <float> (in.b));
+  }
+
+  /** \brief Convert a RGB point type to a I
+    * \param[in] in the input RGB point
+    * \param[out] out the output Intensity point
+    */
+  inline void
+  PointRGBtoI (RGB&          in,
+               Intensity32u& out)
+  {
+    out.intensity = static_cast<uint32_t>(static_cast<float>(std::numeric_limits<uint32_t>::max()) * 0.299f * static_cast <float> (in.r)
+                      + 0.587f * static_cast <float> (in.g) + 0.114f * static_cast <float> (in.b));
+  }
+
+  /** \brief Convert a XYZRGB point type to a XYZHSV
+    * \param[in] in the input XYZRGB point 
+    * \param[out] out the output XYZHSV point
+    */
+  inline void 
+  PointXYZRGBtoXYZHSV (PointXYZRGB& in,
+                       PointXYZHSV& out)
+  {
+    const unsigned char max = std::max (in.r, std::max (in.g, in.b));
+    const unsigned char min = std::min (in.r, std::min (in.g, in.b));
+
+    out.v = static_cast <float> (max) / 255.f;
+
+    if (max == 0) // division by zero
+    {
+      out.s = 0.f;
+      out.h = 0.f; // h = -1.f;
+      return;
+    }
+
+    const float diff = static_cast <float> (max - min);
+    out.s = diff / static_cast <float> (max);
+
+    if (min == max) // diff == 0 -> division by zero
+    {
+      out.h = 0;
+      return;
+    }
+
+    if      (max == in.r) out.h = 60.f * (      static_cast <float> (in.g - in.b) / diff);
+    else if (max == in.g) out.h = 60.f * (2.f + static_cast <float> (in.b - in.r) / diff);
+    else                  out.h = 60.f * (4.f + static_cast <float> (in.r - in.g) / diff); // max == b
+
+    if (out.h < 0.f) out.h += 360.f;
+  }
+
+  /** \brief Convert a XYZRGB point type to a XYZHSV
+    * \param[in] in the input XYZRGB point
+    * \param[out] out the output XYZHSV point
+    * \todo include the A parameter but how?
+    */
+  inline void
+  PointXYZRGBAtoXYZHSV (PointXYZRGBA& in,
+                        PointXYZHSV& out)
+  {
+    const unsigned char max = std::max (in.r, std::max (in.g, in.b));
+    const unsigned char min = std::min (in.r, std::min (in.g, in.b));
+
+    out.v = static_cast <float> (max) / 255.f;
+
+    if (max == 0) // division by zero
+    {
+      out.s = 0.f;
+      out.h = 0.f; // h = -1.f;
+      return;
+    }
+
+    const float diff = static_cast <float> (max - min);
+    out.s = diff / static_cast <float> (max);
+
+    if (min == max) // diff == 0 -> division by zero
+    {
+      out.h = 0;
+      return;
+    }
+
+    if      (max == in.r) out.h = 60.f * (      static_cast <float> (in.g - in.b) / diff);
+    else if (max == in.g) out.h = 60.f * (2.f + static_cast <float> (in.b - in.r) / diff);
+    else                  out.h = 60.f * (4.f + static_cast <float> (in.r - in.g) / diff); // max == b
+
+    if (out.h < 0.f) out.h += 360.f;
+  }
+
+  /* \brief Convert a XYZHSV point type to a XYZRGB
+    * \param[in] in the input XYZHSV point 
+    * \param[out] out the output XYZRGB point
+    */
+  inline void 
+  PointXYZHSVtoXYZRGB (PointXYZHSV&  in,
+                       PointXYZRGB&  out)
+  {
+    out.x = in.x; out.y = in.y; out.z = in.z;
+    if (in.s == 0)
+    {
+      out.r = out.g = out.b = static_cast<uint8_t> (in.v);
+      return;
+    } 
+    float a = in.h / 60;
+    int   i = static_cast<int> (floorf (a));
+    float f = a - static_cast<float> (i);
+    float p = in.v * (1 - in.s);
+    float q = in.v * (1 - in.s * f);
+    float t = in.v * (1 - in.s * (1 - f));
+
+    switch (i)
+    {
+      case 0:
+      {
+        out.r = static_cast<uint8_t> (255 * in.v);
+        out.g = static_cast<uint8_t> (255 * t);
+        out.b = static_cast<uint8_t> (255 * p);
+        break;
+      }
+      case 1:
+      {
+        out.r = static_cast<uint8_t> (255 * q); 
+        out.g = static_cast<uint8_t> (255 * in.v); 
+        out.b = static_cast<uint8_t> (255 * p); 
+        break;
+      }
+      case 2:
+      {
+        out.r = static_cast<uint8_t> (255 * p);
+        out.g = static_cast<uint8_t> (255 * in.v);
+        out.b = static_cast<uint8_t> (255 * t);
+        break;
+      }
+      case 3:
+      {
+        out.r = static_cast<uint8_t> (255 * p);
+        out.g = static_cast<uint8_t> (255 * q);
+        out.b = static_cast<uint8_t> (255 * in.v);
+        break;
+      }
+      case 4:
+      {
+        out.r = static_cast<uint8_t> (255 * t);
+        out.g = static_cast<uint8_t> (255 * p); 
+        out.b = static_cast<uint8_t> (255 * in.v); 
+        break;
+      }
+      default:
+      {
+        out.r = static_cast<uint8_t> (255 * in.v); 
+        out.g = static_cast<uint8_t> (255 * p); 
+        out.b = static_cast<uint8_t> (255 * q);
+        break;
+      }      
+    }
+  }
+
+  /** \brief Convert a RGB point cloud to a Intensity
+    * \param[in] in the input RGB point cloud
+    * \param[out] out the output Intensity point cloud
+    */
+  inline void
+  PointCloudRGBtoI (PointCloud<RGB>&        in,
+                    PointCloud<Intensity>&  out)
+  {
+    out.width   = in.width;
+    out.height  = in.height;
+    for (size_t i = 0; i < in.points.size (); i++)
+    {
+      Intensity p;
+      PointRGBtoI (in.points[i], p);
+      out.points.push_back (p);
+    }
+  }
+
+  /** \brief Convert a RGB point cloud to a Intensity
+    * \param[in] in the input RGB point cloud
+    * \param[out] out the output Intensity point cloud
+    */
+  inline void
+  PointCloudRGBtoI (PointCloud<RGB>&          in,
+                    PointCloud<Intensity8u>&  out)
+  {
+    out.width   = in.width;
+    out.height  = in.height;
+    for (size_t i = 0; i < in.points.size (); i++)
+    {
+      Intensity8u p;
+      PointRGBtoI (in.points[i], p);
+      out.points.push_back (p);
+    }
+  }
+
+  /** \brief Convert a RGB point cloud to a Intensity
+    * \param[in] in the input RGB point cloud
+    * \param[out] out the output Intensity point cloud
+    */
+  inline void
+  PointCloudRGBtoI (PointCloud<RGB>&        in,
+                    PointCloud<Intensity32u>&  out)
+  {
+    out.width   = in.width;
+    out.height  = in.height;
+    for (size_t i = 0; i < in.points.size (); i++)
+    {
+      Intensity32u p;
+      PointRGBtoI (in.points[i], p);
+      out.points.push_back (p);
+    }
+  }
+
+  /** \brief Convert a XYZRGB point cloud to a XYZHSV
+    * \param[in] in the input XYZRGB point cloud
+    * \param[out] out the output XYZHSV point cloud
+    */
+  inline void 
+  PointCloudXYZRGBtoXYZHSV (PointCloud<PointXYZRGB>& in,
+                            PointCloud<PointXYZHSV>& out)
+  {
+    out.width   = in.width;
+    out.height  = in.height;
+    for (size_t i = 0; i < in.points.size (); i++)
+    {
+      PointXYZHSV p;
+      PointXYZRGBtoXYZHSV (in.points[i], p);
+      out.points.push_back (p);
+    }
+  }
+
+  /** \brief Convert a XYZRGB point cloud to a XYZHSV
+    * \param[in] in the input XYZRGB point cloud
+    * \param[out] out the output XYZHSV point cloud
+    */
+  inline void
+  PointCloudXYZRGBAtoXYZHSV (PointCloud<PointXYZRGBA>& in,
+                             PointCloud<PointXYZHSV>& out)
+  {
+    out.width   = in.width;
+    out.height  = in.height;
+    for (size_t i = 0; i < in.points.size (); i++)
+    {
+      PointXYZHSV p;
+      PointXYZRGBAtoXYZHSV (in.points[i], p);
+      out.points.push_back (p);
+    }
+  }
+
+  /** \brief Convert a XYZRGB point cloud to a XYZI
+    * \param[in] in the input XYZRGB point cloud
+    * \param[out] out the output XYZI point cloud
+    */
+  inline void 
+  PointCloudXYZRGBtoXYZI (PointCloud<PointXYZRGB>& in,
+                          PointCloud<PointXYZI>& out)
+  {
+    out.width   = in.width;
+    out.height  = in.height;
+    for (size_t i = 0; i < in.points.size (); i++)
+    {
+      PointXYZI p;
+      PointXYZRGBtoXYZI (in.points[i], p);
+      out.points.push_back (p);
+    }
+  }
+
+  /** \brief Convert registered Depth image and RGB image to PointCloudXYZRGBA
+   *  \param[in] depth the input depth image as intensity points in float
+   *  \param[in] image the input RGB image
+   *  \param[in] focal the focal length
+   *  \param[out] out the output pointcloud
+   *  **/
+  inline void
+  PointCloudDepthAndRGBtoXYZRGBA (PointCloud<Intensity>&  depth,
+                                  PointCloud<RGB>&        image,
+                                  float&                  focal,
+                                  PointCloud<PointXYZRGBA>&     out)
+  {
+    float bad_point = std::numeric_limits<float>::quiet_NaN();
+    int width_ = depth.width;
+    int height_ = depth.height;
+    float constant_ = 1.0f / focal;
+
+    for(unsigned int v = 0; v < height_; v++)
+    {
+      for(unsigned int u = 0; u < width_; u++)
+      {
+        PointXYZRGBA pt;
+        pt.a = 0;
+        float depth_ = depth.at(u,v).intensity;
+
+        if (depth_ == 0)
+        {
+          pt.x = pt.y = pt.z = bad_point;
+        }
+        else
+        {
+          pt.z = depth_ * 0.001f;
+          pt.x = static_cast<float> (u) * pt.z * constant_;
+          pt.y = static_cast<float> (v) * pt.z * constant_;
+        }
+        pt.r = image.at(u,v).r;
+        pt.g = image.at(u,v).g;
+        pt.b = image.at(u,v).b;
+
+        out.points.push_back(pt);
+      }
+    }
+    out.width = width_;
+    out.height = height_;
+  }
+}
+
+#endif //#ifndef PCL_TYPE_CONVERSIONS_H
+

--- a/jsk_pcl_ros/plugins/nodelet/libjsk_pcl_ros.xml
+++ b/jsk_pcl_ros/plugins/nodelet/libjsk_pcl_ros.xml
@@ -228,6 +228,24 @@
          base_class_type="nodelet::Nodelet">
     <description>modeling the environment</description>
   </class>
+  <class name="jsk_pcl/ColorHistogram" type="jsk_pcl_ros::ColorHistogram"
+         base_class_type="nodelet::Nodelet">
+    <description>
+      Compute histogram for each point indices
+    </description>
+  </class>
+  <class name="jsk_pcl/ColorHistogramClassifier" type="jsk_pcl_ros::ColorHistogramClassifier"
+         base_class_type="nodelet::Nodelet">
+    <description>
+      Classify point indices using color histogram
+    </description>
+  </class>
+  <class name="jsk_pcl/ColorHistogramFilter" type="jsk_pcl_ros::ColorHistogramFilter"
+         base_class_type="nodelet::Nodelet">
+    <description>
+      Filter point indices using color histogram
+    </description>
+  </class>
   <class name="jsk_pcl/ColorHistogramMatcher" type="jsk_pcl_ros::ColorHistogramMatcher"
          base_class_type="nodelet::Nodelet">
     <description>find object based on h-s-v histogram</description>

--- a/jsk_pcl_ros/sample/sample_color_histogram.launch
+++ b/jsk_pcl_ros/sample/sample_color_histogram.launch
@@ -1,0 +1,48 @@
+<launch>
+  <arg name="input_cloud" default="/camera/depth_registered/points" />
+
+  <arg name="manager" default="color_histogram_manager" />
+
+  <node name="$(arg manager)"
+        pkg="nodelet" type="nodelet" args="manager" />
+
+  <group ns="color_histogram">
+    <node name="input_relay"
+          pkg="nodelet" type="nodelet"
+          args="load jsk_topic_tools/Relay /$(arg manager)">
+      <remap from="~input" to="$(arg input_cloud)" />
+    </node>
+
+    <node name="point_cloud_to_cluster_point_indices"
+          pkg="nodelet" type="nodelet"
+          args="load jsk_pcl_utils/PointCloudToClusterPointIndices /$(arg manager)">
+      <remap from="~input" to="input_relay/output" />
+    </node>
+
+    <node name="color_histogram"
+          pkg="nodelet" type="nodelet"
+          args="load jsk_pcl/ColorHistogram /$(arg manager)">
+      <remap from="~input" to="input_relay/output"/>
+      <remap from="~input/indices" to="point_cloud_to_cluster_point_indices/output" />
+      <rosparam>
+        bin_size: 20
+        histogram_policy: 0
+      </rosparam>
+    </node>
+
+    <node name="color_histogram_visualizer"
+          pkg="jsk_pcl_ros" type="color_histogram_visualizer.py" output="screen">
+      <remap from="~input/array" to="color_histogram/output"/>
+      <rosparam>
+        histogram_policy: 0
+        histogram_index: 0
+        histogram_scale: 1.0
+      </rosparam>
+    </node>
+
+    <node name="image_view"
+          pkg="image_view" type="image_view">
+      <remap from="image" to="color_histogram_visualizer/output" />
+    </node>
+  </group>
+</launch>

--- a/jsk_pcl_ros/scripts/color_histogram_visualizer.py
+++ b/jsk_pcl_ros/scripts/color_histogram_visualizer.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+
+import math
+import cv2
+from cv_bridge import CvBridge
+from dynamic_reconfigure.server import Server
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+from matplotlib import pyplot as plt
+from matplotlib import gridspec
+import rospy
+from jsk_topic_tools import ConnectionBasedTransport
+from jsk_recognition_msgs.msg import ColorHistogram, ColorHistogramArray
+from sensor_msgs.msg import Image
+from jsk_pcl_ros.cfg import ColorHistogramVisualizerConfig as Config
+
+
+# matplotlib outputs image with size 800x600 by default
+IMG_WIDTH=800
+IMG_HEIGHT=600
+
+
+class ColorHistogramVisualizer(ConnectionBasedTransport):
+    def __init__(self):
+        super(ColorHistogramVisualizer, self).__init__()
+
+        self.dyn_server = Server(Config, self.config_callback)
+
+        self.cv_bridge = CvBridge()
+        self.hsv_color_map = plt.cm.get_cmap('hsv')
+        self.hsv_color_map_2d = self.get_hsv_color_map_2d()
+
+        self.pub_image = self.advertise("~output", Image, queue_size=1)
+
+    def config_callback(self, config, level):
+        self.histogram_policy = config.histogram_policy
+        self.histogram_index = config.histogram_index
+        self.histogram_scale = config.histogram_scale
+        return config
+
+    def subscribe(self):
+        self.sub_histogram = rospy.Subscriber("~input", ColorHistogram,
+                                              self.callback, queue_size=1)
+        self.sub_histogram_array = rospy.Subscriber("~input/array", ColorHistogramArray,
+                                                    self.callback_array, queue_size=1)
+
+    def unsubscribe(self):
+        self.sub_histogram.unregister()
+        self.sub_histogram_array.unregister()
+
+    def get_hsv_color_map_2d(self):
+        hsv_map = np.zeros((IMG_HEIGHT, IMG_WIDTH, 3), np.uint8)
+        h, s = np.indices(hsv_map.shape[:2])
+        hsv_map[:, :, 0] = h / float(IMG_HEIGHT) * 180.0
+        hsv_map[:, :, 1] = 125.0
+        hsv_map[:, :, 2] = s / float(IMG_WIDTH)  * 256.0
+        hsv_map = cv2.cvtColor(hsv_map, cv2.COLOR_HLS2BGR)
+        return hsv_map
+
+    def callback(self, msg):
+        if self.histogram_policy == Config.ColorHistogramVisualizer_HUE:
+            img = self.plot_hist_hue(msg.histogram)
+        elif self.histogram_policy == Config.ColorHistogramVisualizer_HUE_AND_SATURATION:
+            img = self.plot_hist_hs(msg.histogram)
+        else:
+            rospy.logerr("Invalid histogram policy")
+            return
+        try:
+            pub_msg = self.cv_bridge.cv2_to_imgmsg(img, "bgr8")
+            self.pub_image.publish(pub_msg)
+        except Exception as e:
+            rospy.logerr("Failed to convert image: %s" % str(e))
+
+    def callback_array(self, msg):
+        if 0 <= self.histogram_index < len(msg.histograms):
+            self.callback(msg.histograms[self.histogram_index])
+        else:
+            rospy.logerr("histogram index Out-of-index")
+
+    def image_from_plot(self):
+        fig = plt.gcf()
+        fig.canvas.draw()
+        w, h = fig.canvas.get_width_height()
+        img = np.fromstring(fig.canvas.tostring_rgb(), dtype=np.uint8)
+        fig.clf()
+        img.shape = (h, w, 3)
+        img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
+        return img
+
+    def plot_hist_hue(self, hist):
+        gs = gridspec.GridSpec(1, 2, width_ratios=[4, 1])
+        plt.subplot(gs[0])
+        bin_size = len(hist) - 2
+        bin_step = 360.0 / bin_size
+        x = np.arange(360.0, step=bin_step)
+        bars = plt.bar(x, hist[:-2], width=bin_step)
+        cs = np.arange(0.0, 1.0, 1.0 / bin_size)
+        for c, b in zip(cs, bars):
+            b.set_facecolor(self.hsv_color_map(c))
+        plt.xlim(0, 360.0)
+        plt.ylim(ymin=0.0, ymax=1.0)
+        ymin, ymax = plt.ylim()
+        plt.subplot(gs[1])
+        bars = plt.bar(range(2), hist[-2:], width=1.0, label=["white", "black"])
+        bars[0].set_facecolor((1.0, 1.0, 1.0, 1.0))
+        bars[1].set_facecolor((0.0, 0.0, 0.0, 1.0))
+        plt.ylim(ymin, ymax)
+        return self.image_from_plot()
+
+    def plot_hist_saturation(self, hist):
+        bin_size = len(hist)
+        bin_step = 256.0 / bin_size
+        x = np.arange(256.0, step=bin_step)
+        plt.bar(x, hist, width=bin_step)
+        plt.xlim(0, 256.0)
+        return self.image_from_plot()
+
+    def plot_hist_hs(self, hist):
+        bin_size = int(math.sqrt(len(hist) - 2))
+        white, black = hist[-2], hist[-1]
+        hist = np.array(hist[:-2]).reshape(bin_size, bin_size).T
+        rospy.loginfo("white: %f, black: %f" % (white, black))
+        hist = np.clip(hist * 150 * self.histogram_scale, white, 1.0 - black)
+        hist = hist[:, :, np.newaxis]
+        hist = cv2.resize(hist, (IMG_WIDTH, IMG_HEIGHT))
+        hist = hist[:, :, np.newaxis]
+        img = self.hsv_color_map_2d * hist
+        img = img.astype(np.uint8)
+        return img
+
+if __name__ == '__main__':
+    rospy.init_node("color_histogram_visualizer")
+    v = ColorHistogramVisualizer()
+    rospy.spin()

--- a/jsk_pcl_ros/src/color_histogram_classifier_nodelet.cpp
+++ b/jsk_pcl_ros/src/color_histogram_classifier_nodelet.cpp
@@ -1,0 +1,211 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+/*
+ * color_histogram_classifier_nodelet.cpp
+ * Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+ */
+
+#include <limits>
+#include <jsk_pcl_ros/color_histogram_classifier.h>
+#include <jsk_recognition_msgs/ClassificationResult.h>
+
+namespace jsk_pcl_ros
+{
+  void ColorHistogramClassifier::onInit()
+  {
+    DiagnosticNodelet::onInit();
+    classifier_name_ = "color_histogram";
+
+    if (!loadReference()) return;
+
+    srv_ = boost::make_shared<dynamic_reconfigure::Server<Config> >(*pnh_);
+    dynamic_reconfigure::Server<Config>::CallbackType f =
+      boost::bind(&ColorHistogramClassifier::configCallback, this, _1, _2);
+    srv_->setCallback(f);
+    pub_class_ = advertise<jsk_recognition_msgs::ClassificationResult>(*pnh_, "output", 1);
+    onInitPostProcess();
+  }
+
+  bool ColorHistogramClassifier::loadReference()
+  {
+
+    // load label names
+    std::vector<std::string> labels;
+    pnh_->param("label_names", labels, std::vector<std::string>());
+    if (labels.empty()) {
+      NODELET_FATAL_STREAM("param ~label_names must not be empty");
+      return false;
+    }
+
+    // load histograms
+    for (size_t i = 0; i < labels.size(); ++i) {
+      std::string name = "histograms/" + labels[i];
+      NODELET_INFO_STREAM("Loading " << name);
+      std::vector<float> hist;
+      pnh_->param(name, hist, std::vector<float>());
+      if (hist.empty()) {
+        NODELET_ERROR_STREAM("Failed to load " << name);
+      } else {
+        label_names_.push_back(labels[i]);
+        reference_histograms_.push_back(hist);
+      }
+    }
+
+    // check bin size
+    bin_size_ = reference_histograms_[0].size();
+    for (size_t i = 0; i < label_names_.size(); ++i) {
+      if (reference_histograms_[i].size() != bin_size_) {
+        NODELET_FATAL_STREAM("size of histogram " << label_names_[i] << " is different from " << label_names_[0]);
+        return false;
+      }
+    }
+
+    NODELET_INFO_STREAM("Loaded " << label_names_.size() << " references");
+    return true;
+  }
+
+  void ColorHistogramClassifier::configCallback(Config &config, uint32_t level)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+    compare_policy_ = jsk_recognition_utils::ComparePolicy(config.compare_policy);
+    detection_threshold_ = config.detection_threshold;
+    if (queue_size_ = config.queue_size) {
+      queue_size_ = config.queue_size;
+      if (isSubscribed()) {
+        unsubscribe();
+        subscribe();
+      }
+    }
+  }
+
+  void ColorHistogramClassifier::subscribe()
+  {
+    sub_hist_ = pnh_->subscribe("input", 1, &ColorHistogramClassifier::feature, this);
+    sub_hists_ = pnh_->subscribe("input/array", 1, &ColorHistogramClassifier::features, this);
+  }
+
+  void ColorHistogramClassifier::unsubscribe()
+  {
+    sub_hist_.shutdown();
+    sub_hists_.shutdown();
+  }
+
+  void ColorHistogramClassifier::computeDistance(const std::vector<float>& histogram,
+                                                 std::vector<double>& distances) {
+    distances.resize(reference_histograms_.size());
+    for (size_t i = 0; i < reference_histograms_.size(); ++i) {
+      jsk_recognition_utils::compareHistogram(
+        histogram, reference_histograms_[i],
+        compare_policy_, distances[i]);
+    }
+  }
+
+  void ColorHistogramClassifier::feature(const jsk_recognition_msgs::ColorHistogram::ConstPtr& histogram)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+
+    jsk_recognition_msgs::ClassificationResult result;
+    result.header = histogram->header;
+    result.classifier = classifier_name_;
+    result.target_names = label_names_;
+
+    std::vector<double> distances;
+    computeDistance(histogram->histogram, distances);
+
+    double max_prob = 0.0;
+    int label;
+    for (size_t i = 0; i < distances.size(); ++i) {
+      double prob = distances[i];
+      result.probabilities.push_back(prob);
+      if (prob > max_prob) {
+        max_prob = prob;
+        label = i;
+      }
+    }
+
+    if (max_prob >= detection_threshold_) {
+      result.labels.push_back(label);
+      result.label_names.push_back(label_names_[label]);
+      result.label_proba.push_back(max_prob);
+    } else {
+      result.labels.push_back(-1);
+      result.label_names.push_back(std::string());
+      result.label_proba.push_back(0.0);
+    }
+
+    pub_class_.publish(result);
+  }
+
+  void ColorHistogramClassifier::features(const jsk_recognition_msgs::ColorHistogramArray::ConstPtr& histograms)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+
+    jsk_recognition_msgs::ClassificationResult result;
+    result.header = histograms->header;
+    result.classifier = classifier_name_;
+    result.target_names = label_names_;
+
+    for (size_t i = 0; i < histograms->histograms.size(); ++i) {
+      std::vector<double> distances;
+      computeDistance(histograms->histograms[i].histogram, distances);
+
+      double max_prob = 0.0;
+      int label;
+      for (size_t i = 0; i < distances.size(); ++i) {
+        double prob = distances[i];
+        result.probabilities.push_back(prob);
+        if (prob > max_prob) {
+          max_prob = prob;
+          label = i;
+        }
+      }
+
+      if (max_prob >= detection_threshold_) {
+        result.labels.push_back(label);
+        result.label_names.push_back(label_names_[label]);
+        result.label_proba.push_back(max_prob);
+      } else {
+        result.labels.push_back(-1);
+        result.label_names.push_back(std::string());
+        result.label_proba.push_back(0.0);
+      }
+    }
+
+    pub_class_.publish(result);
+  }
+}
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(jsk_pcl_ros::ColorHistogramClassifier, nodelet::Nodelet);

--- a/jsk_pcl_ros/src/color_histogram_filter_nodelet.cpp
+++ b/jsk_pcl_ros/src/color_histogram_filter_nodelet.cpp
@@ -1,0 +1,147 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+/*
+ * color_histogram_filter_nodelet.cpp
+ * Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+ */
+
+#include <limits>
+#include <jsk_pcl_ros/color_histogram_filter.h>
+
+namespace jsk_pcl_ros
+{
+  void ColorHistogramFilter::onInit()
+  {
+    DiagnosticNodelet::onInit();
+
+    pnh_->param("reference_histogram", reference_histogram_, std::vector<float>());
+    if (reference_histogram_.empty()) {
+      NODELET_WARN_STREAM("reference histogram is not yet set. waiting ~input/reference topic");
+    }
+
+    srv_ = boost::make_shared<dynamic_reconfigure::Server<Config> >(*pnh_);
+    dynamic_reconfigure::Server<Config>::CallbackType f =
+      boost::bind(&ColorHistogramFilter::configCallback, this, _1, _2);
+    srv_->setCallback(f);
+    pub_histogram_ = advertise<jsk_recognition_msgs::ColorHistogramArray>(*pnh_, "output", 1);
+    pub_indices_ = advertise<jsk_recognition_msgs::ClusterPointIndices>(*pnh_, "output/indices", 1);
+    onInitPostProcess();
+  }
+
+  void ColorHistogramFilter::configCallback(Config &config, uint32_t level)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+    compare_policy_ = jsk_recognition_utils::ComparePolicy(config.compare_policy);
+    distance_threshold_ = config.distance_threshold;
+    flip_threshold_ = config.flip_threshold;
+    if (queue_size_ = config.queue_size) {
+      queue_size_ = config.queue_size;
+      if (isSubscribed()) {
+        unsubscribe();
+        subscribe();
+      }
+    }
+  }
+
+  void ColorHistogramFilter::subscribe()
+  {
+    sub_reference_ = pnh_->subscribe("input/reference", 1,
+                                     &ColorHistogramFilter::reference, this);
+    sub_histogram_.subscribe(*pnh_, "input", 1);
+    sub_indices_.subscribe(*pnh_, "input/indices", 1);
+    sync_ = boost::make_shared<message_filters::Synchronizer<SyncPolicy> >(queue_size_);
+    sync_->connectInput(sub_histogram_, sub_indices_);
+    sync_->registerCallback(boost::bind(&ColorHistogramFilter::feature, this, _1, _2));
+  }
+
+  void ColorHistogramFilter::unsubscribe()
+  {
+    sub_reference_.shutdown();
+    sub_histogram_.unsubscribe();
+    sub_indices_.unsubscribe();
+  }
+
+  void ColorHistogramFilter::feature(const jsk_recognition_msgs::ColorHistogramArray::ConstPtr &input_histogram,
+                                     const jsk_recognition_msgs::ClusterPointIndices::ConstPtr &input_indices)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+    if (reference_histogram_.empty()) {
+      NODELET_WARN_THROTTLE(1.0, "reference histogram is empty");
+      return;
+    }
+
+    // check histogram size
+    size_t size = reference_histogram_.size();
+    for (size_t i = 0; i < input_histogram->histograms.size(); ++i) {
+      if (input_histogram->histograms[i].histogram.size() != size) {
+        NODELET_ERROR_STREAM("size of histogram " << i << " is different from reference");
+        return;
+      }
+    }
+
+    jsk_recognition_msgs::ColorHistogramArray out_hist;
+    jsk_recognition_msgs::ClusterPointIndices out_indices;
+
+    out_hist.header = input_histogram->header;
+    out_indices.header = input_indices->header;
+
+    NODELET_DEBUG("distance_threshold: %f", distance_threshold_);
+    for (size_t i = 0; i < input_histogram->histograms.size(); ++i) {
+      double distance = 0.0;
+      bool ok = jsk_recognition_utils::compareHistogram(
+        input_histogram->histograms[i].histogram, reference_histogram_,
+        compare_policy_, distance);
+      if (flip_threshold_) ok &= distance_threshold_ < distance;
+      else                 ok &= distance_threshold_ > distance;
+      NODELET_DEBUG("#%lu: %f (%s)", i, distance, ok ? "OK" : "NG");
+      if (ok) {
+        out_hist.histograms.push_back(input_histogram->histograms[i]);
+        out_indices.cluster_indices.push_back(input_indices->cluster_indices[i]);
+      }
+    }
+
+    pub_histogram_.publish(out_hist);
+    pub_indices_.publish(out_indices);
+  }
+
+  void ColorHistogramFilter::reference(const jsk_recognition_msgs::ColorHistogram::ConstPtr &input)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+    reference_histogram_ = input->histogram;
+  }
+}
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(jsk_pcl_ros::ColorHistogramFilter, nodelet::Nodelet);

--- a/jsk_pcl_ros/src/color_histogram_matcher_nodelet.cpp
+++ b/jsk_pcl_ros/src/color_histogram_matcher_nodelet.cpp
@@ -36,9 +36,15 @@
 #include "jsk_pcl_ros/color_histogram_matcher.h"
 #include <pluginlib/class_list_macros.h>
 #include <pcl/filters/extract_indices.h>
-#include <pcl/point_types_conversion.h>
 #include <pcl/common/centroid.h>
 #include <geometry_msgs/PoseStamped.h>
+
+#include <pcl/pcl_config.h>
+#if PCL_VERSION_COMPARE (<, 1, 7, 2)
+#include <jsk_pcl_ros/pcl/point_types_conversion.h>
+#else
+#include <pcl/point_types_conversion.h>
+#endif
 
 namespace jsk_pcl_ros
 {

--- a/jsk_pcl_ros/src/color_histogram_nodelet.cpp
+++ b/jsk_pcl_ros/src/color_histogram_nodelet.cpp
@@ -1,0 +1,147 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+/*
+ * color_histogram_nodelet.cpp
+ * Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+ */
+
+#include <jsk_pcl_ros/color_histogram.h>
+#include <pcl/filters/extract_indices.h>
+
+#include <pcl/pcl_config.h>
+#if PCL_VERSION_COMPARE (<, 1, 7, 2)
+#include <jsk_pcl_ros/pcl/point_types_conversion.h>
+#else
+#include <pcl/point_types_conversion.h>
+#endif
+
+namespace jsk_pcl_ros
+{
+  void ColorHistogram::onInit()
+  {
+    DiagnosticNodelet::onInit();
+    srv_ = boost::make_shared<dynamic_reconfigure::Server<Config> >(*pnh_);
+    dynamic_reconfigure::Server<Config>::CallbackType f =
+      boost::bind(&ColorHistogram::configCallback, this, _1, _2);
+    srv_->setCallback(f);
+    pub_histogram_ = advertise<jsk_recognition_msgs::ColorHistogramArray>(*pnh_, "output", 1);
+    onInitPostProcess();
+  }
+
+  void ColorHistogram::configCallback(Config& config, uint32_t level)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+    bin_size_ = config.bin_size;
+    histogram_policy_ = jsk_recognition_utils::HistogramPolicy(config.histogram_policy);
+    white_threshold_ = config.white_threshold;
+    black_threshold_ = config.black_threshold;
+    if (queue_size_ != config.queue_size) {
+      queue_size_ = config.queue_size;
+      if (isSubscribed()) {
+        unsubscribe();
+        subscribe();
+      }
+    }
+  }
+
+  void ColorHistogram::subscribe()
+  {
+    sub_cloud_.subscribe(*pnh_, "input", 1);
+    sub_indices_.subscribe(*pnh_, "input/indices", 1);
+    sync_ = boost::make_shared<message_filters::Synchronizer<SyncPolicy> >(queue_size_);
+    sync_->connectInput(sub_cloud_, sub_indices_);
+    sync_->registerCallback(boost::bind(&ColorHistogram::feature,
+                                        this, _1, _2));
+  }
+
+  void ColorHistogram::unsubscribe()
+  {
+    sub_cloud_.unsubscribe();
+    sub_indices_.unsubscribe();
+  }
+
+  void ColorHistogram::feature(
+    const sensor_msgs::PointCloud2::ConstPtr& input_cloud,
+    const jsk_recognition_msgs::ClusterPointIndices::ConstPtr& input_indices)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+
+    pcl::PointCloud<pcl::PointXYZRGB>::Ptr rgb_cloud(new pcl::PointCloud<pcl::PointXYZRGB>);
+    pcl::fromROSMsg(*input_cloud, *rgb_cloud);
+
+    pcl::PointCloud<pcl::PointXYZHSV>::Ptr hsv_cloud(new pcl::PointCloud<pcl::PointXYZHSV>);
+    pcl::PointCloudXYZRGBtoXYZHSV(*rgb_cloud, *hsv_cloud);
+
+    for (size_t i = 0; i < rgb_cloud->points.size(); i++) {
+      hsv_cloud->points[i].x = rgb_cloud->points[i].x;
+      hsv_cloud->points[i].y = rgb_cloud->points[i].y;
+      hsv_cloud->points[i].z = rgb_cloud->points[i].z;
+    }
+
+    pcl::ExtractIndices<pcl::PointXYZHSV> extract;
+    extract.setInputCloud(hsv_cloud);
+
+    jsk_recognition_msgs::ColorHistogramArray histogram_array;
+    histogram_array.histograms.resize(input_indices->cluster_indices.size());
+    histogram_array.header = input_cloud->header;
+    for (size_t i = 0; i < input_indices->cluster_indices.size(); ++i) {
+      pcl::IndicesPtr indices(new std::vector<int>(input_indices->cluster_indices[i].indices));
+      extract.setIndices(indices);
+      pcl::PointCloud<pcl::PointXYZHSV> segmented_cloud;
+      extract.filter(segmented_cloud);
+      histogram_array.histograms[i].header = input_cloud->header;
+      if (histogram_policy_ == jsk_recognition_utils::HUE) {
+        jsk_recognition_utils::computeColorHistogram1d(segmented_cloud,
+                                                       histogram_array.histograms[i].histogram,
+                                                       bin_size_,
+                                                       white_threshold_,
+                                                       black_threshold_);
+      } else if (histogram_policy_ == jsk_recognition_utils::HUE_AND_SATURATION) {
+        jsk_recognition_utils::computeColorHistogram2d(segmented_cloud,
+                                                       histogram_array.histograms[i].histogram,
+                                                       bin_size_,
+                                                       white_threshold_,
+                                                       black_threshold_);
+      } else {
+        NODELET_FATAL("Invalid histogram policy");
+        return;
+      }
+    }
+    pub_histogram_.publish(histogram_array);
+  }
+}
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(jsk_pcl_ros::ColorHistogram, nodelet::Nodelet);

--- a/jsk_pcl_ros/test/color_histogram.test
+++ b/jsk_pcl_ros/test/color_histogram.test
@@ -1,0 +1,93 @@
+<launch>
+  <arg name="cloud_input" default="/right_hand_camera/depth_registered/points" />
+
+  <node name="rosbag_play"
+        pkg="rosbag" type="play"
+        args="$(find jsk_pcl_ros_utils)/sample/data/2017-02-05-16-11-09_shelf_bin.bag --clock --loop">
+  </node>
+  <include file="$(find openni2_launch)/launch/openni2.launch">
+    <arg name="camera" value="right_hand_camera"/>
+    <arg name="load_driver" value="false"/>
+    <arg name="depth_registration" value="true"/>
+  </include>
+
+  <node name="indices"
+        pkg="jsk_pcl_ros_utils" type="pointcloud_to_cluster_point_indices">
+    <remap from="~input" to="$(arg cloud_input)"/>
+  </node>
+
+  <node name="color_histogram"
+        pkg="jsk_pcl_ros" type="color_histogram" output="screen">
+    <remap from="~input" to="$(arg cloud_input)"/>
+    <remap from="~input/indices" to="indices/output" />
+    <rosparam>
+      bin_size: 10
+      histogram_policy: 0
+    </rosparam>
+  </node>
+
+  <node name="color_histogram_filter"
+        pkg="jsk_pcl_ros" type="color_histogram_filter" output="screen">
+    <remap from="~input" to="color_histogram/output" />
+    <remap from="~input/indices" to="indices/output" />
+    <rosparam>
+      bin_size: 10
+      distance_threshold: 0.9999
+      flip_threshold: true
+      reference_histogram: [0.1366894543170929, 0.018193358555436134, 0.019957682117819786, 0.010312500409781933, 0.02364908903837204, 0.13187174499034882, 0.13228841125965118, 0.05075846239924431, 0.021832682192325592, 0.0352376289665699, 0.18575845658779144, 0.2334505170583725]
+    </rosparam>
+  </node>
+
+  <node name="color_histogram_classifier"
+        pkg="jsk_pcl_ros" type="color_histogram_classifier" output="screen">
+    <remap from="~input/array" to="color_histogram/output" />
+    <rosparam>
+      label_names:
+        - test
+      histograms:
+        test: [0.1366894543170929, 0.018193358555436134, 0.019957682117819786, 0.010312500409781933, 0.02364908903837204, 0.13187174499034882, 0.13228841125965118, 0.05075846239924431, 0.021832682192325592, 0.0352376289665699, 0.18575845658779144, 0.2334505170583725]
+    </rosparam>
+  </node>
+
+  <node name="color_histogram_visualizer"
+        pkg="jsk_pcl_ros" type="color_histogram_visualizer.py">
+    <remap from="~input/array" to="color_histogram/output"/>
+    <rosparam>
+      histogram_index: 0
+      histogram_policy: 0
+    </rosparam>
+  </node>
+
+  <test test-name="test_color_histogram_filter" pkg="rostest" type="hztest"
+        time-limit="10">
+    <rosparam>
+      topic: color_histogram_filter/output
+      hz: 15
+      hzerror: 14
+      test_duration: 5.0
+      wait_time: 5.0
+    </rosparam>
+  </test>
+
+  <test test-name="test_color_histogram_classifier" pkg="rostest" type="hztest"
+        time-limit="10">
+    <rosparam>
+      topic: color_histogram_classifier/output
+      hz: 15
+      hzerror: 14
+      test_duration: 5.0
+      wait_time: 5.0
+    </rosparam>
+  </test>
+
+  <test test-name="test_color_histogram_visualizer" pkg="rostest" type="hztest"
+        time-limit="10">
+    <rosparam>
+      topic: color_histogram_visualizer/output
+      hz: 15
+      hzerror: 14
+      test_duration: 5.0
+      wait_time: 5.0
+    </rosparam>
+  </test>
+</launch>

--- a/jsk_recognition_utils/include/jsk_recognition_utils/pcl/color_histogram.h
+++ b/jsk_recognition_utils/include/jsk_recognition_utils/pcl/color_histogram.h
@@ -1,0 +1,253 @@
+// -*- mode: C++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+/*
+ * color_histogram.h
+ * Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+ */
+
+#ifndef JSK_RECOGNITION_UTILS_COLOR_HISTOGRAM_H__
+#define JSK_RECOGNITION_UTILS_COLOR_HISTOGRAM_H__
+
+#include <algorithm>
+#include <iterator>
+#include <vector>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+namespace jsk_recognition_utils {
+  enum HistogramPolicy {
+    HUE = 0,
+    HUE_AND_SATURATION
+  };
+
+  enum ComparePolicy {
+    CORRELATION = 0,
+    BHATTACHARYYA,
+    INTERSECTION,
+    CHISQUARE,
+    KL_DIVERGENCE
+  };
+
+  struct PointXYZHLS {
+    double x, y, z;
+    double h, l, s;
+  };
+
+  inline void
+  HSV2HLS(const pcl::PointXYZHSV& hsv, PointXYZHLS& hls) {
+    hls.x = hsv.x; hls.y = hsv.y; hls.z = hsv.z;
+    hls.h = hsv.h;
+    hls.l = (2.0 - hsv.s) * hsv.v;
+    hls.s = hsv.s * hsv.v;
+    hls.s /= (hls.l <= 1.0) ? hls.l : 2.0 - hls.l;
+    hls.l /= 2.0;
+  }
+
+  inline int
+  getHistogramBin(const double& val, const int& step,
+         const double& min, const double& max)
+  {
+    int idx = std::floor((val - min) / (max - min) * step);
+    if (idx >= step) return step - 1;
+    else if (idx <= 0) return 0;
+    else return idx;
+  }
+
+  inline void
+  normalizeHistogram(std::vector<float>& histogram)
+  {
+    float sum = 0.0f;
+    for (size_t i = 0; i < histogram.size(); ++i)
+      sum += histogram[i];
+    if (sum != 0.0) {
+      for (size_t i = 0; i < histogram.size(); ++i)
+        histogram[i] /= sum;
+    }
+  }
+
+  inline void
+  computeColorHistogram1d(const pcl::PointCloud<pcl::PointXYZHSV>& cloud,
+                          std::vector<float>& histogram,
+                          const int bin_size,
+                          const double white_threshold=0.1,
+                          const double black_threshold=0.1)
+  {
+    histogram.resize(bin_size + 2, 0.0f); // h + w + b
+    int white_index = bin_size;
+    int black_index = bin_size + 1;
+
+    for (size_t i = 0; i < cloud.points.size(); ++i) {
+      PointXYZHLS p;
+      HSV2HLS(cloud.points[i], p);
+      if (p.l > 1.0 - white_threshold)
+        histogram[white_index] += 1.0f;
+      else if (p.l < black_threshold)
+        histogram[black_index] += 1.0f;
+      else {
+        int h_bin = getHistogramBin(p.h, bin_size, 0.0, 360.0);
+        histogram[h_bin] += 1.0f;
+      }
+    }
+
+    normalizeHistogram(histogram);
+  }
+
+  inline void
+  computeColorHistogram2d(const pcl::PointCloud<pcl::PointXYZHSV>& cloud,
+                          std::vector<float>& histogram,
+                          const int bin_size_per_channel,
+                          const double white_threshold=0.1,
+                          const double black_threshold=0.1)
+  {
+    histogram.resize(bin_size_per_channel  * bin_size_per_channel + 2, 0.0f); // h * s + w + b
+    int white_index = bin_size_per_channel * bin_size_per_channel;
+    int black_index = bin_size_per_channel * bin_size_per_channel + 1;
+
+    // vote
+    for (size_t i = 0; i < cloud.points.size(); ++i) {
+      PointXYZHLS p;
+      HSV2HLS(cloud.points[i], p);
+      if (p.l < white_threshold)
+        histogram[white_index] += 1.0f;
+      else if (p.l > 1.0 - black_threshold)
+        histogram[black_index] += 1.0f;
+      else {
+        int h_bin = getHistogramBin(p.h, bin_size_per_channel, 0.0, 360.0);
+        int s_bin = getHistogramBin(p.s, bin_size_per_channel, 0.0, 1.0);
+        histogram[s_bin * bin_size_per_channel + h_bin] += 1.0f;
+      }
+    }
+
+    normalizeHistogram(histogram);
+  }
+
+  inline void
+  rotateHistogram1d(const std::vector<float>& input,
+                    std::vector<float>& output,
+                    const double degree)
+  {
+    size_t bin_size = input.size() - 2;
+    int offset = std::floor(degree / 360.0 * bin_size);
+    output.resize(input.size());
+    for (size_t h = 0; h < bin_size; ++h) {
+      int hout = h + offset % bin_size;
+      output[hout] = input[h];
+    }
+
+    // copy white + black
+    int index = bin_size;
+    output[index] = input[index];
+    output[index+1] = input[index+1];
+  }
+
+  inline void
+  rotateHistogram2d(const std::vector<float>& input,
+                    std::vector<float>& output,
+                    const double degree)
+  {
+    size_t bin_size = (size_t)(std::sqrt(input.size() - 2));
+    int offset = std::floor(degree / 360.0 * bin_size);
+    output.resize(input.size());
+    for (size_t s = 0; s < bin_size; ++s) {
+      for (size_t h = 0; h < bin_size; ++h) {
+        int hout = h + offset % bin_size;
+        output[s * bin_size + hout] = input[s * bin_size + h];
+      }
+    }
+
+    // copy white + black
+    int index = bin_size * bin_size;
+    output[index] = input[index];
+    output[index+1] = input[index+1];
+  }
+
+  inline bool
+  compareHistogram(const std::vector<float>& input,
+                   const std::vector<float>& reference,
+                   const ComparePolicy policy,
+                   double& distance)
+  {
+    if (input.size() != reference.size()) {
+      ROS_ERROR("Mismatch histogram bin size");
+      return false;
+    }
+
+    distance = 0.0;
+    size_t len = input.size();
+    if (policy == CHISQUARE) {
+      for (size_t i = 0; i < len; ++i) {
+        double a = input[i] - reference[i], b = input[i];
+        if (std::fabs(b) > DBL_EPSILON) distance += a * a / b;
+      }
+    } else if (policy == CORRELATION) {
+      double s1 = 0.0, s2 = 0.0, s11 = 0.0, s12 = 0.0, s22 = 0.0;
+      for (size_t i = 0; i < len; ++i) {
+        double a = input[i], b = reference[i];
+        s11 += a*a; s12 += a*b; s22 += b*b;
+        s1 += a; s2 += b;
+      }
+      double num = s12 - s1*s2/len;
+      double denom2 = (s11 - s1 * s1 / len) * (s22 - s2 * s2 / len);
+      distance = std::fabs(denom2) > DBL_EPSILON ? num / std::sqrt(denom2) : 1.0;
+    } else if (policy == INTERSECTION) {
+      for (size_t i = 0; i < len; ++i) {
+        distance += std::min(input[i], reference[i]);
+      }
+    } else if (policy == BHATTACHARYYA) {
+      double s1 = 0.0, s2 = 0.0;
+      for (size_t i = 0; i < len; ++i) {
+        distance += std::sqrt(input[i] * reference[i]);
+        s1 += input[i]; s2 += reference[i];
+      }
+      s1 *= s2;
+      s1 = std::fabs(s1) > DBL_EPSILON ? 1.0 / std::sqrt(s1) : 1.0;
+      distance = std::sqrt(std::max(1.0 - distance * s1, 0.0));
+    } else if (policy == KL_DIVERGENCE) {
+      for (size_t i = 0; i < len; ++i) {
+        double p = input[i], q = reference[i];
+        if (std::fabs(p) <= DBL_EPSILON) continue;
+        if (std::fabs(q) <= DBL_EPSILON) q = 1e-10;
+        distance += p * std::log(p / q);
+      }
+    } else {
+      ROS_ERROR("Invalid compare policy");
+      return false;
+    }
+
+    return true;
+  }
+} // namespace
+
+#endif // JSK_RECOGNITION_UTILS_COLOR_HISTOGRAM_H__


### PR DESCRIPTION
- [x] separate logic to compute color histogram from nodelet internal definition
- [x] add nodelet for computing color histogram for each point indices
- [x] add nodelet for filtering indices using similarity of color histogram
- [x] add image for doc
- [x] update docs
- [x] add sample launch file
- [x] add test codes

related https://github.com/jsk-ros-pkg/jsk_recognition/pull/2094

Below is image that iemon green tea is filtered.

![color_histogram](https://cloud.githubusercontent.com/assets/1901008/26710312/f1343f54-4793-11e7-8848-9a2f31e4b5d5.png)
