### PR TITLE
fix bug in label_image_classifier

### DIFF
--- a/jsk_perception/node_scripts/label_image_classifier.py
+++ b/jsk_perception/node_scripts/label_image_classifier.py
@@ -42,6 +42,9 @@ class LabelImageClassifier(ConnectionBasedTransport):
     def _classify(self, label_img):
         label_img = label_img.flatten()
         counts = np.bincount(label_img)
+        if len(counts) < len(self.target_names):
+            counts = np.hstack(
+                (counts, np.zeros(len(self.target_names) - len(counts))))
         counts[self.ignore_labels] = 0
         label = np.argmax(counts)
         proba = counts.astype(np.float32) / counts.sum()

--- a/jsk_perception/node_scripts/label_image_classifier.py
+++ b/jsk_perception/node_scripts/label_image_classifier.py
@@ -40,11 +40,8 @@ class LabelImageClassifier(ConnectionBasedTransport):
         self.pub.publish(msg)
 
     def _classify(self, label_img):
-        label_img = label_img.flatten()
-        counts = np.bincount(label_img)
-        if len(counts) < len(self.target_names):
-            counts = np.hstack(
-                (counts, np.zeros(len(self.target_names) - len(counts))))
+        counts = np.bincount(label_img.flatten(),
+                             minlength=len(self.target_names))
         counts[self.ignore_labels] = 0
         label = np.argmax(counts)
         proba = counts.astype(np.float32) / counts.sum()


### PR DESCRIPTION
if `label_img` only have several elements like `[0, 37, 37, 0, ....]` and `ignore_labels` are set as `[0, 41]`, it occurs `out of index` error.
I pad zeros to avoid this error.