### PR TITLE
jsk_pcl_ros: multi_plane_extraction: add option use_coefficients

### DIFF
--- a/doc/jsk_pcl_ros/nodes/multi_plane_extraction.md
+++ b/doc/jsk_pcl_ros/nodes/multi_plane_extraction.md
@@ -11,7 +11,9 @@ Extract the points above the planes between `~min_height` and `~max_height`.
 * `~input_polygons` (`jsk_recognition_msgs/PolygonArray`)
 * `~input_coefficients` (`jsk_recognition_msgs/ModelCoefficientsArray`):
 
-   The input planes. If `~use_indices` parameter is false, `~indices` will not be used.
+   The input planes.
+   If `~use_indices` parameter is false, `~indices` is be used.
+   If `~use_coefficients` parameter is false, `~coefficients` is not used. (Instead `~use_sensor_frame` should be enabled in order to determine normal direction of planes.)
 
 ## Publishing Topics
 * `~output` (`sensor_msgs/PointCloud2`):
@@ -46,10 +48,30 @@ Extract the points above the planes between `~min_height` and `~max_height`.
    Magnify planes by this parameter. The unit is m.
 * `~use_async` (Boolean, default: `False`)
 
-  Approximate sync input topics.
+   Approximate sync input topics.
+* `~use_coefficients` (Bool, default: `False`)
+
+   Use coefficients topic to determine viewpoint.
+   For avoiding plane flipping, either this parameter or `~use_sensor_frame` should be enabled.
 * `~use_sensor_frame` (Boolean, default: `False`)
 
-  Use sensor viewpoint
+   Set viewpoint as a TF sensor frame.
+   If this parameter is enabled, `~use_coefficients` is ignored and handled as `false`.
 * `~sensor_frame` (String, default: `head_root`)
 
-  Specify frame\_id of sensor origin.
+   Specify frame\_id of sensor origin.
+   This parameter is enabled only when `~use_sensor_frame` is enabled.
+
+## Issues
+
+- Normal direction of planes
+
+  Normal directions of each planes are computed as followings:
+
+  |                         | use_sensor_frame: false            | use_sensor_frame: true                 |
+  |-------------------------|------------------------------------|----------------------------------------|
+  | use_coefficients: false | PCL computes z-axis internally (it occurs flipping. warning shows up)   | Determine z-axis direction to TF frame |
+  | use_coefficients: true  | Determine z-axis from coefficients topic | N/A (This condition is invalid. ~use_coefficients is disabled in this case. Also warning shows up)                 |
+  
+  Both `~use_sensor_frame` and `~use_coefficients` is disabled by default, which means the normal directions are computed individually on every callback and can be flipped on the continuous time domain.
+  Generally it's better to set either `~use_sensor_frame` or `~use_coefficients` as `true` for stable detection.


### PR DESCRIPTION
Addresses #2186 

If `~use_sensor_frame` is false, the z-axis of plane may be flipped on each detection and coefficients topic is never used.
I added a new option `~use_coefficients` that determines z-axis of each planes.

**NOTE** Visualization of normal arrow in rviz is not valid. (To see actual z normal axis, we must consider both polygon and coefficients)

![extraction_falure](https://user-images.githubusercontent.com/1901008/29239209-12751dbe-7f84-11e7-84e4-8dbb7aa1f236.png)

![extraction_success](https://user-images.githubusercontent.com/1901008/29239227-86eae0d4-7f84-11e7-92ed-4ec4bc539c1e.png)
