### PR TITLE
add bg_label in apply_context_to_label_probability

### DIFF
--- a/doc/jsk_perception/nodes/apply_context_to_label_probability.rst
+++ b/doc/jsk_perception/nodes/apply_context_to_label_probability.rst
@@ -19,8 +19,7 @@ Subscribing Topic
 
 * ``~input/candidates`` (``jsk_recognition_msgs/LabelArray``)
 
-  Array of candidates label.
-  This topic is only subscribed when parameter ``~use_topic`` is ``True``.
+  Array of candidates label to update ``~candidates``.
 
 
 Publishing Topic
@@ -52,9 +51,9 @@ Parameters
   If no candidates are provided,
   this node does nothing and just transports the input msg.
 
-* ``~use_topic`` (Bool, default: ``False``)
+* ``~candidates`` (List of String, default: ``[]``)
 
-  Update candidates by ``~input/candidates`` subscription
+  Candidates that never changed by services or topics.
 
 Sample
 ------

--- a/doc/jsk_perception/nodes/apply_context_to_label_probability.rst
+++ b/doc/jsk_perception/nodes/apply_context_to_label_probability.rst
@@ -51,7 +51,7 @@ Parameters
   If no candidates are provided,
   this node does nothing and just transports the input msg.
 
-* ``~candidates`` (List of String, default: ``[]``)
+* ``~candidates_fixed`` (List of String, default: ``[]``)
 
   Candidates that never changed by services or topics.
 

--- a/jsk_perception/node_scripts/apply_context_to_label_probability
+++ b/jsk_perception/node_scripts/apply_context_to_label_probability
@@ -17,6 +17,7 @@ class ApplyContextToLabelProbability(ConnectionBasedTransport):
     def __init__(self):
         super(self.__class__, self).__init__()
         self.use_topic = rospy.get_param('~use_topic', False)
+        self.bg_label = rospy.get_param('~bg_label', None)
 
         # list of label values
         self.candidates = rospy.get_param('~candidates', [])
@@ -67,8 +68,12 @@ class ApplyContextToLabelProbability(ConnectionBasedTransport):
                              "the number of input labels.")
                 return
 
+            candidates = self.candidates[:]
+            if self.bg_label is not None:
+                candidates.append(self.bg_label)
+
             for lbl in range(n_labels):
-                if lbl not in self.candidates:
+                if lbl not in candidates:
                     proba_img[:, :, lbl] = 0.
 
         # do dynamic scaling for the probability image

--- a/jsk_perception/node_scripts/apply_context_to_label_probability
+++ b/jsk_perception/node_scripts/apply_context_to_label_probability
@@ -24,8 +24,6 @@ class ApplyContextToLabelProbability(ConnectionBasedTransport):
 
     def __init__(self):
         super(self.__class__, self).__init__()
-        self.use_topic = rospy.get_param('~use_topic', False)
-
         # list of label values
         self.candidates = get_param_uint_list('~candidates', [])
 
@@ -38,15 +36,12 @@ class ApplyContextToLabelProbability(ConnectionBasedTransport):
 
     def subscribe(self):
         self._sub_img = rospy.Subscriber('~input', Image, self._apply)
-        if self.use_topic:
-            self._sub_candidates = rospy.Subscriber(
-                '~input/candidates', LabelArray,
-                self._update_candidates_with_topic)
+        self._sub_candidates = rospy.Subscriber(
+            '~input/candidates', LabelArray, self._update_candidates_with_topic)
 
     def unsubscribe(self):
         self._sub_img.unregister()
-        if self.use_topic:
-            self._sub_candidates.unregister()
+        self._sub_candidates.unregister()
 
     def _update_candidates(self, req):
         self.candidates = req.labels

--- a/jsk_perception/node_scripts/apply_context_to_label_probability
+++ b/jsk_perception/node_scripts/apply_context_to_label_probability
@@ -12,21 +12,26 @@ from jsk_recognition_msgs.srv import SetLabels
 from jsk_recognition_msgs.srv import SetLabelsResponse
 
 
+def get_param_uint_list(name, default=None):
+    param = rospy.get_param(name, default)
+    if not (isinstance(param, list) and
+            all(isinstance(el, int) and el >= 0 for el in param)):
+        raise ValueError("Elements of '%s' must be integer and >=0." % param)
+    return param
+
+
 class ApplyContextToLabelProbability(ConnectionBasedTransport):
 
     def __init__(self):
         super(self.__class__, self).__init__()
         self.use_topic = rospy.get_param('~use_topic', False)
-        self.bg_label = rospy.get_param('~bg_label', None)
 
         # list of label values
-        self.candidates = rospy.get_param('~candidates', [])
-        if not self.use_topic:
-            if not all(isinstance(lbl, int) and lbl >= 0
-                       for lbl in self.candidates):
-                rospy.logfatal("Elements of '~candidates' must be "
-                               "integer and >=0.")
-                quit(1)
+        self.candidates = get_param_uint_list('~candidates', [])
+
+        # candidates which are never updated
+        self.candidates_fixed = get_param_uint_list('~candidates_fixed', [])
+
         rospy.Service('~update_candidates', SetLabels, self._update_candidates)
         self.pub_proba = self.advertise('~output', Image, queue_size=1)
         self.pub_label = self.advertise('~output/label', Image, queue_size=1)
@@ -61,16 +66,16 @@ class ApplyContextToLabelProbability(ConnectionBasedTransport):
             rospy.logerr('Image shape must be (height, width, channels).')
             return
 
-        if self.candidates:
+        # current candidates
+        candidates = self.candidates + self.candidates_fixed
+        candidates = set(candidates)
+
+        if candidates:
             n_labels = proba_img.shape[2]
-            if max(self.candidates) >= n_labels:
+            if max(candidates) >= n_labels:
                 rospy.logerr("The max label value in '~candidates' exceeds "
                              "the number of input labels.")
                 return
-
-            candidates = self.candidates[:]
-            if self.bg_label is not None:
-                candidates.append(self.bg_label)
 
             for lbl in range(n_labels):
                 if lbl not in candidates:


### PR DESCRIPTION
add `bg_label` for masked images.
if `candidates` does not contain `bg_label`, sum of masked regions would be `0`, and probability would be `nan`.
This can happen, for example, weight_candidates_publisher do not publish `__background__` as candidates.
