### PR TITLE
[jsk_pcl_ros_utils] add ignore_labels in label_to_cluster_point_indices

### DIFF
--- a/doc/jsk_pcl_ros_utils/nodes/label_to_cluster_point_indices.rst
+++ b/doc/jsk_pcl_ros_utils/nodes/label_to_cluster_point_indices.rst
@@ -38,3 +38,8 @@ Parameters
 * ``~bg_label`` (``Int``, default: ``0``)
 
   Label value for which background point indices is published.
+
+* ``~ignore_labels`` (List of ``Int``, default ``[]``)
+
+  List of ignored labels.
+  Indices of ignored labels are replaced by empty ones.

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/label_to_cluster_point_indices.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/label_to_cluster_point_indices.h
@@ -64,6 +64,7 @@ protected:
   ros::Publisher pub_bg_;
 
   int bg_label_;
+  std::vector<int> ignore_labels_;
 private:
 };
 

--- a/jsk_pcl_ros_utils/src/label_to_cluster_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/label_to_cluster_point_indices_nodelet.cpp
@@ -47,6 +47,7 @@ namespace jsk_pcl_ros_utils
   {
     DiagnosticNodelet::onInit();
     pnh_->param("bg_label", bg_label_, 0);
+    pnh_->param("ignore_labels", ignore_labels_, std::vector<int>());
     pub_ = advertise<jsk_recognition_msgs::ClusterPointIndices>(*pnh_, "output", 1);
     pub_bg_ = advertise<pcl_msgs::PointIndices>(*pnh_, "output/bg_indices", 1);
     onInitPostProcess();
@@ -93,9 +94,9 @@ namespace jsk_pcl_ros_utils
     cluster_indices_msg.header = bg_indices_msg.header = label_msg->header;
     for (size_t i=0; i <= max_label; i++)
     {
+      pcl_msgs::PointIndices indices_msg;
       if (i == bg_label_) {
         if (label_to_indices.count(i) == 0) {
-          pcl_msgs::PointIndices indices_msg;
           indices_msg.header = label_msg->header;
           bg_indices_msg = indices_msg;
         }
@@ -103,8 +104,8 @@ namespace jsk_pcl_ros_utils
           bg_indices_msg = label_to_indices[i];
         }
       }
-      else if (label_to_indices.count(i) == 0) {
-        pcl_msgs::PointIndices indices_msg;
+      else if (label_to_indices.count(i) == 0 ||
+              std::find(ignore_labels_.begin(), ignore_labels_.end(), i) != ignore_labels_.end()) {
         indices_msg.header = label_msg->header;
         cluster_indices_msg.cluster_indices.push_back(indices_msg);
       }

--- a/jsk_pcl_ros_utils/src/label_to_cluster_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/label_to_cluster_point_indices_nodelet.cpp
@@ -105,7 +105,7 @@ namespace jsk_pcl_ros_utils
         }
       }
       else if (label_to_indices.count(i) == 0 ||
-              std::find(ignore_labels_.begin(), ignore_labels_.end(), i) != ignore_labels_.end()) {
+               std::find(ignore_labels_.begin(), ignore_labels_.end(), i) != ignore_labels_.end()) {
         indices_msg.header = label_msg->header;
         cluster_indices_msg.cluster_indices.push_back(indices_msg);
       }


### PR DESCRIPTION
add param `~ignore_labels` in `label_to_cluster_point_indices`
indices of ignored label are replaced by `[]`