### PR TITLE
[jsk_perception/draw_rect_array.py] check polygon_msg list size

### DIFF
--- a/jsk_perception/node_scripts/draw_rect_array.py
+++ b/jsk_perception/node_scripts/draw_rect_array.py
@@ -57,14 +57,15 @@ class DrawRectArray(ConnectionBasedTransport):
 
     def _draw_polygon(self, imgmsg, polygon_msg):
         rect_msg = Rect()
-        x1 = polygon_msg.polygon.points[0].x
-        y1 = polygon_msg.polygon.points[0].y
-        x2 = polygon_msg.polygon.points[1].x
-        y2 = polygon_msg.polygon.points[1].y
-        rect_msg.x = int(x1)
-        rect_msg.y = int(y1)
-        rect_msg.width = int(x2 - x1)
-        rect_msg.height = int(y2 - y1)
+        if len(polygon_msg.polygon.points) == 2:
+            x1 = polygon_msg.polygon.points[0].x
+            y1 = polygon_msg.polygon.points[0].y
+            x2 = polygon_msg.polygon.points[1].x
+            y2 = polygon_msg.polygon.points[1].y
+            rect_msg.x = int(x1)
+            rect_msg.y = int(y1)
+            rect_msg.width = int(x2 - x1)
+            rect_msg.height = int(y2 - y1)
         rects = [rect_msg]
         rects_msg = RectArray(header=polygon_msg.header, rects=rects)
         self._draw(imgmsg, rects_msg)


### PR DESCRIPTION
When polygon_msg like below (list is empty) is published, 
```
header: 
  seq: 304
  stamp: 
    secs: 1497531876
    nsecs: 174966328
  frame_id: head_rgbd_sensor_rgb_frame
polygon: 
  points: []
```
this kind of error occurs.

```
Traceback (most recent call last):
  File "/opt/ros/indigo/lib/python2.7/dist-packages/rospy/topics.py", line 720, 
in _invoke_callback
    cb(msg)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/message_filters/__init__.py"
, line 74, in callback
    self.signalMessage(msg)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/message_filters/__init__.py"
, line 56, in signalMessage
    cb(*(msg + args))
  File "/opt/ros/indigo/lib/python2.7/dist-packages/message_filters/__init__.py"
, line 199, in add
    self.signalMessage(*msgs)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/message_filters/__init__.py"
, line 56, in signalMessage
    cb(*(msg + args))
  File "/home/kochigami/ros/indigo/src/jsk-ros-pkg/jsk_recognition/jsk_perceptio
n/node_scripts/draw_rect_array.py", line 60, in _draw_polygon
    x1 = polygon_msg.polygon.points[0].x
IndexError: list index out of range
```
That's why I added checking list size.
If there is any problem, please let me know.
