### PR TITLE
install dlib in ros-indigo-pcl1.8

### DIFF
--- a/docker/ros/indigo/pcl1.8/Dockerfile
+++ b/docker/ros/indigo/pcl1.8/Dockerfile
@@ -37,3 +37,7 @@ RUN cd ~/ros/ws_jsk_recognition && \
     apt-get install -y python-catkin-tools && \
     . /opt/ros/indigo/setup.sh && \
     catkin build
+
+RUN apt-get update && apt-get install -y python-setuptools
+RUN easy_install 'pip==6.0.7'
+RUN pip install -U dlib


### PR DESCRIPTION
pip install dlib takes 15 minutes, so it's better to include in docker file