### PR TITLE
jsk_pcl_ros/multi_plane_extraction: fix typo 'maginify'

### DIFF
--- a/jsk_pcl_ros/cfg/MultiPlaneExtraction.cfg
+++ b/jsk_pcl_ros/cfg/MultiPlaneExtraction.cfg
@@ -11,6 +11,7 @@ gen = ParameterGenerator ()
 
 gen.add("min_height", double_t, 0, "the minimum height of the prism craeted by the planes", 0.0, -5.0, 5.0)
 gen.add("max_height", double_t, 0, "the minimum height of the prism craeted by the planes", 0.5, -5.0, 5.0)
-gen.add("maginify", double_t, 0, "maginify polygon region (m)", 0.0, -1.0, 1.0)
+gen.add("maginify", double_t, 0, "DEPRECATED! Use magnify", 0.0, -1.0, 1.0)
+gen.add("magnify", double_t, 0, "magnify polygon region (m)", 0.0, -1.0, 1.0)
 gen.add("keep_organized", bool_t, 0, "keep organized pointcloud or not", True)
 exit (gen.generate (PACKAGE, "jsk_pcl_ros", "MultiPlaneExtraction"))

--- a/jsk_pcl_ros/include/jsk_pcl_ros/multi_plane_extraction.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/multi_plane_extraction.h
@@ -128,7 +128,7 @@ namespace jsk_pcl_ros
     int maximum_queue_size_;
     double min_height_, max_height_;
     bool use_indices_;
-    double maginify_;
+    double magnify_;
     bool use_sensor_frame_;
     std::string sensor_frame_;
     bool use_coefficients_;

--- a/jsk_pcl_ros/src/multi_plane_extraction_nodelet.cpp
+++ b/jsk_pcl_ros/src/multi_plane_extraction_nodelet.cpp
@@ -163,8 +163,19 @@ namespace jsk_pcl_ros
     boost::mutex::scoped_lock lock(mutex_);
     min_height_ = config.min_height;
     max_height_ = config.max_height;
-    maginify_ = config.maginify;
     keep_organized_ = config.keep_organized;
+
+    if (magnify_ != config.magnify)
+    {
+      magnify_ = config.magnify;
+      config.maginify = magnify_;
+    }
+    else if (magnify_ != config.maginify)
+    {
+      ROS_WARN_STREAM_ONCE("parameter 'maginify' is deprecated! Use 'magnify' instead!");
+      magnify_ = config.maginify;
+      config.magnify = magnify_;
+    }
   }
 
   void MultiPlaneExtraction::updateDiagnostic(
@@ -321,7 +332,7 @@ namespace jsk_pcl_ros
         jsk_recognition_utils::pointFromXYZToXYZ<geometry_msgs::Point32, pcl::PointXYZRGB>(
           the_polygon.points[i], p);
         Eigen::Vector3f dir = (p.getVector3fMap() - centroid).normalized();
-        p.getVector3fMap() = dir * maginify_ + p.getVector3fMap();
+        p.getVector3fMap() = dir * magnify_ + p.getVector3fMap();
         hull_cloud->points.push_back(p);
       }
       


### PR DESCRIPTION
This closes #2202

- Added correct parameter `magnify` that synchronizes with `maginify`
- Add deprecation warning for `maginify`