### PR TITLE
jsk_pcl_ros_utils: add depth image for input to pointcloud_to_mask_image

### DIFF
--- a/doc/jsk_pcl_ros_utils/nodes/pointcloud_to_mask_image.rst
+++ b/doc/jsk_pcl_ros_utils/nodes/pointcloud_to_mask_image.rst
@@ -1,6 +1,7 @@
 PointCloudToMaskImage
 =====================
 
+![pointcloud_to_mask_image](https://user-images.githubusercontent.com/1901008/34367264-aaa28e1e-eaeb-11e7-8699-c5e17dec71e8.gif)
 
 What is this?
 -------------
@@ -18,6 +19,10 @@ Subscribing Topic
 
   Input pointcloud
 
+  * `~input/depth` (`sensor_msgs/Image`)
+
+  Input depth image
+
 
 Publishing Topic
 ----------------
@@ -25,3 +30,14 @@ Publishing Topic
 * `~output` (`sensor_msgs/Image`)
 
   Output mask image.
+
+Parameters
+----------
+
+* `~z_near` (`Double`, default: `0.0`)
+
+  Lower limit of depth to be projected to mask image for each pixel (meter)
+
+* `~z_far~ (`Double`, default: `10.0`)
+
+  Upper limit of depth to be projected to mask image for each pixel (meter)

--- a/jsk_pcl_ros_utils/CMakeLists.txt
+++ b/jsk_pcl_ros_utils/CMakeLists.txt
@@ -79,6 +79,7 @@ generate_dynamic_reconfigure_options(
   cfg/PlaneConcatenator.cfg
   cfg/PlaneReasoner.cfg
   cfg/PlaneRejector.cfg
+  cfg/PointCloudToMaskImage.cfg
   cfg/PointCloudToPCD.cfg
   cfg/PolygonArrayAreaLikelihood.cfg
   cfg/PolygonArrayLikelihoodFilter.cfg

--- a/jsk_pcl_ros_utils/cfg/PointCloudToMaskImage.cfg
+++ b/jsk_pcl_ros_utils/cfg/PointCloudToMaskImage.cfg
@@ -1,0 +1,13 @@
+#! /usr/bin/env python
+
+PACKAGE='jsk_pcl_ros_utils'
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+#       name    type     level     description     default      min      max
+gen.add("z_near", double_t, 0, "Near", 0.0, 0.0, 10.0)
+gen.add("z_far", double_t, 0, "Far", 10.0, 0.0, 10.0)
+
+exit(gen.generate(PACKAGE, "jsk_pcl_ros_utils", "PointCloudToMaskImage"))

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pointcloud_to_mask_image.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pointcloud_to_mask_image.h
@@ -37,14 +37,21 @@
 #ifndef JSK_PCL_ROS_UTILS_POINTCLOUD_TO_MASK_IMAGE_H_
 #define JSK_PCL_ROS_UTILS_POINTCLOUD_TO_MASK_IMAGE_H_
 
+#include <boost/shared_ptr.hpp>
+
+#include <dynamic_reconfigure/server.h>
 #include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <sensor_msgs/Image.h>
 #include <sensor_msgs/PointCloud2.h>
+
+#include <jsk_pcl_ros_utils/PointCloudToMaskImageConfig.h>
 
 namespace jsk_pcl_ros_utils
 {
   class PointCloudToMaskImage: public jsk_topic_tools::DiagnosticNodelet
   {
   public:
+    typedef PointCloudToMaskImageConfig Config;
     PointCloudToMaskImage(): DiagnosticNodelet("PointCloudToMaskImage") { }
   protected:
     ////////////////////////////////////////////////////////
@@ -54,12 +61,18 @@ namespace jsk_pcl_ros_utils
     virtual void subscribe();
     virtual void unsubscribe();
     virtual void updateDiagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat);
+    virtual void configCallback(Config &config, uint32_t level);
+    virtual void convert(const sensor_msgs::Image::ConstPtr& image_msg);
     virtual void convert(const sensor_msgs::PointCloud2::ConstPtr& cloud_msg);
 
     ////////////////////////////////////////////////////////
     // ROS variables
     ////////////////////////////////////////////////////////
-    ros::Subscriber sub_;
+    float z_near_, z_far_;
+    boost::mutex mutex_;
+    boost::shared_ptr<dynamic_reconfigure::Server<Config> > srv_;
+    ros::Subscriber sub_cloud_;
+    ros::Subscriber sub_image_;
     ros::Publisher pub_;
   private:
 

--- a/jsk_pcl_ros_utils/sample/config/sample_pointcloud_to_mask_image.perspective
+++ b/jsk_pcl_ros_utils/sample/config/sample_pointcloud_to_mask_image.perspective
@@ -1,0 +1,217 @@
+{
+  "keys": {},
+  "groups": {
+    "pluginmanager": {
+      "keys": {
+        "running-plugins": {
+          "type": "repr",
+          "repr": "{u'rqt_image_view/ImageView': [3, 2, 1]}"
+        }
+      },
+      "groups": {
+        "plugin__rqt_image_view__ImageView__2": {
+          "keys": {},
+          "groups": {
+            "dock_widget__ImageViewWidget": {
+              "keys": {
+                "dockable": {
+                  "type": "repr",
+                  "repr": "True"
+                },
+                "parent": {
+                  "type": "repr",
+                  "repr": "None"
+                },
+                "dock_widget_title": {
+                  "type": "repr",
+                  "repr": "u'Image View (2)'"
+                }
+              },
+              "groups": {}
+            },
+            "plugin": {
+              "keys": {
+                "max_range": {
+                  "type": "repr",
+                  "repr": "10.0"
+                },
+                "mouse_pub_topic": {
+                  "type": "repr",
+                  "repr": "u'/pointcloud_to_mask_image/output_mouse_left'"
+                },
+                "num_gridlines": {
+                  "type": "repr",
+                  "repr": "0"
+                },
+                "toolbar_hidden": {
+                  "type": "repr",
+                  "repr": "False"
+                },
+                "zoom1": {
+                  "type": "repr",
+                  "repr": "False"
+                },
+                "dynamic_range": {
+                  "type": "repr",
+                  "repr": "False"
+                },
+                "topic": {
+                  "type": "repr",
+                  "repr": "u'/pointcloud_to_mask_image/output'"
+                },
+                "publish_click_location": {
+                  "type": "repr",
+                  "repr": "False"
+                }
+              },
+              "groups": {}
+            }
+          }
+        },
+        "plugin__rqt_image_view__ImageView__3": {
+          "keys": {},
+          "groups": {
+            "dock_widget__ImageViewWidget": {
+              "keys": {
+                "dockable": {
+                  "type": "repr",
+                  "repr": "True"
+                },
+                "parent": {
+                  "type": "repr",
+                  "repr": "None"
+                },
+                "dock_widget_title": {
+                  "type": "repr",
+                  "repr": "u'Image View (3)'"
+                }
+              },
+              "groups": {}
+            },
+            "plugin": {
+              "keys": {
+                "max_range": {
+                  "type": "repr",
+                  "repr": "10.0"
+                },
+                "mouse_pub_topic": {
+                  "type": "repr",
+                  "repr": "u'/depth_to_mask_image/output_mouse_left'"
+                },
+                "num_gridlines": {
+                  "type": "repr",
+                  "repr": "0"
+                },
+                "toolbar_hidden": {
+                  "type": "repr",
+                  "repr": "False"
+                },
+                "zoom1": {
+                  "type": "repr",
+                  "repr": "False"
+                },
+                "dynamic_range": {
+                  "type": "repr",
+                  "repr": "False"
+                },
+                "topic": {
+                  "type": "repr",
+                  "repr": "u'/depth_to_mask_image/output'"
+                },
+                "publish_click_location": {
+                  "type": "repr",
+                  "repr": "False"
+                }
+              },
+              "groups": {}
+            }
+          }
+        },
+        "plugin__rqt_image_view__ImageView__1": {
+          "keys": {},
+          "groups": {
+            "dock_widget__ImageViewWidget": {
+              "keys": {
+                "dockable": {
+                  "type": "repr",
+                  "repr": "True"
+                },
+                "parent": {
+                  "type": "repr",
+                  "repr": "None"
+                },
+                "dock_widget_title": {
+                  "type": "repr",
+                  "repr": "u'Image View'"
+                }
+              },
+              "groups": {}
+            },
+            "plugin": {
+              "keys": {
+                "max_range": {
+                  "type": "repr",
+                  "repr": "2.0"
+                },
+                "mouse_pub_topic": {
+                  "type": "repr",
+                  "repr": "u'/right_hand_camera/depth_registered/hw_registered/image_rect_mouse_left'"
+                },
+                "num_gridlines": {
+                  "type": "repr",
+                  "repr": "0"
+                },
+                "toolbar_hidden": {
+                  "type": "repr",
+                  "repr": "False"
+                },
+                "zoom1": {
+                  "type": "repr",
+                  "repr": "False"
+                },
+                "dynamic_range": {
+                  "type": "repr",
+                  "repr": "False"
+                },
+                "topic": {
+                  "type": "repr",
+                  "repr": "u'/right_hand_camera/depth_registered/hw_registered/image_rect'"
+                },
+                "publish_click_location": {
+                  "type": "repr",
+                  "repr": "False"
+                }
+              },
+              "groups": {}
+            }
+          }
+        }
+      }
+    },
+    "mainwindow": {
+      "keys": {
+        "geometry": {
+          "type": "repr(QByteArray.hex)",
+          "repr(QByteArray.hex)": "QtCore.QByteArray('01d9d0cb000200000000087e0000030000000edc0000050e0000087f0000031c00000edb0000050d00000000000000000f00')",
+          "pretty-print": "     ~                   "
+        },
+        "state": {
+          "type": "repr(QByteArray.hex)",
+          "repr(QByteArray.hex)": "QtCore.QByteArray('000000ff00000000fd00000001000000030000065d000001d9fc0100000003fb0000005a007200710074005f0069006d006100670065005f0076006900650077005f005f0049006d0061006700650056006900650077005f005f0031005f005f0049006d006100670065005600690065007700570069006400670065007401000000000000021a000000bc00fffffffb0000005a007200710074005f0069006d006100670065005f0076006900650077005f005f0049006d0061006700650056006900650077005f005f0032005f005f0049006d006100670065005600690065007700570069006400670065007401000002200000021a000000cf00fffffffb0000005a007200710074005f0069006d006100670065005f0076006900650077005f005f0049006d0061006700650056006900650077005f005f0033005f005f0049006d006100670065005600690065007700570069006400670065007401000004400000021d0000018e00ffffff0000065d0000000000000004000000040000000800000008fc00000001000000030000000100000036004d0069006e0069006d0069007a006500640044006f0063006b00570069006400670065007400730054006f006f006c0062006100720000000000ffffffff0000000000000000')",
+          "pretty-print": "                 Zrqt_image_view__ImageView__1__ImageViewWidget          Zrqt_image_view__ImageView__2__ImageViewWidget          Zrqt_image_view__ImageView__3__ImageViewWidget                            6MinimizedDockWidgetsToolbar        "
+        }
+      },
+      "groups": {
+        "toolbar_areas": {
+          "keys": {
+            "MinimizedDockWidgetsToolbar": {
+              "type": "repr",
+              "repr": "8"
+            }
+          },
+          "groups": {}
+        }
+      }
+    }
+  }
+}

--- a/jsk_pcl_ros_utils/sample/sample_pointcloud_to_mask_image.launch
+++ b/jsk_pcl_ros_utils/sample/sample_pointcloud_to_mask_image.launch
@@ -2,20 +2,26 @@
 
   <arg name="gui" default="true" />
 
-  <include file="$(find jsk_pcl_ros_utils)/sample/include/play_rosbag_shelf_bin.xml" />
+  <arg name="INPUT_CLOUD" default="/right_hand_camera/depth_registered/points" />
+  <arg name="INPUT_DEPTH" default="/right_hand_camera/depth_registered/hw_registered/image_rect" />
 
-  <arg name="INPUT_CLOUD" value="/right_hand_camera/depth_registered/points" />
+  <include file="$(find jsk_pcl_ros_utils)/sample/include/play_rosbag_shelf_bin.xml" />
 
   <node name="pointcloud_to_mask_image"
         pkg="jsk_pcl_ros_utils" type="pointcloud_to_mask_image">
     <remap from="~input" to="$(arg INPUT_CLOUD)" />
   </node>
 
-  <group if="$(arg gui)">
-    <node name="image_view"
-          pkg="image_view" type="image_view">
-      <remap from="image" to="pointcloud_to_mask_image/output" />
-    </node>
-  </group>
+  <node name="depth_to_mask_image"
+        pkg="jsk_pcl_ros_utils" type="pointcloud_to_mask_image">
+    <remap from="~input/depth" to="$(arg INPUT_DEPTH)" />
+    <rosparam>
+      z_near: 0.5
+      z_far: 0.7
+    </rosparam>
+  </node>
 
+  <node if="$(arg gui)"
+        name="rqt_gui" pkg="rqt_gui" type="rqt_gui"
+        args="--perspective-file $(find jsk_pcl_ros_utils)/sample/config/sample_pointcloud_to_mask_image.perspective" />
 </launch>

--- a/jsk_pcl_ros_utils/test/pointcloud_to_mask_image.test
+++ b/jsk_pcl_ros_utils/test/pointcloud_to_mask_image.test
@@ -11,6 +11,8 @@
     <rosparam>
       topic_0: /pointcloud_to_mask_image/output
       timeout_0: 30
+      topic_1: /depth_to_mask_image/output
+      timeout_1: 30
     </rosparam>
   </test>
 


### PR DESCRIPTION
This pull request adds a nodelet for creating mask image in the range of specified depth from sensor.

![sample_depth_to_mask_image](https://user-images.githubusercontent.com/1901008/34367264-aaa28e1e-eaeb-11e7-8699-c5e17dec71e8.gif)


- [x] document
- [x] sample launch file
- [x] test code