### PR TITLE
jsk_perception: people_pose_estimation_2d.py: unsynchronize camera info

### DIFF
--- a/doc/jsk_perception/nodes/people_pose_estimation_2d.rst
+++ b/doc/jsk_perception/nodes/people_pose_estimation_2d.rst
@@ -78,9 +78,13 @@ Parameters
 
   Trained model file.
 
-* ``with_depth`` (Bool, Default: ``False``)
+* ``~with_depth`` (Bool, Default: ``False``)
 
   If true, subscribe ``~input/depth`` and ``~input/info``.
+
+* ``~sync_camera_info`` (Bool, Default: ``False``)
+
+  Synchronize ``~input/info`` if enabled, otherwise the last received camera info message is used.
 
 * ``~approximate_sync`` (Bool, Default: ``True``)
 

--- a/jsk_perception/node_scripts/people_pose_estimation_2d.py
+++ b/jsk_perception/node_scripts/people_pose_estimation_2d.py
@@ -100,6 +100,7 @@ class PeoplePoseEstimation2D(ConnectionBasedTransport):
         self._load_model()
         self.image_pub = self.advertise('~output', Image, queue_size=1)
         self.pose_pub = self.advertise('~pose', PeoplePoseArray, queue_size=1)
+        self.sub_info = None
         if self.with_depth is True:
             self.pose_2d_pub = self.advertise('~pose_2d', PeoplePoseArray, queue_size=1)
 
@@ -127,9 +128,19 @@ class PeoplePoseEstimation2D(ConnectionBasedTransport):
                 '~input', Image, queue_size=1, buff_size=2**24)
             sub_depth = message_filters.Subscriber(
                 '~input/depth', Image, queue_size=1, buff_size=2**24)
-            sub_info = message_filters.Subscriber(
-                '~input/info', CameraInfo, queue_size=1, buff_size=2**24)
-            self.subs = [sub_img, sub_depth, sub_info]
+            self.subs = [sub_img, sub_depth]
+
+            # NOTE: Camera info is not synchronized by default.
+            # See https://github.com/jsk-ros-pkg/jsk_recognition/issues/2165
+            sync_cam_info = rospy.get_param("~sync_camera_info", False)
+            if sync_cam_info:
+                sub_info = message_filters.Subscriber(
+                    '~input/info', CameraInfo, queue_size=1, buff_size=2**24)
+                self.subs.append(sub_info)
+            else:
+                self.sub_info = rospy.Subscriber(
+                    '~input/info', CameraInfo, self._cb_cam_info)
+
             if rospy.get_param('~approximate_sync', True):
                 slop = rospy.get_param('~slop', 0.1)
                 sync = message_filters.ApproximateTimeSynchronizer(
@@ -137,7 +148,10 @@ class PeoplePoseEstimation2D(ConnectionBasedTransport):
             else:
                 sync = message_filters.TimeSynchronizer(
                     fs=self.subs, queue_size=queue_size)
-            sync.registerCallback(self._cb_with_depth)
+            if sync_cam_info:
+                sync.registerCallback(self._cb_with_depth_info)
+            else:
+                sync.registerCallback(self._cb_with_depth)
         else:
             sub_img = rospy.Subscriber(
                 '~input', Image, self._cb, queue_size=1, buff_size=2**24)
@@ -146,8 +160,22 @@ class PeoplePoseEstimation2D(ConnectionBasedTransport):
     def unsubscribe(self):
         for sub in self.subs:
             sub.unregister()
+        if self.sub_info is not None:
+            self.sub_info.unregister()
+            self.sub_info = None
 
-    def _cb_with_depth(self, img_msg, depth_msg, camera_info_msg):
+    def _cb_cam_info(self, msg):
+        self.camera_info_msg = msg
+        self.sub_info.unregister()
+        self.sub_info = None
+        rospy.loginfo("Received camera info")
+
+    def _cb_with_depth(self, img_msg, depth_msg):
+        if self.camera_info_msg is None:
+            return
+        self._cb_with_depth_info(img_msg, depth_msg, self.camera_info_msg)
+
+    def _cb_with_depth_info(self, img_msg, depth_msg, camera_info_msg):
         br = cv_bridge.CvBridge()
         img = br.imgmsg_to_cv2(img_msg, desired_encoding='bgr8')
         depth_img = br.imgmsg_to_cv2(depth_msg, 'passthrough')


### PR DESCRIPTION
This pull request disables synchronization of camera info with images and let the node use it only once instead.
Fixes #2165 