### PR TITLE
Publish sorted cluster point indices in ClusterPointIndicesDecomposer

### DIFF
--- a/doc/jsk_pcl_ros/nodes/cluster_point_indices_decomposer.md
+++ b/doc/jsk_pcl_ros/nodes/cluster_point_indices_decomposer.md
@@ -44,6 +44,10 @@ It also publishes tf of centroids of each cluster and oriented bounding box of t
 
   Point indices which are not included in input indices.
 
+* `~cluster_indices` (`jsk_recognition_msgs/ClusterPointIndices`)
+
+  Sorted cluster point indices.
+
 **Optional Topics**
 
 * `~output%02d` (`sensor_msgs/PointCloud2`):

--- a/jsk_pcl_ros/include/jsk_pcl_ros/cluster_point_indices_decomposer.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/cluster_point_indices_decomposer.h
@@ -157,7 +157,7 @@ namespace jsk_pcl_ros
     boost::shared_ptr<message_filters::Synchronizer<ApproximateSyncPolicy> >async_;
     boost::shared_ptr<message_filters::Synchronizer<SyncAlignPolicy> >sync_align_;
     std::vector<ros::Publisher> publishers_;
-    ros::Publisher pc_pub_, box_pub_, mask_pub_, label_pub_, centers_pub_, negative_indices_pub_;
+    ros::Publisher pc_pub_, box_pub_, mask_pub_, label_pub_, centers_pub_, negative_indices_pub_, indices_pub_;
     boost::shared_ptr<tf::TransformBroadcaster> br_;
     std::string tf_prefix_;
     

--- a/jsk_pcl_ros/test/test_cluster_point_indices_decomposer.test
+++ b/jsk_pcl_ros/test/test_cluster_point_indices_decomposer.test
@@ -15,6 +15,14 @@
       timeout_1: 30
       topic_2: /cluster_point_indices_decomposer_align_boxes_with_frame/boxes
       timeout_2: 30
+      topic_3: /cluster_point_indices_decomposer/mask
+      timeout_3: 30
+      topic_4: /cluster_point_indices_decomposer/label
+      timeout_4: 30
+      topic_5: /cluster_point_indices_decomposer/cluster_indices
+      timeout_5: 30
+      topic_6: /cluster_point_indices_decomposer/centroid_pose_array
+      timeout_6: 30
     </rosparam>
   </test>
 


### PR DESCRIPTION
We used this in the Grasped Region Classification at ARC2017 pick/stow task.