### PR TITLE
[jsk_perception] add RectArrayToMaskImage

### DIFF
--- a/doc/jsk_perception/nodes/rect_array_to_mask_image.md
+++ b/doc/jsk_perception/nodes/rect_array_to_mask_image.md
@@ -1,0 +1,17 @@
+# RectArrayToMaskImage
+Convert array of rectangle (`jsk_recognition_msgs/PolygonArray`) into mask image (`sensor_msgs/Image`)
+
+We expect it will be used with image_view2.
+
+## Subscribing Topic
+* `~input` (`jsk_recognition_msgs/PolygonArray`)
+
+  PolygonArray to represent rectangle region of image.
+* `~input/camera_info` (`sensor_msgs/CameraInfo`)
+
+  Original camera info.
+
+## Publishing Topic
+* `~output` (`sensor_msgs/Image`)
+
+  Mask image.

--- a/jsk_perception/CMakeLists.txt
+++ b/jsk_perception/CMakeLists.txt
@@ -230,6 +230,7 @@ jsk_add_nodelet(src/morphological_operator.cpp "jsk_perception/TopHat" "top_hat"
 jsk_add_nodelet(src/morphological_operator.cpp "jsk_perception/BlackHat" "black_hat")
 jsk_add_nodelet(src/label_to_mask_image.cpp "jsk_perception/LabelToMaskImage" "label_to_mask_image")
 jsk_add_nodelet(src/rect_to_mask_image.cpp "jsk_perception/RectToMaskImage" "rect_to_mask_image")
+jsk_add_nodelet(src/rect_array_to_mask_image.cpp "jsk_perception/RectArrayToMaskImage" "rect_array_to_mask_image")
 jsk_add_nodelet(src/mask_image_to_roi.cpp "jsk_perception/MaskImageToROI" "mask_image_to_roi")
 jsk_add_nodelet(src/mask_image_to_rect.cpp "jsk_perception/MaskImageToRect" "mask_image_to_rect")
 jsk_add_nodelet(src/bounding_rect_mask_image.cpp "jsk_perception/BoundingRectMaskImage" "bounding_rect_mask_image")

--- a/jsk_perception/include/jsk_perception/rect_array_to_mask_image.h
+++ b/jsk_perception/include/jsk_perception/rect_array_to_mask_image.h
@@ -1,0 +1,71 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+
+#ifndef JSK_PERCEPTION_RECT_ARRAY_TO_MASK_IMAGE_H_
+#define JSK_PERCEPTION_RECT_ARRAY_TO_MASK_IMAGE_H_
+
+#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_msgs/PolygonArray.h>
+#include <sensor_msgs/Image.h>
+#include <sensor_msgs/CameraInfo.h>
+#include <opencv2/opencv.hpp>
+
+namespace jsk_perception
+{
+  class RectArrayToMaskImage: public jsk_topic_tools::DiagnosticNodelet
+  {
+  public:
+    RectArrayToMaskImage(): DiagnosticNodelet("RectArrayToMaskImag") {}
+  protected:
+    virtual void onInit();
+    virtual void subscribe();
+    virtual void unsubscribe();
+    virtual void convert(
+      const jsk_recognition_msgs::PolygonArray::ConstPtr& rect_array_msg);
+    virtual void infoCallback(
+      const sensor_msgs::CameraInfo::ConstPtr& info_msg);
+
+    boost::mutex mutex_;
+    ros::Publisher pub_;
+    ros::Subscriber sub_;
+    ros::Subscriber sub_info_;
+    sensor_msgs::CameraInfo::ConstPtr camera_info_;
+  private:
+    
+  };
+}
+
+#endif

--- a/jsk_perception/plugins/nodelet/libjsk_perception.xml
+++ b/jsk_perception/plugins/nodelet/libjsk_perception.xml
@@ -59,6 +59,10 @@
          type="jsk_perception::RectToMaskImage"
          base_class_type="nodelet::Nodelet">
   </class>
+  <class name="jsk_perception/RectArrayToMaskImage"
+         type="jsk_perception::RectArrayToMaskImage"
+         base_class_type="nodelet::Nodelet">
+  </class>
   <class name="jsk_perception/RectToROI"
          type="jsk_perception::RectToROI"
          base_class_type="nodelet::Nodelet">

--- a/jsk_perception/src/rect_array_to_mask_image.cpp
+++ b/jsk_perception/src/rect_array_to_mask_image.cpp
@@ -1,0 +1,103 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include "jsk_perception/rect_array_to_mask_image.h"
+#include <boost/assign.hpp>
+#include <jsk_topic_tools/log_utils.h>
+#include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
+
+namespace jsk_perception
+{
+  void RectArrayToMaskImage::onInit()
+  {
+    DiagnosticNodelet::onInit();
+    pub_ = advertise<sensor_msgs::Image>(*pnh_, "output", 1);
+    onInitPostProcess();
+  }
+
+  void RectArrayToMaskImage::subscribe()
+  {
+    sub_ = pnh_->subscribe("input", 1, &RectArrayToMaskImage::convert, this);
+    sub_info_ = pnh_->subscribe("input/camera_info", 1,
+                                &RectArrayToMaskImage::infoCallback, this);
+    ros::V_string names = boost::assign::list_of("~input")("~input/camera_info");
+    jsk_topic_tools::warnNoRemap(names);
+  }
+
+  void RectArrayToMaskImage::unsubscribe()
+  {
+    sub_.shutdown();
+    sub_info_.shutdown();
+  }
+
+  void RectArrayToMaskImage::convert(const jsk_recognition_msgs::PolygonArray::ConstPtr& rect_array_msg)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+    if (camera_info_) {
+      cv::Mat mask_image = cv::Mat::zeros(camera_info_->height,
+                                          camera_info_->width,
+                                          CV_8UC1);
+      for (size_t i=0; i < rect_array_msg->polygons.size(); i++){
+	geometry_msgs::PolygonStamped rect_msg = rect_array_msg->polygons[i];
+	geometry_msgs::Point32 P0 = rect_msg.polygon.points[0];
+	geometry_msgs::Point32 P1 = rect_msg.polygon.points[1];
+	double min_x = std::max(std::min(P0.x, P1.x), 0.0f);
+	double max_x = std::max(P0.x, P1.x);
+	double min_y = std::max(std::min(P0.y, P1.y), 0.0f);
+	double max_y = std::max(P0.y, P1.y);
+	double width = std::min(max_x - min_x, camera_info_->width - min_x);
+	double height = std::min(max_y - min_y, camera_info_->height - min_y);
+	cv::Rect region(min_x, min_y, width, height);
+	cv::rectangle(mask_image, region, cv::Scalar(255), CV_FILLED);
+      }
+      pub_.publish(cv_bridge::CvImage(
+                     rect_array_msg->header,
+                     sensor_msgs::image_encodings::MONO8,
+                     mask_image).toImageMsg());
+    }
+  }
+
+  
+  void RectArrayToMaskImage::infoCallback(
+    const sensor_msgs::CameraInfo::ConstPtr& info_msg)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+    camera_info_ = info_msg;
+  }
+}
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS (jsk_perception::RectArrayToMaskImage, nodelet::Nodelet);


### PR DESCRIPTION
I just created ```RectArrayToMaskImage``` based on what I want to do described in https://github.com/jsk-ros-pkg/jsk_recognition/issues/2119.
If it is not needed, I'll close this.

- like ```RectToMaskImage``` uses ```geometry_msgs/PolygonStamped``` as input, ```RectArrayToMaskImage``` uses ```jsk_recognition_msgs/PolygonArray``` as input

- I followed https://github.com/jsk-ros-pkg/jsk_recognition/blob/master/jsk_perception/src/rect_to_mask_image.cpp about source code and documentation
- however, I couldn't make a test program because I didn't follow three points below...
-- 1. I have to prepare code for publishing the topic of ```jsk_recognition_msgs/PolygonArray```.
-- 2. I don't have a good bag file or picture  (I use this program for moving detection after face detection, but I feel difficulty uploading a file including many people to public now...) 
-- 3. I have to learn how to upload a bag file

Maybe point 1, 3 are OK, but I got stuck in point 2.
  