### PR TITLE
Add docker image of ros-indigo-base-jsk-recognition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ env:
     - USE_JENKINS=true
     - USE_DEB=true
   matrix:
-    - ROS_DISTRO=indigo
-    - ROS_DISTRO=indigo CATKIN_TOOLS_CONFIG_OPTIONS="--install" TEST_PKGS='jsk_recognition_msgs' # to skip test
-    - ROS_DISTRO=indigo ROS_REPOSITORY_PATH="http://packages.ros.org/ros/ubuntu"
-    - ROS_DISTRO=indigo BEFORE_SCRIPT='$CI_SOURCE_PATH/.travis_before_script_opencv3.bash' BUILD_PKGS='checkerboard_detector imagesift jsk_perception jsk_recognition_utils resized_image_transport'
-    - ROS_DISTRO=indigo BEFORE_SCRIPT='$CI_SOURCE_PATH/.travis_before_script_pcl1.8.bash' BUILD_PKGS='jsk_pcl_ros_utils jsk_pcl_ros' DOCKER_IMAGE_JENKINS='ros-indigo-pcl1.8'
+    - ROS_DISTRO=indigo DOCKER_IMAGE_JENKINS='ros-indigo-base-jsk-recognition'
+    - ROS_DISTRO=indigo DOCKER_IMAGE_JENKINS='ros-indigo-base-jsk-recognition' CATKIN_TOOLS_CONFIG_OPTIONS="--install" TEST_PKGS='jsk_recognition_msgs' # to skip test
+    - ROS_DISTRO=indigo DOCKER_IMAGE_JENKINS='ros-indigo-base-jsk-recognition' ROS_REPOSITORY_PATH="http://packages.ros.org/ros/ubuntu"
+    - ROS_DISTRO=indigo DOCKER_IMAGE_JENKINS='ros-indigo-base-jsk-recognition' BEFORE_SCRIPT='$CI_SOURCE_PATH/.travis_before_script_opencv3.bash' BUILD_PKGS='checkerboard_detector imagesift jsk_perception jsk_recognition_utils resized_image_transport'
+    - ROS_DISTRO=indigo DOCKER_IMAGE_JENKINS='ros-indigo-pcl1.8-jsk-recognition' BEFORE_SCRIPT='$CI_SOURCE_PATH/.travis_before_script_pcl1.8.bash' BUILD_PKGS='jsk_pcl_ros_utils jsk_pcl_ros' DOCKER_IMAGE_JENKINS='ros-indigo-pcl1.8'
     - ROS_DISTRO=kinetic
 script:
   - source .travis/travis.sh

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -2,6 +2,10 @@
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# ros-indigo-pcl1.8
-(cd ${DIR}/ros/indigo/pcl1.8 && sudo docker build -t ros-indigo-pcl1.8 .)
-(echo -e "FROM ros-indigo-pcl1.8\nRUN apt-get update\nRUN apt-get -y upgrade\nEXPOSE 22" | sudo docker build -t ros-indigo-pcl1.8 -)
+set -x
+
+(cd ${DIR}/ros/indigo/base && sudo docker build --no-cache -t ros-indigo-base-jsk-recognition .)
+
+(cd ${DIR}/ros/indigo/pcl1.8 && sudo docker build --no-cache -t ros-indigo-pcl1.8-jsk-recognition .)
+
+set +x

--- a/docker/ros/indigo/base/Dockerfile
+++ b/docker/ros/indigo/base/Dockerfile
@@ -3,6 +3,7 @@ FROM ros:indigo-ros-core
 RUN apt-get update && apt-get install -y \
     ccache \
     git \
+    wget \
     python-setuptools \
     python-rosdep \
     python-wstool
@@ -22,7 +23,7 @@ RUN mkdir -p ~/ros/ws_jsk_recognition/src && \
 
 RUN cd ~/ros/ws_jsk_recognition/src && \
     rosdep update && \
-    rosdep install --from-path . -y -i -r
+    wget http://raw.github.com/jsk-ros-pkg/jsk_travis/master/rosdep-install.sh -O - | bash
 
 RUN cd ~/ros/ws_jsk_recognition && \
     apt-get install -y python-catkin-tools && \

--- a/docker/ros/indigo/base/Dockerfile
+++ b/docker/ros/indigo/base/Dockerfile
@@ -1,0 +1,28 @@
+FROM ros:indigo-ros-core
+
+RUN apt-get update && apt-get install -y \
+    git \
+    python-setuptools \
+    python-rosdep \
+    python-wstool
+
+RUN easy_install -U pip && \
+    pip install -U pip setuptools
+
+RUN mkdir -p ~/ros/ws_jsk_recognition/src && \
+    cd ~/ros/ws_jsk_recognition/src && \
+    wstool init; \
+    wstool set jsk-ros-pkg/jsk_recognition https://github.com/jsk-ros-pkg/jsk_recognition.git -v master --git -y && \
+    wstool up  && \
+    wstool merge -y jsk-ros-pkg/jsk_recognition/.travis.rosinstall; \
+    wstool up -j -1
+
+RUN cd ~/ros/ws_jsk_recognition/src && \
+    rosdep update && \
+    rosdep install --from-path . -y -i
+
+RUN cd ~/ros/ws_jsk_recognition && \
+    apt-get install -y python-catkin-tools && \
+    . /opt/ros/indigo/setup.sh && \
+    catkin build && \
+    catkin clean -y

--- a/docker/ros/indigo/base/Dockerfile
+++ b/docker/ros/indigo/base/Dockerfile
@@ -28,6 +28,6 @@ RUN cd ~/ros/ws_jsk_recognition && \
     apt-get install -y python-catkin-tools && \
     . /opt/ros/indigo/setup.sh && \
     export PATH=/usr/lib/ccache:$PATH && \
-    catkin build && \
+    catkin build -c && \
     cd && \
     rm -rf ros/ws_jsk_recognition

--- a/docker/ros/indigo/base/Dockerfile
+++ b/docker/ros/indigo/base/Dockerfile
@@ -22,7 +22,7 @@ RUN mkdir -p ~/ros/ws_jsk_recognition/src && \
 
 RUN cd ~/ros/ws_jsk_recognition/src && \
     rosdep update && \
-    rosdep install --from-path . -y -i
+    rosdep install --from-path . -y -i -r
 
 RUN cd ~/ros/ws_jsk_recognition && \
     apt-get install -y python-catkin-tools && \

--- a/docker/ros/indigo/base/Dockerfile
+++ b/docker/ros/indigo/base/Dockerfile
@@ -9,9 +9,11 @@ RUN apt-get update && apt-get install -y \
     python-wstool
 
 RUN ccache -M 10G
+ENV PATH /usr/lib/ccache:$PATH
 
-RUN easy_install -U pip && \
-    pip install -U pip setuptools
+# pip==7.1.2 is necessary to reinstall python modules by rosdep
+# https://github.com/pypa/pip/issues/3384
+RUN easy_install pip==7.1.2
 
 RUN mkdir -p ~/ros/ws_jsk_recognition/src && \
     cd ~/ros/ws_jsk_recognition/src && \
@@ -21,6 +23,13 @@ RUN mkdir -p ~/ros/ws_jsk_recognition/src && \
     wstool merge -y jsk-ros-pkg/jsk_recognition/.travis.rosinstall; \
     wstool up -j -1
 
+# for pip install numpy matplotlib pillow
+RUN apt-get install -y build-essential pkg-config && \
+    apt-get install -y liblapack-dev gfortran && \
+    apt-get install -y libtiff5-dev libpng12-dev libjpeg8-dev zlib1g-dev \
+      libfreetype6-dev liblcms2-dev libwebp-dev libharfbuzz-dev libfribidi-dev \
+      tcl8.6-dev tk8.6-dev python-tk
+
 RUN cd ~/ros/ws_jsk_recognition/src && \
     rosdep update && \
     wget http://raw.github.com/jsk-ros-pkg/jsk_travis/master/rosdep-install.sh -O - | bash
@@ -28,7 +37,6 @@ RUN cd ~/ros/ws_jsk_recognition/src && \
 RUN cd ~/ros/ws_jsk_recognition && \
     apt-get install -y python-catkin-tools && \
     . /opt/ros/indigo/setup.sh && \
-    export PATH=/usr/lib/ccache:$PATH && \
     catkin build -c && \
     cd && \
-    rm -rf ros/ws_jsk_recognition
+    rm -rf ~/ros

--- a/docker/ros/indigo/base/Dockerfile
+++ b/docker/ros/indigo/base/Dockerfile
@@ -1,10 +1,13 @@
 FROM ros:indigo-ros-core
 
 RUN apt-get update && apt-get install -y \
+    ccache \
     git \
     python-setuptools \
     python-rosdep \
     python-wstool
+
+RUN ccache -M 10G
 
 RUN easy_install -U pip && \
     pip install -U pip setuptools
@@ -24,5 +27,7 @@ RUN cd ~/ros/ws_jsk_recognition/src && \
 RUN cd ~/ros/ws_jsk_recognition && \
     apt-get install -y python-catkin-tools && \
     . /opt/ros/indigo/setup.sh && \
+    export PATH=/usr/lib/ccache:$PATH && \
     catkin build && \
-    catkin clean -y
+    cd && \
+    rm -rf ros/ws_jsk_recognition

--- a/docker/ros/indigo/base/Dockerfile
+++ b/docker/ros/indigo/base/Dockerfile
@@ -11,9 +11,12 @@ RUN apt-get update && apt-get install -y \
 RUN ccache -M 10G
 ENV PATH /usr/lib/ccache:$PATH
 
-# pip==7.1.2 is necessary to reinstall python modules by rosdep
-# https://github.com/pypa/pip/issues/3384
-RUN easy_install pip==7.1.2
+# Install pip
+# pip>=10 no longer uninstalls distutils packages (ex. packages installed via apt),
+# and fails to install packages via pip if they are already installed via apt.
+# See https://github.com/pypa/pip/issues/4805 for detail.
+RUN curl https://bootstrap.pypa.io/get-pip.py | python - \
+    pip install 'pip<10'
 
 RUN mkdir -p ~/ros/ws_jsk_recognition/src && \
     cd ~/ros/ws_jsk_recognition/src && \

--- a/docker/ros/indigo/pcl1.8/Dockerfile
+++ b/docker/ros/indigo/pcl1.8/Dockerfile
@@ -36,9 +36,8 @@ RUN cd ~/ros/ws_jsk_recognition/src && \
     rosdep install --from-path . -y -i -r
 
 RUN cd ~/ros/ws_jsk_recognition && \
-    apt-get install -y python-catkin-tools && \
     . /opt/ros/indigo/setup.sh && \
     export PATH=/usr/lib/ccache:$PATH && \
-    catkin build && \
+    catkin build -c && \
     cd && \
     rm -rf ros/ws_jsk_recognition

--- a/docker/ros/indigo/pcl1.8/Dockerfile
+++ b/docker/ros/indigo/pcl1.8/Dockerfile
@@ -36,7 +36,6 @@ RUN cd ~/ros/ws_jsk_recognition/src && \
 
 RUN cd ~/ros/ws_jsk_recognition && \
     . /opt/ros/indigo/setup.sh && \
-    export PATH=/usr/lib/ccache:$PATH && \
     catkin build -c && \
     cd && \
     rm -rf ros/ws_jsk_recognition

--- a/docker/ros/indigo/pcl1.8/Dockerfile
+++ b/docker/ros/indigo/pcl1.8/Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir -p ~/ros/ws_jsk_recognition/src && \
 
 RUN cd ~/ros/ws_jsk_recognition/src && \
     rosdep update && \
-    rosdep install --from-path . -y -i
+    rosdep install --from-path . -y -i -r
 
 RUN cd ~/ros/ws_jsk_recognition && \
     apt-get install -y python-catkin-tools && \

--- a/docker/ros/indigo/pcl1.8/Dockerfile
+++ b/docker/ros/indigo/pcl1.8/Dockerfile
@@ -1,4 +1,4 @@
-FROM ros:indigo-ros-core
+FROM ros-indigo-base-jsk-recognition
 
 RUN apt-get update && apt-get install -y \
     wget \
@@ -21,12 +21,14 @@ RUN cd ~/pcl-pcl-1.8.0rc2 && \
 
 RUN mkdir -p ~/ros/ws_jsk_recognition/src && \
     cd ~/ros/ws_jsk_recognition/src && \
-    apt-get install -y python-rosinstall-generator python-wstool && \
+    apt-get install -y python-rosinstall-generator && \
+    wstool init; \
     rosinstall_generator --tar --rosdistro indigo \
         pcl_conversions \
         pcl_ros \
         octomap_server \
-        > .rosinstall && \
+        > $$.rosinstall && \
+    wstool merge -y $$.rosinstall && \
     wstool up -j -1
 
 RUN cd ~/ros/ws_jsk_recognition/src && \
@@ -36,8 +38,5 @@ RUN cd ~/ros/ws_jsk_recognition/src && \
 RUN cd ~/ros/ws_jsk_recognition && \
     apt-get install -y python-catkin-tools && \
     . /opt/ros/indigo/setup.sh && \
-    catkin build
-
-RUN apt-get update && apt-get install -y python-setuptools
-RUN easy_install 'pip==6.0.7'
-RUN pip install -U dlib
+    catkin build && \
+    catkin clean -y

--- a/docker/ros/indigo/pcl1.8/Dockerfile
+++ b/docker/ros/indigo/pcl1.8/Dockerfile
@@ -38,5 +38,7 @@ RUN cd ~/ros/ws_jsk_recognition/src && \
 RUN cd ~/ros/ws_jsk_recognition && \
     apt-get install -y python-catkin-tools && \
     . /opt/ros/indigo/setup.sh && \
+    export PATH=/usr/lib/ccache:$PATH && \
     catkin build && \
-    catkin clean -y
+    cd && \
+    rm -rf ros/ws_jsk_recognition

--- a/docker/ros/indigo/pcl1.8/Dockerfile
+++ b/docker/ros/indigo/pcl1.8/Dockerfile
@@ -1,7 +1,6 @@
 FROM ros-indigo-base-jsk-recognition
 
 RUN apt-get update && apt-get install -y \
-    wget \
     libboost-all-dev \
     libeigen3-dev \
     libflann-dev \
@@ -33,7 +32,7 @@ RUN mkdir -p ~/ros/ws_jsk_recognition/src && \
 
 RUN cd ~/ros/ws_jsk_recognition/src && \
     rosdep update && \
-    rosdep install --from-path . -y -i -r
+    wget http://raw.github.com/jsk-ros-pkg/jsk_travis/master/rosdep-install.sh -O - | bash
 
 RUN cd ~/ros/ws_jsk_recognition && \
     . /opt/ros/indigo/setup.sh && \


### PR DESCRIPTION
## Why?

- For faster CI testing.
- To test it *corretly* (currently we use closed dockerfile).