### PR TITLE
[jsk_pcl_ros_utils] polygon_flipper: add option '~use_indices'

### DIFF
--- a/doc/jsk_pcl_ros_utils/nodes/polygon_flipper.md
+++ b/doc/jsk_pcl_ros_utils/nodes/polygon_flipper.md
@@ -5,14 +5,26 @@ Flip `jsk_recognition_msgs/PolygonArray` to specified sensor_frame.
 ## Subscribing Topic
 * `~input/polygons` (`jsk_recognition_msgs/PolygonArray`)
 * `~input/coefficients` (`jsk_recognition_msgs/ModelCoefficientsArray`)
+* `~input/indices` (`jsk_recognition_msgs/ClusterPointIndices`)
 
   Input polygons.
+  If `~use_indices` is disabled, `~input/indices` is not used.
 ## Publishing Topic
 * `~output/polygons` (`jsk_recognition_msgs/PolygonArray`)
 * `~output/coefficients` (`jsk_recognition_msgs/ModelCoefficientsArray`)
+* `~output/indices` (`jsk_recognition_msgs/ClusterPointIndices`)
 
   Output flipped polygons which look at the origin of sensor_frame.
+  If `~use_indices` is disabled, `~output/indices` is not published.
 ## Parameter
-* `~sensor_frame` (String)
+* `~sensor_frame` (`String`, Required):
 
-   frame_id of sensor for polygons to look at.
+   The frame_id of sensor for polygons to look at.
+
+* `~queue_size` (`Int`, default: `100`):
+
+   Queue size of subscribed messages for message synchronization.
+
+* `~use_indices` (`Bool`, default: `true`):
+
+   Use indices if this parameter is enabled.

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_flipper.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_flipper.h
@@ -48,6 +48,7 @@
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/synchronizer.h>
+#include <message_filters/pass_through.h>
 
 namespace jsk_pcl_ros_utils
 {
@@ -65,6 +66,8 @@ namespace jsk_pcl_ros_utils
     virtual void subscribe();
     virtual void unsubscribe();
 
+    virtual void fillEmptyIndices(
+      const jsk_recognition_msgs::PolygonArray::ConstPtr& polygon_msg);
     virtual void flip(
       const jsk_recognition_msgs::PolygonArray::ConstPtr& polygon_msg,
       const jsk_recognition_msgs::ClusterPointIndices::ConstPtr& indices_msg,
@@ -72,13 +75,16 @@ namespace jsk_pcl_ros_utils
     
     boost::shared_ptr<message_filters::Synchronizer<SyncPolicy> > sync_;
     message_filters::Subscriber<jsk_recognition_msgs::PolygonArray> sub_polygons_;
-    message_filters::Subscriber<jsk_recognition_msgs::ClusterPointIndices> sub_indices_;
     message_filters::Subscriber<jsk_recognition_msgs::ModelCoefficientsArray> sub_coefficients_;
+    message_filters::Subscriber<jsk_recognition_msgs::ClusterPointIndices> sub_indices_;
+    message_filters::PassThrough<jsk_recognition_msgs::ClusterPointIndices> sub_indices_null_;
     ros::Publisher pub_polygons_;
     ros::Publisher pub_indices_;
     ros::Publisher pub_coefficients_;
     tf::TransformListener* tf_listener_;
     std::string sensor_frame_;
+    bool use_indices_;
+    int queue_size_;
   private:
     
   };


### PR DESCRIPTION
Addressed at #2188 

- [x] Added `~use_indices` to flip polygons / coefficients without indices.
- [x] update docs