### PR TITLE
[jsk_pcl_ros/pointcloud_screenpoint] modify bad service callback error

### DIFF
--- a/jsk_pcl_ros/src/pointcloud_screenpoint_nodelet.cpp
+++ b/jsk_pcl_ros/src/pointcloud_screenpoint_nodelet.cpp
@@ -193,7 +193,7 @@ bool jsk_pcl_ros::PointcloudScreenpoint::screenpoint_cb (jsk_recognition_msgs::T
   boost::mutex::scoped_lock lock(this->mutex_callback_);
   if ( pts_.points.size() == 0 ) {
     ROS_ERROR("no point cloud was received");
-    return false;
+    return true;
   }
 
   res.header = header_;
@@ -204,7 +204,7 @@ bool jsk_pcl_ros::PointcloudScreenpoint::screenpoint_cb (jsk_recognition_msgs::T
   res.point.x = rx; res.point.y = ry; res.point.z = rz;
 
   if (!ret) {
-    return false;
+    return true;
   }
 
   // search normal


### PR DESCRIPTION
I wrote in  #2163 
I'd like to avoid service call exception because my program stops here if it happens,

I modified return value when condition is not satisfied (*)
of ```screenpoint_cb``` (```/pointcloud_screenpoint/screen_to_point``` service callback) 

(*)
- (case1) when no point is received: https://github.com/jsk-ros-pkg/jsk_recognition/compare/master...kochigami:modify-bad-service-call?expand=1#diff-23ee278b6f1dbfb726f017466e7fa56fL195
- (case2) when ```extract_point``` returns false (= point is received, but there is no point around targeted (u, v)): https://github.com/jsk-ros-pkg/jsk_recognition/compare/master...kochigami:modify-bad-service-call?expand=1#diff-23ee278b6f1dbfb726f017466e7fa56fL206

- ```return false``` in service callback causes Service Exception error
- ```return true``` changes the return value as follows:
  (case1) point and vector component are 0
```
[http://192.168.11.5:11311][192.168.11.5] kochigami@kochigami-ThinkPad-T450:~/ros/indigo/src/jsk-ros-pkg/jsk_recognition/jsk_pcl_ros/src$ rosservice call /people_detection/pointcloud_screenpoint/screen_to_point "x: 0.0
y: 50.0" 
header: 
  seq: 0
  stamp: 
    secs: 0
    nsecs:         0
  frame_id: ''
point: 
  x: 0.0
  y: 0.0
  z: 0.0
vector: 
  x: 0.0
  y: 0.0
  z: 0.0
```
(case2) vector component is 0
```
[http://192.168.11.5:11311][192.168.11.5] kochigami@kochigami-ThinkPad-T450:~/ros/indigo/src/jsk-ros-pkg/jsk_recognition/jsk_pcl_ros/src$ rosservice call /people_detection/pointcloud_screenpoint/screen_to_point "x: 1000.0
y: 1000.0" 
header: 
  seq: 23
  stamp: 
    secs: 1497581597
    nsecs: 250556700
  frame_id: head_rgbd_sensor_rgb_frame
point: 
  x: 0.0
  y: 3.50324616081e-44
  z: 0.0
vector: 
  x: 0.0
  y: 0.0
  z: 0.0
```


% (case 3) :  point (around targeted (u, v)) is found
```
[http://192.168.11.5:11311][192.168.11.5] kochigami@kochigami-ThinkPad-T450:~/ros/indigo/src/jsk-ros-pkg/jsk_recognition/jsk_pcl_ros/src$ rosservice call /people_detection/pointcloud_screenpoint/screen_to_point "x: 10.0
y: 50.0" 
header: 
  seq: 23
  stamp: 
    secs: 1497581597
    nsecs: 250556700
  frame_id: head_rgbd_sensor_rgb_frame
point: 
  x: -1.75254487991
  y: -1.09459161758
  z: 3.09200024605
vector: 
  x: 0.030112111941
  y: -0.00123238540255
  z: 0.999545812607
```