### PR TITLE
[jsk_recognition_utils] install node_scripts dir

### DIFF
--- a/jsk_recognition_utils/CMakeLists.txt
+++ b/jsk_recognition_utils/CMakeLists.txt
@@ -110,3 +110,8 @@ install(TARGETS jsk_recognition_utils
 
 install(DIRECTORY include/${PROJECT_NAME}/
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+
+install(DIRECTORY node_scripts/
+        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+        USE_SOURCE_PERMISSIONS
+)


### PR DESCRIPTION
Fix #2117 
I have not much knowledge about debian release, but `node_scripts` `install` section is missing, which seems the cause of the issue.
If I'm misunderstanding, please let me know.