### PR TITLE
Capability of specifying background label for LabelToClusterPointIndices

### DIFF
--- a/doc/jsk_pcl_ros_utils/nodes/label_to_cluster_point_indices.rst
+++ b/doc/jsk_pcl_ros_utils/nodes/label_to_cluster_point_indices.rst
@@ -26,3 +26,15 @@ Publishing Topic
   Set of point indices and each point indices means each label.
   label value ``0`` is recognized as background label, so ``i(index of cluster point indices) + 1`` = ``label number``.
   (ex. point indices in index ``0`` is region where label value is ``1``)
+
+* ``~output/bg_indices`` (``sensor_msgs/PointIndices``)
+
+  Point indices which means background label.
+
+
+Parameters
+----------
+
+* ``~bg_label`` (``Int``, default: ``0``)
+
+  Label value for which background point indices is published.

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/label_to_cluster_point_indices.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/label_to_cluster_point_indices.h
@@ -62,6 +62,8 @@ protected:
   ros::Subscriber sub_;
   ros::Publisher pub_;
   ros::Publisher pub_bg_;
+
+  int bg_label_;
 private:
 };
 

--- a/jsk_pcl_ros_utils/src/label_to_cluster_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/label_to_cluster_point_indices_nodelet.cpp
@@ -74,36 +74,43 @@ namespace jsk_pcl_ros_utils
       label_msg, sensor_msgs::image_encodings::TYPE_32SC1);
     // collect indices for each labels
     std::map<int, pcl_msgs::PointIndices> label_to_indices;
+    int max_label = 0;
     for (size_t j = 0; j < label_img_ptr->image.rows; j++)
     {
       for (size_t i = 0; i < label_img_ptr->image.cols; i++)
       {
         int label = label_img_ptr->image.at<int>(j, i);
+        if (label > max_label) {
+           max_label = label;
+        }
         label_to_indices[label].header = label_msg->header;
         label_to_indices[label].indices.push_back(j * label_img_ptr->image.cols + i);
       }
     }
     // convert 'map for label to indices' to 'cluster point indices'
-    int cluster_counter = 0;
     jsk_recognition_msgs::ClusterPointIndices cluster_indices_msg;
     pcl_msgs::PointIndices bg_indices_msg;
     cluster_indices_msg.header = bg_indices_msg.header = label_msg->header;
-    for (std::map<int, pcl_msgs::PointIndices>::iterator it = label_to_indices.begin();
-         it != label_to_indices.end(); it++)
+    for (size_t i=0; i <= max_label; i++)
     {
-      if (it->first == bg_label_) {
-        bg_indices_msg.indices = it->second.indices;
-        cluster_counter++;
-        continue;
+      if (i == bg_label_) {
+        if (label_to_indices.count(i) == 0) {
+          pcl_msgs::PointIndices indices_msg;
+          indices_msg.header = label_msg->header;
+          bg_indices_msg = indices_msg;
+        }
+        else {
+          bg_indices_msg = label_to_indices[i];
+        }
       }
-      while (it->first != cluster_counter) {
+      else if (label_to_indices.count(i) == 0) {
         pcl_msgs::PointIndices indices_msg;
         indices_msg.header = label_msg->header;
         cluster_indices_msg.cluster_indices.push_back(indices_msg);
-        cluster_counter++;
       }
-      cluster_indices_msg.cluster_indices.push_back(it->second);
-      cluster_counter++;
+      else {
+        cluster_indices_msg.cluster_indices.push_back(label_to_indices[i]);
+      }
     }
     pub_bg_.publish(bg_indices_msg);
     pub_.publish(cluster_indices_msg);

--- a/jsk_pcl_ros_utils/src/label_to_cluster_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/label_to_cluster_point_indices_nodelet.cpp
@@ -46,6 +46,7 @@ namespace jsk_pcl_ros_utils
   void LabelToClusterPointIndices::onInit()
   {
     DiagnosticNodelet::onInit();
+    pnh_->param("bg_label", bg_label_, 0);
     pub_ = advertise<jsk_recognition_msgs::ClusterPointIndices>(*pnh_, "output", 1);
     pub_bg_ = advertise<pcl_msgs::PointIndices>(*pnh_, "output/bg_indices", 1);
     onInitPostProcess();
@@ -83,7 +84,6 @@ namespace jsk_pcl_ros_utils
       }
     }
     // convert 'map for label to indices' to 'cluster point indices'
-    int bg_label = 0;
     int cluster_counter = 0;
     jsk_recognition_msgs::ClusterPointIndices cluster_indices_msg;
     pcl_msgs::PointIndices bg_indices_msg;
@@ -91,7 +91,7 @@ namespace jsk_pcl_ros_utils
     for (std::map<int, pcl_msgs::PointIndices>::iterator it = label_to_indices.begin();
          it != label_to_indices.end(); it++)
     {
-      if (it->first == bg_label) {
+      if (it->first == bg_label_) {
         bg_indices_msg.indices = it->second.indices;
         cluster_counter++;
         continue;


### PR DESCRIPTION
## Why?

We'd like to fill index of cluster indices with bg_label to keep index == label_value.