### PR TITLE
[jsk_perception/doc] modified input type of rect_to_mask_image

### DIFF
--- a/doc/jsk_perception/nodes/rect_to_mask_image.md
+++ b/doc/jsk_perception/nodes/rect_to_mask_image.md
@@ -4,9 +4,9 @@ Convert rectangle (`geometry_msgs/Polygon`) into mask image (`sensor_msgs/Image`
 We expect it will be used with image_view2.
 
 ## Subscribing Topic
-* `~input` (`geometry_msgs/Polygon`)
+* `~input` (`geometry_msgs/PolygonStamped`)
 
-  Polygon to represent rectangle region of image.
+  PolygonStamped to represent rectangle region of image.
 * `~input/camera_info` (`sensor_msgs/CameraInfo`)
 
   Original camera info.


### PR DESCRIPTION
I think input message type is ```PointStamped```, not ```Polygon``` based on https://github.com/jsk-ros-pkg/jsk_recognition/blob/master/jsk_perception/src/rect_to_mask_image.cpp#L67

If there is any problem (actually I have a lot of mistakes...), please let me know.