### PR TITLE
[jsk_recognition_utils] install chainermodels dir in setup.py

### DIFF
--- a/jsk_recognition_utils/setup.py
+++ b/jsk_recognition_utils/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
-    packages=['jsk_recognition_utils'],
+    packages=['jsk_recognition_utils', 'jsk_recognition_utils.chainermodels'],
     package_dir={'': 'python'},
 )
 


### PR DESCRIPTION
This is for debian package release.
Currently, `jsk_recognition_utils.chainermodels` cannot be found with debian package