### PR TITLE
[jsk_pcl_ros_utils/src] add onInitPostProcess for StaticPolygonArrayPublisher, PolygonArrayTransformer

### DIFF
--- a/jsk_pcl_ros_utils/src/polygon_array_transformer_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_array_transformer_nodelet.cpp
@@ -52,7 +52,7 @@ namespace jsk_pcl_ros_utils
     polygons_pub_ = advertise<jsk_recognition_msgs::PolygonArray>(*pnh_, "output_polygons", 1);
     coefficients_pub_ = advertise<jsk_recognition_msgs::ModelCoefficientsArray>(
       *pnh_, "output_coefficients", 1);
-    
+    onInitPostProcess();
   }
 
   void PolygonArrayTransformer::subscribe()

--- a/jsk_pcl_ros_utils/src/static_polygon_array_publisher_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/static_polygon_array_publisher_nodelet.cpp
@@ -94,6 +94,7 @@ namespace jsk_pcl_ros_utils
       subscribe();
       timer_ = pnh_->createTimer(ros::Duration(1.0 / periodic_rate_), &StaticPolygonArrayPublisher::timerCallback, this);
     }
+    onInitPostProcess();
   }
 
   void StaticPolygonArrayPublisher::subscribe()


### PR DESCRIPTION
When I launch 
```StaticPolygonArrayPublisher``` (node name is set to ```[/people_detection/footstep_polygon_publisher```) 
and ```PolygonArrayTransformer``` (node name is set to ```[/people_detection/polygon_array_transformer```)
of jsk_pcl_ros_utils, the warning below occurred.

```
[ WARN] [1498035213.941695751]: [/people_detection/footstep_polygon_publisher] onInitPostProcess is not yet called.
[ WARN] [1498035213.942671862]: '/people_detection/footstep_polygon_publisher' subscribes topics only with child subscribers.
[ WARN] [1498035214.353049047]: [/people_detection/polygon_array_transformer] onInitPostProcess is not yet called.
[ WARN] [1498035214.353923307]: '/people_detection/polygon_array_transformer' subscribes topics only with child subscribers.
```
If there is any comments, please let me know.