### PR TITLE
Derive from ros:indigo-ros-core in ros-indigo-pcl1.8

### DIFF
--- a/docker/ros/indigo/pcl1.8/Dockerfile
+++ b/docker/ros/indigo/pcl1.8/Dockerfile
@@ -1,4 +1,4 @@
-FROM ros:indigo
+FROM ros:indigo-ros-core
 
 RUN apt-get update && apt-get install -y \
     wget \


### PR DESCRIPTION
To avoid pre-installed packages unexpectedly.