### PR TITLE
[jsk_pcl_ros/OctomapServerContact] Supress octomap debug message

### DIFF
--- a/jsk_pcl_ros/include/jsk_pcl_ros/octomap_server_contact.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/octomap_server_contact.h
@@ -39,6 +39,7 @@
 #include <ros/ros.h>
 #include <jsk_topic_tools/diagnostic_nodelet.h>
 
+#define NDEBUG
 #include <octomap_server/OctomapServer.h>
 #include <jsk_pcl_ros/OcTreeContact.h>
 #include <jsk_recognition_msgs/ContactSensorArray.h>

--- a/jsk_pcl_ros/src/octomap_server_contact_nodelet.cpp
+++ b/jsk_pcl_ros/src/octomap_server_contact_nodelet.cpp
@@ -250,7 +250,7 @@ namespace jsk_pcl_ros
   }
 
   void OctomapServerContact::insertContactSensorCallback(const jsk_recognition_msgs::ContactSensorArray::ConstPtr& msg) {
-    ROS_WARN_STREAM("insert contact sensor");
+    NODELET_INFO("insert contact sensor");
     std::vector<jsk_recognition_msgs::ContactSensor> datas = msg->datas;
     insertContactSensor(datas);
 


### PR DESCRIPTION
Following output is printed from octomap in every update.
https://github.com/OctoMap/octomap/blob/devel/octomap/include/octomap/OccupancyOcTreeBase.hxx#L947
define NDEBUG to suppress octomap output.
https://github.com/OctoMap/octomap/blob/cc7cddc6e5e01c2fdb1b142124a9890b949a0360/octomap/include/octomap/octomap_types.h#L62
