### PR TITLE
[doc] fix node script name of face_pose_estimation.py document.

### DIFF
--- a/doc/jsk_perception/nodes/face_pose_estimation.rst
+++ b/doc/jsk_perception/nodes/face_pose_estimation.rst
@@ -1,4 +1,4 @@
-people_pose_estimation_2d.py
+face_pose_estimation.py
 ============================
 
 


### PR DESCRIPTION
Node name is not correct in the following doc.
http://jsk-docs.readthedocs.io/en/latest/jsk_recognition/doc/jsk_perception/nodes/face_pose_estimation.html