### PR TITLE
Fix uninitialized pointer error in some recognition nodelets

### DIFF
--- a/jsk_pcl_ros/src/tilt_laser_listener_nodelet.cpp
+++ b/jsk_pcl_ros/src/tilt_laser_listener_nodelet.cpp
@@ -92,6 +92,10 @@ namespace jsk_pcl_ros
     }
     pnh_->param("not_use_laser_assembler_service", not_use_laser_assembler_service_, false);
     pnh_->param("use_laser_assembler", use_laser_assembler_, false);
+    double vital_rate;
+    pnh_->param("vital_rate", vital_rate, 1.0);
+    cloud_vital_checker_.reset(
+      new jsk_topic_tools::VitalChecker(1 / vital_rate));
     if (use_laser_assembler_) {
       if (not_use_laser_assembler_service_) {
         sub_cloud_
@@ -112,10 +116,6 @@ namespace jsk_pcl_ros
       "clear_cache", &TiltLaserListener::clearCacheCallback,
       this);
     trigger_pub_ = advertise<jsk_recognition_msgs::TimeRange>(*pnh_, "output", 1);
-    double vital_rate;
-    pnh_->param("vital_rate", vital_rate, 1.0);
-    cloud_vital_checker_.reset(
-      new jsk_topic_tools::VitalChecker(1 / vital_rate));
     if(subscribe_joint) {
       sub_ = pnh_->subscribe("input", max_queue_size_, &TiltLaserListener::jointCallback, this);
     }

--- a/resized_image_transport/src/image_processing_nodelet.cpp
+++ b/resized_image_transport/src/image_processing_nodelet.cpp
@@ -159,6 +159,12 @@ namespace resized_image_transport
   void ImageProcessing::updateDiagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat)
   {
     boost::mutex::scoped_lock lock(mutex_);
+    
+    if (!image_vital_ || !info_vital_) {
+      // initialization is not finished
+      return;
+    }
+    
     // common
     stat.add("use_camera_info", use_camera_info_);
     stat.add("use_snapshot", use_snapshot_);


### PR DESCRIPTION
Problem:
When a `jsk_topic_tools/standalone_complexed_nodelet` loaded `jsk_pcl/tilt_laser_listener` and `resized_image_transport/ImageResizer` in the situation where input point cloud and image topics are already published, it died with following error message.
```cpp
standalone_complexed_nodelet: /usr/include/boost/smart_ptr/shared_ptr.hpp:653: typename boost::detail::sp_member_access<T>::type boost::shared_ptr<T>::operator->() const [with T = jsk_topic_tools::VitalChecker; typename boost::detail::sp_member_access<T>::type = jsk_topic_tools::VitalChecker*]: Assertion `px != 0' failed.
```

Proposed solution:
This error seems to be caused by initialization order of the vital checker (the pointer for a vital checker is referred in a callback function before it is initialized).
This PR prevents the pointers of the vital checker from being referred before initialization has finished.

