### PR TITLE
Fix missing pkg_name in install_sample_data.py

### DIFF
--- a/jsk_pcl_ros/scripts/install_sample_data.py
+++ b/jsk_pcl_ros/scripts/install_sample_data.py
@@ -6,24 +6,21 @@ import multiprocessing
 import jsk_data
 
 
-def download_data(*args, **kwargs):
-    p = multiprocessing.Process(
-            target=jsk_data.download_data,
-            args=args,
-            kwargs=kwargs)
-    p.start()
-
-
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-v', '--verbose', dest='quiet', action='store_false')
     args = parser.parse_args()
     quiet = args.quiet
 
-    PKG = 'jsk_pcl_ros'
+    def download_data(**kwargs):
+        kwargs['pkg_name'] = 'jsk_pcl_ros'
+        kwargs['quiet'] = quiet
+        p = multiprocessing.Process(
+            target=jsk_data.download_data,
+            kwargs=kwargs)
+        p.start()
 
     download_data(
-        pkg_name=PKG,
         path='sample/data/2016-06-24-17-43-57_tabletop.bag.tgz',
         url='https://drive.google.com/uc?id=0B9P1L--7Wd2vUllPT3VPOHN6LVU',
         md5='dbc3daff4fe9812cab7328e7702e6438',
@@ -31,7 +28,6 @@ def main():
     )
 
     download_data(
-        pkg_name=PKG,
         path='sample/data/2017-06-19-19-34-18_tabletop_coffeecup.tgz',
         url='https://drive.google.com/uc?id=0B5DV6gwLHtyJRTJ0eGdVYk43bEU',
         md5='d58e894c853fc4485d08547b9fc2b640',
@@ -39,7 +35,6 @@ def main():
     )
 
     download_data(
-        pkg_name=PKG,
         path='sample/data/2016-10-26-02-09-51_coffee_cup.pcd',
         url='https://drive.google.com/uc?id=0B5DV6gwLHtyJVVQ2TFhVSTJqZ3M',
         md5='27d1a39e6ea596c4e24f1347f53f2e7b',
@@ -47,7 +42,6 @@ def main():
     )
 
     download_data(
-        pkg_name=PKG,
         path='sample/data/drill.pcd',
         url='http://www.jsk.t.u-tokyo.ac.jp/~ueda/dataset/2015/02/drill.pcd',
         md5='b6ea8f7bd97fd1e88fb6af2f6cd42ac5',
@@ -55,32 +49,28 @@ def main():
     )
 
     download_data(
-        pkg_name=PKG,
         path='sample/data/2016-07-06-12-16-43-person-in-point-cloud.tgz',
         url='https://drive.google.com/uc?id=0B_NiLAzvehC9cHhnOFd0YUN2N1U',
         md5='c59067adc429fb9f1cf180d350a2da43',
         extract=True,
         compressed_bags=[
-            'sample/data/2016-07-06-12-16-43-person-in-point-cloud/vision.compressed.bag',
+            'sample/data/2016-07-06-12-16-43-person-in-point-cloud/vision.compressed.bag',  # NOQA
         ],
     )
 
     download_data(
-        pkg_name=PKG,
         path='sample/data/stereo_arc2017_objects.bag',
         url='https://drive.google.com/uc?id=0B9P1L--7Wd2va1ZvWHJRT3Y5dkk',
         md5='4d8f51d0827f66afe5b91473aeaf9c97',
     )
 
     download_data(
-        pkg_name=PKG,
         path='sample/data/room73b2_table.bag',
         url='https://drive.google.com/uc?id=0B9P1L--7Wd2vdXdfMWNSUU9IVEU',
         md5='a38fee55c926152f3d65023d60322eb0',
     )
 
     download_data(
-        pkg_name=PKG,
         path='sample/data/sample_add_color_from_image_20170319.bag',
         url='https://drive.google.com/uc?id=0B9P1L--7Wd2vN284RHBXT1duUWM',
         md5='d432e7eec587708849ac85fdb3c6247f',
@@ -90,7 +80,6 @@ def main():
     )
 
     download_data(
-        pkg_name=PKG,
         path='sample/data/pr2_sink.bag.tgz',
         url='https://drive.google.com/uc?id=19VujodKsX7EJJwHetqFGCRYz0JBtZQ6h',
         md5='9bdc1500610a1a97480cae6fcf261811',
@@ -101,7 +90,6 @@ def main():
     )
 
     download_data(
-        pkg_name=PKG,
         path='sample/data/kettle.pcd',
         url='https://drive.google.com/uc?id=1MpQ3MK3D5VTlmj--r9dFPrfyLPQU7LO0',
         md5='87579bdbb5f87a058697ace16887e37f',


### PR DESCRIPTION
## Problem

`pkg_name` argument is required.
And `./install_sample_data.py` fails...

## Why this happens?

Because of the merge commit.
You can see `git show 338d9b850623cb614eb5596fba9c6b7ff1e2b9c9`.
The git log says @k-okada triggered `git merge` in https://github.com/jsk-ros-pkg/jsk_recognition/pull/1991,
and this bug was introduced.

I'm not sure this is caused by the failure of auto git-merge or mistaken conflict resolving.
Do you remember something? @k-okada @furushchev 

```
commit 338d9b850623cb614eb5596fba9c6b7ff1e2b9c9
Merge: 8382f6b 778063d
Author: Kei Okada <k-okada@jsk.t.u-tokyo.ac.jp>
Date:   Mon Jan 22 13:00:54 2018 +0900

    Merge branch 'master' into icp-2d

diff --cc jsk_pcl_ros/scripts/install_sample_data.py
index 0a8af1b,8b865d6..8b6618b
--- a/jsk_pcl_ros/scripts/install_sample_data.py
+++ b/jsk_pcl_ros/scripts/install_sample_data.py
@@@ -91,22 -91,14 +91,32 @@@ def main()
  
      download_data(
          pkg_name=PKG,
 +        path='sample/data/pr2_sink.bag.tgz',
 +        url='https://drive.google.com/uc?id=19VujodKsX7EJJwHetqFGCRYz0JBtZQ6h',
 +        md5='9bdc1500610a1a97480cae6fcf261811',
 +        extract=True,
 +        compressed_bags=[
 +            'sample/data/pr2_sink.bag',
 +        ],
 +    )
 +
 +    download_data(
 +        pkg_name=PKG,
 +        path='sample/data/kettle.pcd',
 +        url='https://drive.google.com/uc?id=1MpQ3MK3D5VTlmj--r9dFPrfyLPQU7LO0',
 +        md5='87579bdbb5f87a058697ace16887e37f',
 +        extract=False,
 +    )
 +
++    download_data(
+         path='sample/data/sample_door_handle_detector.bag',
+         url='https://drive.google.com/uc?id=0B4ysRIwB7GryMGxCTUI0MHhqWFk',
+         md5='f702e012730db7aaf01b9868280d8bca',
+         compressed_bags=[
+             'sample/data/sample_door_handle_detector.bag',
+         ],
+     )
+ 
+ 
  if __name__ == '__main__':
      main()
```