### PR TITLE
fix checkerboard_detector

### DIFF
--- a/checkerboard_detector/CMakeLists.txt
+++ b/checkerboard_detector/CMakeLists.txt
@@ -5,6 +5,7 @@ project(checkerboard_detector)
 find_package(catkin REQUIRED COMPONENTS roscpp rosconsole dynamic_reconfigure cv_bridge sensor_msgs image_geometry
   posedetection_msgs eigen_conversions message_filters tf tf2 jsk_recognition_msgs jsk_recognition_msgs
 )
+find_package(OpenCV REQUIRED)
 find_package(OpenMP)
 find_package(posedetection_msgs)
 
@@ -12,7 +13,7 @@ generate_dynamic_reconfigure_options(cfg/CheckerboardDetector.cfg)
 
 catkin_package(
     CATKIN_DEPENDS roscpp rosconsole cv_bridge sensor_msgs posedetection_msgs image_geometry jsk_recognition_msgs
-    DEPENDS
+    DEPENDS OpenCV
     INCLUDE_DIRS # TODO include
     LIBRARIES # TODO
 )
@@ -22,7 +23,7 @@ if (OPENMP_FOUND)
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 endif()
 
-include_directories(SYSTEM ${catkin_INCLUDE_DIRS})
+include_directories(SYSTEM ${OpenCV_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 
 #set the default path for built executables to the "bin" directory
 # set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
@@ -30,11 +31,11 @@ include_directories(SYSTEM ${catkin_INCLUDE_DIRS})
 # set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
 
 add_executable(checkerboard_detector src/checkerboard_detector.cpp)
-target_link_libraries(checkerboard_detector ${catkin_LIBRARIES})
+target_link_libraries(checkerboard_detector ${OpenCV_LIBRARIES} ${catkin_LIBRARIES})
 add_executable(objectdetection_transform_echo src/objectdetection_transform_echo.cpp)
 target_link_libraries(objectdetection_transform_echo ${catkin_LIBRARIES})
 add_executable(checkerboard_calibration src/checkerboard_calibration.cpp)
-target_link_libraries(checkerboard_calibration ${catkin_LIBRARIES})
+target_link_libraries(checkerboard_calibration ${OpenCV_LIBRARIES} ${catkin_LIBRARIES})
 add_dependencies(checkerboard_detector    posedetection_msgs_gencpp)
 add_dependencies(checkerboard_calibration posedetection_msgs_gencpp)
 add_dependencies(objectdetection_transform_echo posedetection_msgs_gencpp)


### PR DESCRIPTION
@k-okada 
Checkerboard_detector and checkerboard_calibration are released with using opencv3.2.
So, checkerboard_detector could not be used in ros kinetic.
This PR add 
find_package(OpenCV REQUIRED) 
and resolve the bug. Thanks @wkentaro .

We think the released deb should be fixed.


Checkerboard_detector is fixed with this PR
![checker-board](https://user-images.githubusercontent.com/6872136/29820910-09b8f4ae-8d01-11e7-8047-cc7e361c6287.png)


error message
```
pazeshun@pazeshun-ThinkPad-T440p:/opt/ros/kinetic$ roslaunch roseus_tutorials checkerboard-detector.launch 
... logging to /home/pazeshun/.ros/log/561b196a-8c86-11e7-8854-e8b1fce891e4/roslaunch-pazeshun-ThinkPad-T440p-12343.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

started roslaunch server http://192.168.97.72:42939/

SUMMARY
========

PARAMETERS
 * /display: 1
 * /frame_id: camera
 * /grid0_size_x: 7
 * /grid0_size_y: 5
 * /rect0_size_x: 0.03
 * /rect0_size_y: 0.03
 * /rosdistro: kineticgrid0_size_x:=5 grid0_size_y:=4 translation0:="0 0 0"
 * /rosversion: 1.12.6
 * /rotation0: 1.0 0.0 0.0 0.0 -...
 * /single: 1
 * /translation0: 0.060 0.090 0
 * /type0: test_object

NODES
  /
    checkerboard_detector (checkerboard_detector/checkerboard_detector)

WARNING: unrecognized tag sphinxdoc
ROS_MASTER_URI=http://localhost:11311

core service [/rosout] found
/opt/ros/kinetic/lib/checkerboard_detector/checkerboard_detector: error while loading shared libraries: libopencv_calib3d3.so.3.2: cannot open shared object file: No such file or directory
process[checkerboard_detector-1]: started with pid [12361]
[checkerboard_detector-1] process has died [pid 12361, exit code 127, cmd /opt/ros/kinetic/lib/checkerboard_detector/checkerboard_detector image:=image_rect __name:=checkerboard_detector __log:=/home/pazeshun/.ros/log/561b196a-8c86-11e7-8854-e8b1fce891e4/checkerboard_detector-1.log].
log file: /home/pazeshun/.ros/log/561b196a-8c86-11e7-8854-e8b1fce891e4/checkerboard_detector-1*.log
all processes on machine have died, roslaunch will exit
shutting down processing monitor...
... shutting down processing monitor complete
done
```


Opencv3.2 is used only for checkerboard_detector and checkerboard_calibration although other pkgs use opencv3.1.
```
pazeshun@pazeshun-ThinkPad-T440p:/opt/ros/kinetic/lib$ grep -ir "libopencv_calib3d3.so.3.2"
バイナリファイル libar_track_alvar.so に一致しました
バイナリファイル checkerboard_detector/checkerboard_detector に一致しました
バイナリファイル checkerboard_detector/checkerboard_calibration に一致しました
```


