### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/jsk_libfreenect2/src/driver_nodelet.cpp
+++ b/jsk_libfreenect2/src/driver_nodelet.cpp
@@ -237,5 +237,5 @@ namespace jsk_libfreenect2
 
 #include <pluginlib/class_list_macros.h>
 typedef jsk_libfreenect2::Driver Driver;
-PLUGINLIB_DECLARE_CLASS (jsk_libfreenect2, Driver, Driver, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(Driver, nodelet::Nodelet);
 


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions