### PR TITLE
somehow pcl_ros_LIBRARIES missing pcl_visualization

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -1,3 +1,4 @@
+
 # http://ros.org/doc/groovy/api/catkin/html/user_guide/supposed.html
 cmake_minimum_required(VERSION 2.8.3)
 project(jsk_pcl_ros)
@@ -128,7 +129,7 @@ generate_dynamic_reconfigure_options(
 find_package(OpenCV REQUIRED core imgproc)
 
 include_directories(include ${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS} ${PCL_INCLUDE_DIRS})
-link_directories(${catkin_LIBRARY_DIRS})
+link_directories(${catkin_LIBRARY_DIRS} pcl_tracking pcl_people)
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -z defs")
 endif()

--- a/jsk_recognition_utils/CMakeLists.txt
+++ b/jsk_recognition_utils/CMakeLists.txt
@@ -59,8 +59,9 @@ if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
 endif()
 include_directories(
   include ${catkin_INCLUDE_DIRS}
-)
-link_libraries(${catkin_LIBRARIES} ${pcl_ros_LIBRARIES} ${OpenCV_LIBRARIES}  yaml-cpp)
+  )
+# libpcl_visualization is missing from pcl_ros_LIBRARIES (see https://github.com/jsk-ros-pkg/jsk_recognition/issues/2259#issuecomment-379529111)
+link_libraries(${catkin_LIBRARIES} ${pcl_ros_LIBRARIES} pcl_visualization ${OpenCV_LIBRARIES}  yaml-cpp)
 
 add_library(jsk_recognition_utils SHARED
   src/grid_index.cpp


### PR DESCRIPTION
Closes #2259 

This is regression of updating pcl_ros from 1.4.1 to 1.4.2

```
$ grep VERSION\  /opt/ros/kinetic/share/pcl_ros/cmake/pcl_rosConfig-version.cmake 
set(PACKAGE_VERSION "1.4.1")
$ grep libpcl_visu /opt/ros/kinetic/share/pcl_ros/cmake/pcl_rosConfig.cmake 
set(libraries "pcl_ros_filters;pcl_ros_io;pcl_ros_tf;optimized;/usr/lib/x86_64-linux-gnu/libpcl_common.so;debug;/usr/lib/x86_64-linux-gnu/libpcl_common.so;optimized;/usr/lib/x86_64-linux-gnu/libpcl_kdtree.so;debug;/usr/lib/x86_64-linux-gnu/libpcl_kdtree.so;optimized;/usr/lib/x86_64-linux-gnu/libpcl_octree.so;debug;/usr/lib/x86_64-linux-gnu/libpcl_octree.so;optimized;/usr/lib/x86_64-linux-gnu/libpcl_search.so;debug;/usr/lib/x86_64-linux-gnu/libpcl_search.so;optimized;/usr/lib/x86_64-linux-gnu/libpcl_io.so;debug;/usr/lib/x86_64-linux-gnu/libpcl_io.so;optimized;/usr/lib/x86_64-linux-gnu/libpcl_sample_consensus.so;debug;/usr/lib/x86_64-linux-gnu/libpcl_sample_consensus.so;optimized;/usr/lib/x86_64-linux-gnu/libpcl_filters.so;debug;/usr/lib/x86_64-linux-gnu/libpcl_filters.so;optimized;/usr/lib/x86_64-linux-gnu/libpcl_features.so;debug;/usr/lib/x86_64-linux-gnu/libpcl_features.so;optimized;/usr/lib/x86_64-linux-gnu/libpcl_segmentation.so;debug;/usr/lib/x86_64-linux-gnu/libpcl_segmentation.so;optimized;/usr/lib/x86_64-linux-gnu/libpcl_surface.so;debug;/usr/lib/x86_64-linux-gnu/libpcl_surface.so;optimized;/usr/lib/x86_64-linux-gnu/libpcl_registration.so;debug;/usr/lib/x86_64-linux-gnu/libpcl_registration.so;optimized;/usr/lib/x86_64-linux-gnu/libpcl_recognition.so;debug;/usr/lib/x86_64-linux-gnu/libpcl_recognition.so;optimized;/usr/lib/x86_64-linux-gnu/libpcl_keypoints.so;debug;/usr/lib/x86_64-linux-gnu/libpcl_keypoints.so;optimized;/usr/lib/x86_64-linux-gnu/libpcl_visualization.so;debug;/usr/lib/x86_64-linux-gnu/libpcl_visualization.so;optimized;/usr/lib/x86_64-linux-gnu/libpcl_people.so;debug;/usr/lib/x86_64-linux-gnu/libpcl_people.so;optimized;/usr/lib/x86_64-linux-gnu/libpcl_outofcore.so;debug;/usr/lib/x86_64-linux-gnu/libpcl_outofcore.so;optimized;/usr/lib/x86_64-linux-gnu/libpcl_tracking.so;debug;/usr/lib/x86_64-linux-gnu/libpcl_tracking.so;/usr/lib/x86_64-linux-gnu/libboost_system.so;/usr/lib/x86_64-linux-gnu/libboost_filesystem.so;/usr/lib/x86_64-linux-gnu/libboost_thread.so;/usr/lib/x86_64-linux-gnu/li
```

```
user@ubuntu-16:~/jsk_ws/src/jsk_recognition/jsk_recognition_utils$ grep VERSION\  /opt/ros/kinetic/share/pcl_ros/cmake/pcl_rosConfig-version.cmake 
set(PACKAGE_VERSION "1.4.2")
user@ubuntu-16:~/jsk_ws/src/jsk_recognition/jsk_recognition_utils$ grep libpcl_visu /opt/ros/kinetic/share/pcl_ros/cmake/pcl_rosConfig.cmake 
user@ubuntu-16:~/jsk_ws/src/jsk_recognition/jsk_recognition_utils$ 
```