### PR TITLE
jsk_pcl_ros: support lazy mode for pointcloud_screenpoint nodelet

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -123,6 +123,7 @@ generate_dynamic_reconfigure_options(
   cfg/PPFRegistration.cfg
   cfg/PrimitiveShapeClassifier.cfg
   cfg/Kinfu.cfg
+  cfg/PointcloudScreenpoint.cfg
   )
 
 find_package(OpenCV REQUIRED core imgproc)

--- a/jsk_pcl_ros/cfg/PointcloudScreenpoint.cfg
+++ b/jsk_pcl_ros/cfg/PointcloudScreenpoint.cfg
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+#       name    type     level     description     default      min      max
+gen.add("synchronization", bool_t, 0, "Enable Synchronization", False)
+gen.add("approximate_sync", bool_t, 0, "Approximate synchronization", False)
+gen.add("queue_size", int_t, 0, "Queue size", 1, 1, 1000)
+gen.add("crop_size", int_t, 0, "Size of cropping", 10, 1, 100)
+gen.add("search_size", int_t, 0, "Size of search", 16, 1, 100)
+gen.add("timeout", double_t, 0, "Timeout to wait for point cloud", 3.0, 0.0, 30.0)
+exit(gen.generate("jsk_pcl_ros", "jsk_pcl_ros", "PointcloudScreenpoint"))

--- a/jsk_pcl_ros/src/pointcloud_screenpoint_nodelet.cpp
+++ b/jsk_pcl_ros/src/pointcloud_screenpoint_nodelet.cpp
@@ -33,120 +33,442 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include <jsk_topic_tools/log_utils.h>
-#include "jsk_pcl_ros/pointcloud_screenpoint.h"
+#include <jsk_pcl_ros/pointcloud_screenpoint.h>
 #include <pcl_conversions/pcl_conversions.h>
 
 // F/K/A <ray converter>
 // Haseru Chen, Kei Okada, Yohei Kakiuchi
 
-void jsk_pcl_ros::PointcloudScreenpoint::onInit()
+namespace mf = message_filters;
+
+namespace jsk_pcl_ros
 {
-  PCLNodelet::onInit();
 
-  queue_size_ = 1;
-  crop_size_ = 10;
-  k_ = 16; // todo : this value should be set from parameter.
+void PointcloudScreenpoint::onInit()
+{
+  ConnectionBasedNodelet::onInit();
 
-  pnh_->param ("queue_size", queue_size_, 1);
-  pnh_->param ("crop_size", crop_size_, 10);
-  pnh_->param ("search_size", k_, 16);
 
-  pnh_->param ("use_rect", use_rect_, false);
-  pnh_->param ("use_point", use_point_, false);
-  pnh_->param ("use_sync", use_sync_, false);
-  pnh_->param ("use_point_array", use_point_array_, false);
-  pnh_->param ("use_poly", use_poly_, false);
-  pnh_->param("publish_points", publish_points_, false);
-  pnh_->param("publish_point", publish_point_, false);
-
-  srv_ = pnh_->advertiseService("screen_to_point", &PointcloudScreenpoint::screenpoint_cb, this);
-
-  if (publish_point_) {
-    pub_point_ = pnh_->advertise< geometry_msgs::PointStamped > ("output_point", 1);
-    ROS_INFO("Publish output as geometry_msgs::PointStamped to '%s'", pub_point_.getTopic().c_str());
-  }
-
-  if (publish_points_) {
-    pub_points_ = pnh_->advertise< sensor_msgs::PointCloud2 > ("output", 1);
-    ROS_INFO("Publish output as sensor_msgs::PointCloud2 to '%s'", pub_points_.getTopic().c_str());
-  }
-
-  pub_polygon_ = pnh_->advertise<geometry_msgs::PolygonStamped>("output_polygon", 1);
-  ROS_INFO("Publish output as geometry_msgs::PolygonStamped to '%s'", pub_polygon_.getTopic().c_str());
-
-#if ( PCL_MAJOR_VERSION >= 1 && PCL_MINOR_VERSION >= 5 )
-  normals_tree_ = boost::make_shared< pcl::search::KdTree<pcl::PointXYZ> > ();
-#else
-  normals_tree_ = boost::make_shared<pcl::KdTreeFLANN<pcl::PointXYZ> > ();
-#endif
-  n3d_.setKSearch (k_);
+  normals_tree_ = boost::make_shared< pcl::search::KdTree< pcl::PointXYZ > > ();
   n3d_.setSearchMethod (normals_tree_);
 
-  points_sub_.subscribe (*pnh_, "points", queue_size_);
-  ROS_INFO("Subscribe '%s' of sensor_msgs::PointCloud2", points_sub_.getTopic().c_str());
+  dyn_srv_ = boost::make_shared< dynamic_reconfigure::Server< Config > >(*pnh_);
+  dynamic_reconfigure::Server<Config>::CallbackType f =
+      boost::bind(&PointcloudScreenpoint::configCallback, this, _1, _2);
+  dyn_srv_->setCallback(f);
 
-  if (use_rect_) {
-    rect_sub_.subscribe   (*pnh_, "rect", queue_size_);
-    ROS_INFO("Subscribe '%s' of geometry_msgs::PolygonStamped", rect_sub_.getTopic().c_str());
-    if (use_sync_) {
-      sync_a_rect_ = boost::make_shared < message_filters::Synchronizer< PolygonApproxSyncPolicy > > (queue_size_);
-      sync_a_rect_->connectInput (points_sub_, rect_sub_);
-      sync_a_rect_->registerCallback (boost::bind (&PointcloudScreenpoint::callback_rect, this, _1, _2));
-    } else {
-      rect_sub_.registerCallback (boost::bind (&PointcloudScreenpoint::rect_cb, this, _1));
-    }
-  }
-  
-  if (use_poly_) {
-    poly_sub_.subscribe   (*pnh_, "poly", queue_size_);
-    ROS_INFO("Subscribe '%s' of geometry_msgs::PolygonStamped", poly_sub_.getTopic().c_str());
-    if (use_sync_) {
-      sync_a_poly_ = boost::make_shared < message_filters::Synchronizer< PolygonApproxSyncPolicy > > (queue_size_);
-      sync_a_poly_->connectInput (points_sub_, rect_sub_);
-      sync_a_poly_->registerCallback (boost::bind (&PointcloudScreenpoint::callback_poly, this, _1, _2));
-    } else {
-      poly_sub_.registerCallback (boost::bind (&PointcloudScreenpoint::poly_cb, this, _1));
-    }
-  }
+  srv_ = pnh_->advertiseService(
+      "screen_to_point", &PointcloudScreenpoint::screenpoint_cb, this);
 
-  if (use_point_) {
-    point_sub_.subscribe  (*pnh_, "point", queue_size_);
-    ROS_INFO("Subscribe '%s' of geometry_msgs::PointStamped", point_sub_.getTopic().c_str());
-    if (use_sync_) {
-      sync_a_point_ = boost::make_shared < message_filters::Synchronizer< PointApproxSyncPolicy > > (queue_size_);
-      sync_a_point_->connectInput (points_sub_, point_sub_);
-      sync_a_point_->registerCallback (boost::bind (&PointcloudScreenpoint::callback_point, this, _1, _2));
-    } else {
-      point_sub_.registerCallback (boost::bind (&PointcloudScreenpoint::point_cb, this, _1));
-    }
-  }
+  pub_points_  = advertise< sensor_msgs::PointCloud2 >(*pnh_, "output", 1);
+  pub_point_   = advertise< geometry_msgs::PointStamped >(*pnh_, "output_point", 1);
+  pub_polygon_ = advertise< geometry_msgs::PolygonStamped >(*pnh_, "output_polygon", 1);
 
-  if (use_point_array_) {
-    point_array_sub_.subscribe(*pnh_, "point_array", queue_size_);
-    ROS_INFO("Subscribe '%s' of sensor_msgs::PointCloud2", point_array_sub_.getTopic().c_str());
-    if (use_sync_) {
-      sync_a_point_array_ = boost::make_shared < message_filters::Synchronizer< PointCloudApproxSyncPolicy > > (queue_size_);
-      sync_a_point_array_->connectInput (points_sub_, point_array_sub_);
-      sync_a_point_array_->registerCallback (boost::bind (&PointcloudScreenpoint::callback_point_array, this, _1, _2));
-    } else {
-      point_array_sub_.registerCallback (boost::bind (&PointcloudScreenpoint::point_array_cb, this, _1));
-    }
-  }
-
-  points_sub_.registerCallback (boost::bind (&PointcloudScreenpoint::points_cb, this, _1));
+  onInitPostProcess();
 }
 
+void PointcloudScreenpoint::subscribe()
+{
+  points_sub_.subscribe(*pnh_, "points", 1);
+  rect_sub_.subscribe(*pnh_, "rect", 1);
+  poly_sub_.subscribe(*pnh_, "poly", 1);
+  point_sub_.subscribe(*pnh_, "point", 1);
+  point_array_sub_.subscribe(*pnh_, "point_array", 1);
 
-bool jsk_pcl_ros::PointcloudScreenpoint::checkpoint (pcl::PointCloud< pcl::PointXYZ > &in_pts, int x, int y,
-                                                     float &resx, float &resy, float &resz)  {
-  if ((x < 0) || (y < 0) || (x >= in_pts.width) || (y >= in_pts.height)) {
-    ROS_WARN("Requested point is out of image size.  point: (%d, %d)  size: (%d, %d)", x, y, in_pts.width, in_pts.height);
+  if (synchronization_)
+  {
+    if (approximate_sync_)
+    {
+      async_rect_ = boost::make_shared<
+        mf::Synchronizer<PolygonApproxSyncPolicy> >(queue_size_);
+      async_rect_->connectInput(points_sub_, rect_sub_);
+      async_rect_->registerCallback(
+          boost::bind(&PointcloudScreenpoint::sync_rect_cb, this, _1, _2));
+
+      async_poly_ = boost::make_shared<
+        mf::Synchronizer<PolygonApproxSyncPolicy> >(queue_size_);
+      async_poly_->connectInput(points_sub_, rect_sub_);
+      async_poly_->registerCallback(
+          boost::bind(&PointcloudScreenpoint::sync_poly_cb, this, _1, _2));
+
+      async_point_ = boost::make_shared<
+        mf::Synchronizer<PointApproxSyncPolicy> >(queue_size_);
+      async_point_->connectInput(points_sub_, point_sub_);
+      async_point_->registerCallback(
+          boost::bind(&PointcloudScreenpoint::sync_point_cb, this, _1, _2));
+
+      async_point_array_ = boost::make_shared<
+        mf::Synchronizer<PointCloudApproxSyncPolicy> >(queue_size_);
+      async_point_array_->connectInput(points_sub_, point_array_sub_);
+      async_point_array_->registerCallback(
+          boost::bind(&PointcloudScreenpoint::sync_point_array_cb, this, _1, _2));
+    }
+    else
+    {
+      sync_rect_ = boost::make_shared<
+        mf::Synchronizer<PolygonExactSyncPolicy> >(queue_size_);
+      sync_rect_->connectInput(points_sub_, rect_sub_);
+      sync_rect_->registerCallback(
+          boost::bind(&PointcloudScreenpoint::sync_rect_cb, this, _1, _2));
+
+      sync_poly_ = boost::make_shared<
+        mf::Synchronizer<PolygonExactSyncPolicy> >(queue_size_);
+      sync_poly_->connectInput(points_sub_, rect_sub_);
+      sync_poly_->registerCallback(
+          boost::bind(&PointcloudScreenpoint::sync_poly_cb, this, _1, _2));
+
+      sync_point_ = boost::make_shared<
+        mf::Synchronizer<PointExactSyncPolicy> >(queue_size_);
+      sync_point_->connectInput(points_sub_, point_sub_);
+      sync_point_->registerCallback(
+          boost::bind(&PointcloudScreenpoint::sync_point_cb, this, _1, _2));
+
+      sync_point_array_ = boost::make_shared<
+        mf::Synchronizer<PointCloudExactSyncPolicy> >(queue_size_);
+      sync_point_array_->connectInput(points_sub_, point_array_sub_);
+      sync_point_array_->registerCallback(
+          boost::bind(&PointcloudScreenpoint::sync_point_array_cb, this, _1, _2));
+    }
+  }
+  else
+  {
+    points_sub_.registerCallback(
+        boost::bind(&PointcloudScreenpoint::points_cb, this, _1));
+    rect_sub_.registerCallback(
+        boost::bind(&PointcloudScreenpoint::rect_cb, this, _1));
+    poly_sub_.registerCallback(
+        boost::bind(&PointcloudScreenpoint::poly_cb, this, _1));
+    point_sub_.registerCallback(
+        boost::bind(&PointcloudScreenpoint::point_cb, this, _1));
+    point_array_sub_.registerCallback(
+        boost::bind(&PointcloudScreenpoint::point_array_cb, this, _1));
+  }
+}
+
+void PointcloudScreenpoint::unsubscribe()
+{
+  points_sub_.unsubscribe();
+  rect_sub_.unsubscribe();
+  poly_sub_.unsubscribe();
+  point_sub_.unsubscribe();
+  point_array_sub_.unsubscribe();
+}
+
+void PointcloudScreenpoint::configCallback(Config& config, uint32_t level)
+{
+  boost::mutex::scoped_lock lock(mutex_);
+
+  bool need_resubscribe = false;
+  if (synchronization_ != config.synchronization ||
+      approximate_sync_ != config.approximate_sync ||
+      queue_size_ != config.queue_size)
+    need_resubscribe = true;
+
+  synchronization_ = config.synchronization;
+  approximate_sync_ = config.approximate_sync;
+  queue_size_ = config.queue_size;
+  crop_size_ = config.crop_size;
+  timeout_ = config.timeout;
+
+  if (search_size_ != config.search_size)
+  {
+    search_size_ = config.search_size;
+    n3d_.setKSearch (search_size_);
+  }
+
+  if (need_resubscribe && isSubscribed())
+  {
+    unsubscribe();
+    subscribe();
+  }
+}
+
+// Service callback functions
+bool PointcloudScreenpoint::screenpoint_cb (
+    jsk_recognition_msgs::TransformScreenpoint::Request &req,
+    jsk_recognition_msgs::TransformScreenpoint::Response &res)
+{
+  NODELET_DEBUG("PointcloudScreenpoint::screenpoint_cb");
+  boost::mutex::scoped_lock lock(mutex_);
+
+  if ( latest_cloud_.empty() && req.no_update ) {
+    NODELET_ERROR("no point cloud was received");
     return false;
   }
+
+  bool need_unsubscribe = false;
+  if (!points_sub_.getSubscriber()) {
+    points_sub_.registerCallback(
+        boost::bind(&PointcloudScreenpoint::points_cb, this, _1));
+    need_unsubscribe = true;
+  }
+
+  // wait for cloud
+  ros::Time start = ros::Time::now();
+  ros::Rate r(10);
+  while (ros::ok())
+  {
+    if ( !latest_cloud_.empty() ) break;
+    if ((ros::Time::now() - start).toSec() > timeout_) break;
+    r.sleep();
+    ros::spinOnce();
+    NODELET_INFO_THROTTLE(1.0, "Waiting for point cloud...");
+  }
+
+  if (need_unsubscribe)
+  {
+    points_sub_.unsubscribe();
+  }
+
+  if (latest_cloud_.empty())
+  {
+    NODELET_ERROR("no point cloud was received");
+    return false;
+  }
+
+  res.header = latest_cloud_header_;
+
+  bool ret;
+  float rx, ry, rz;
+  ret = extract_point (latest_cloud_, req.x, req.y, rx, ry, rz);
+  res.point.x = rx; res.point.y = ry; res.point.z = rz;
+
+  if (!ret) {
+    NODELET_ERROR("Failed to extract point");
+    return false;
+  }
+
+  // search normal
+  n3d_.setSearchSurface(
+      boost::make_shared<pcl::PointCloud<pcl::PointXYZ > > (latest_cloud_));
+
+  pcl::PointCloud<pcl::PointXYZ> cloud_;
+  pcl::PointXYZ pt;
+  pt.x = res.point.x;
+  pt.y = res.point.y;
+  pt.z = res.point.z;
+  cloud_.points.resize(0);
+  cloud_.points.push_back(pt);
+
+  n3d_.setInputCloud (boost::make_shared<pcl::PointCloud<pcl::PointXYZ > > (cloud_));
+  pcl::PointCloud<pcl::Normal> cloud_normals;
+  n3d_.compute (cloud_normals);
+
+  res.vector.x = cloud_normals.points[0].normal_x;
+  res.vector.y = cloud_normals.points[0].normal_y;
+  res.vector.z = cloud_normals.points[0].normal_z;
+
+  if((res.point.x * res.vector.x + res.point.y * res.vector.y + res.point.z * res.vector.z) < 0) {
+    res.vector.x *= -1;
+    res.vector.y *= -1;
+    res.vector.z *= -1;
+  }
+
+  if (pub_point_.getNumSubscribers() > 0) {
+    geometry_msgs::PointStamped ps;
+    ps.header = latest_cloud_header_;
+    ps.point.x = res.point.x;
+    ps.point.y = res.point.y;
+    ps.point.z = res.point.z;
+    pub_point_.publish(ps);
+  }
+
+  return true;
+}
+
+// Message callback functions
+void PointcloudScreenpoint::points_cb(const sensor_msgs::PointCloud2::ConstPtr &msg)
+{
+  NODELET_DEBUG("PointcloudScreenpoint::points_cb, width=%d, height=%d, fields=%ld",
+                msg->width, msg->height, msg->fields.size());
+
+  latest_cloud_header_ = msg->header;
+  pcl::fromROSMsg (*msg, latest_cloud_);
+}
+
+void PointcloudScreenpoint::point_cb (const geometry_msgs::PointStampedConstPtr& pt_ptr)
+{
+  if (latest_cloud_.empty())
+  {
+    NODELET_ERROR_THROTTLE(1.0, "no point cloud was received");
+    return;
+  }
+  if (pub_point_.getNumSubscribers() > 0)
+  {
+    geometry_msgs::PointStamped ps;
+    bool ret; float rx, ry, rz;
+    ret = extract_point (latest_cloud_, pt_ptr->point.x, pt_ptr->point.y, rx, ry, rz);
+
+    if (ret) {
+      ps.point.x = rx; ps.point.y = ry; ps.point.z = rz;
+      ps.header = latest_cloud_header_;
+      pub_point_.publish (ps);
+    }
+  }
+  if (pub_points_.getNumSubscribers() > 0)
+  {
+    int st_x = pt_ptr->point.x - crop_size_;
+    int st_y = pt_ptr->point.y - crop_size_;
+    int ed_x = pt_ptr->point.x + crop_size_;
+    int ed_y = pt_ptr->point.y + crop_size_;
+    sensor_msgs::PointCloud2 out_pts;
+    extract_rect (latest_cloud_, st_x, st_y, ed_x, ed_y, out_pts);
+    pub_points_.publish(out_pts);
+  }
+}
+
+void PointcloudScreenpoint::point_array_cb (const sensor_msgs::PointCloud2ConstPtr& pt_arr_ptr)
+{
+  if (latest_cloud_.empty())
+  {
+    NODELET_ERROR_THROTTLE(1.0, "no point cloud was received");
+    return;
+  }
+  if (pub_points_.getNumSubscribers() > 0) {
+    pcl::PointCloud<pcl::PointXY>::Ptr point_array_cloud(new pcl::PointCloud<pcl::PointXY>);
+    pcl::fromROSMsg(*pt_arr_ptr, *point_array_cloud);
+    pcl::PointCloud<pcl::PointXYZ>::Ptr result_cloud(new pcl::PointCloud<pcl::PointXYZ>);
+    result_cloud->header = pcl_conversions::toPCL(latest_cloud_header_); // FIXME: if hydro
+    for (size_t i = 0; i < point_array_cloud->points.size(); i++) {
+      pcl::PointXY point = point_array_cloud->points[i];
+      geometry_msgs::PointStamped ps;
+      bool ret; float rx, ry, rz;
+      ret = extract_point (latest_cloud_, point.x, point.y, rx, ry, rz);
+      if (ret) {
+        pcl::PointXYZ point_on_screen;
+        point_on_screen.x = rx;
+        point_on_screen.y = ry;
+        point_on_screen.z = rz;
+        result_cloud->points.push_back(point_on_screen);
+      }
+    }
+    sensor_msgs::PointCloud2::Ptr ros_cloud(new sensor_msgs::PointCloud2);
+    pcl::toROSMsg(*result_cloud, *ros_cloud);
+    ros_cloud->header = latest_cloud_header_;
+    pub_points_.publish(ros_cloud);
+  }
+}
+
+void PointcloudScreenpoint::rect_cb (const geometry_msgs::PolygonStampedConstPtr& array_ptr) {
+  if (latest_cloud_.empty())
+  {
+    NODELET_ERROR_THROTTLE(1.0, "no point cloud was received");
+    return;
+  }
+
+  int num_pts = array_ptr->polygon.points.size();
+  if ( num_pts < 2) {
+    NODELET_ERROR("Point size must be 2.");
+    return;
+  } else if ( num_pts > 2 ) {
+    NODELET_WARN("Expected point size is 2, got %ld. "
+                 "Used first 2 points to compute mid-coords.",
+                 array_ptr->polygon.points.size());
+  }
+
+  int st_x = array_ptr->polygon.points[0].x;
+  int st_y = array_ptr->polygon.points[0].y;
+  int ed_x = array_ptr->polygon.points[1].x;
+  int ed_y = array_ptr->polygon.points[1].y;
+
+  if (pub_point_.getNumSubscribers() > 0)
+  {
+    geometry_msgs::PointStamped ps;
+    bool ret; float rx, ry, rz;
+    ret = extract_point (latest_cloud_, (st_x + ed_x) / 2, (st_y + ed_y) / 2, rx, ry, rz);
+
+    if (ret) {
+      ps.point.x = rx; ps.point.y = ry; ps.point.z = rz;
+      ps.header = latest_cloud_header_;
+      pub_point_.publish (ps);
+    }
+  }
+  if (pub_points_.getNumSubscribers() > 0)
+  {
+    sensor_msgs::PointCloud2 out_pts;
+    extract_rect (latest_cloud_, st_x, st_y, ed_x, ed_y, out_pts);
+    pub_points_.publish(out_pts);
+  }
+}
+
+void PointcloudScreenpoint::poly_cb(const geometry_msgs::PolygonStampedConstPtr& array_ptr)
+{
+  if (latest_cloud_.empty())
+  {
+    NODELET_ERROR_THROTTLE(1.0, "no point cloud was received");
+    return;
+  }
+  if (pub_polygon_.getNumSubscribers() > 0)
+  {
+    geometry_msgs::PolygonStamped result_polygon;
+    result_polygon.header = latest_cloud_header_;
+    for (size_t i = 0; i < array_ptr->polygon.points.size(); i++) {
+      geometry_msgs::Point32 p = array_ptr->polygon.points[i];
+      float rx, ry, rz;
+      bool ret = extract_point (latest_cloud_, p.x, p.y, rx, ry, rz);
+      if (!ret) {
+        NODELET_ERROR("Failed to project point");
+        continue;
+      }
+      geometry_msgs::Point32 p_projected;
+      p_projected.x = rx;
+      p_projected.y = ry;
+      p_projected.z = rz;
+      result_polygon.polygon.points.push_back(p_projected);
+    }
+    pub_polygon_.publish(result_polygon);
+  }
+}
+
+void PointcloudScreenpoint::sync_point_cb (
+    const sensor_msgs::PointCloud2::ConstPtr& points_ptr,
+    const geometry_msgs::PointStamped::ConstPtr& pt_ptr)
+{
+  boost::mutex::scoped_lock lock(mutex_);
+  points_cb (points_ptr);
+  point_cb (pt_ptr);
+}
+
+void PointcloudScreenpoint::sync_point_array_cb (
+    const sensor_msgs::PointCloud2::ConstPtr& points_ptr,
+    const sensor_msgs::PointCloud2::ConstPtr& pt_arr_ptr)
+{
+  boost::mutex::scoped_lock lock(mutex_);
+  points_cb (points_ptr);
+  point_array_cb(pt_arr_ptr);
+}
+
+void PointcloudScreenpoint::sync_poly_cb(
+    const sensor_msgs::PointCloud2::ConstPtr& points_ptr,
+    const geometry_msgs::PolygonStamped::ConstPtr& array_ptr)
+{
+  boost::mutex::scoped_lock lock(mutex_);
+  points_cb (points_ptr);
+  poly_cb(array_ptr);
+}
+
+void PointcloudScreenpoint::sync_rect_cb(
+    const sensor_msgs::PointCloud2::ConstPtr& points_ptr,
+    const geometry_msgs::PolygonStamped::ConstPtr& array_ptr) {
+  boost::mutex::scoped_lock lock(mutex_);
+  points_cb(points_ptr);
+  rect_cb (array_ptr);
+}
+
+bool PointcloudScreenpoint::checkpoint (const pcl::PointCloud< pcl::PointXYZ > &in_pts,
+                                        int x, int y,
+                                        float &resx, float &resy, float &resz)
+{
+  if ((x < 0) || (y < 0) || (x >= in_pts.width) || (y >= in_pts.height)) {
+    NODELET_WARN("Requested point is out of image size. "
+             "point: (%d, %d)  size: (%d, %d)",
+             x, y, in_pts.width, in_pts.height);
+    return false;
+  }
+
   pcl::PointXYZ p = in_pts.points[in_pts.width * y + x];
   // search near points
-  ROS_INFO("Request: screenpoint (%d, %d) => (%f, %f, %f)", x, y, p.x, p.y, p.z);
+  NODELET_DEBUG("Request: screenpoint (%d, %d) => (%f, %f, %f)", x, y, p.x, p.y, p.z);
   //return !(isnan (p.x) || ( (p.x == 0.0) && (p.y == 0.0) && (p.z == 0.0)));
 
   if ( !std::isnan (p.x) && ((p.x != 0.0) || (p.y != 0.0) || (p.z == 0.0)) ) {
@@ -156,13 +478,15 @@ bool jsk_pcl_ros::PointcloudScreenpoint::checkpoint (pcl::PointCloud< pcl::Point
   return false;
 }
 
-bool jsk_pcl_ros::PointcloudScreenpoint::extract_point (pcl::PointCloud< pcl::PointXYZ > &in_pts, int reqx, int reqy,
-                                                        float &resx, float &resy, float &resz) {
+bool PointcloudScreenpoint::extract_point(const pcl::PointCloud< pcl::PointXYZ > &in_pts,
+                                          int reqx, int reqy,
+                                          float &resx, float &resy, float &resz)
+{
   int x, y;
 
   x = reqx < 0.0 ? ceil(reqx - 0.5) : floor(reqx + 0.5);
   y = reqy < 0.0 ? ceil(reqy - 0.5) : floor(reqy + 0.5);
-  ROS_INFO("Request : %d %d", x, y);
+  NODELET_DEBUG("Request : %d %d", x, y);
 
   if (checkpoint (in_pts, x, y, resx, resy, resz)) {
     return true;
@@ -194,73 +518,14 @@ bool jsk_pcl_ros::PointcloudScreenpoint::extract_point (pcl::PointCloud< pcl::Po
   return false;
 }
 
-bool jsk_pcl_ros::PointcloudScreenpoint::screenpoint_cb (jsk_recognition_msgs::TransformScreenpoint::Request &req,
-                                                         jsk_recognition_msgs::TransformScreenpoint::Response &res)
+void PointcloudScreenpoint::extract_rect (const pcl::PointCloud< pcl::PointXYZ >& in_pts,
+                                          int st_x, int st_y,
+                                          int ed_x, int ed_y,
+                                          sensor_msgs::PointCloud2& out_pts)
 {
-  ROS_DEBUG("PointcloudScreenpoint::screenpoint_cb");
-  boost::mutex::scoped_lock lock(this->mutex_callback_);
-  if ( pts_.points.size() == 0 ) {
-    ROS_ERROR("no point cloud was received");
-    return false;
-  }
+  sensor_msgs::PointCloud2::Ptr points_ptr(new sensor_msgs::PointCloud2);
+  pcl::toROSMsg(in_pts, *points_ptr);
 
-  res.header = header_;
-
-  bool ret;
-  float rx, ry, rz;
-  ret = extract_point (pts_, req.x, req.y, rx, ry, rz);
-  res.point.x = rx; res.point.y = ry; res.point.z = rz;
-
-  if (!ret) {
-    return false;
-  }
-
-  // search normal
-  n3d_.setSearchSurface(boost::make_shared<pcl::PointCloud<pcl::PointXYZ > > (pts_));
-
-  pcl::PointCloud<pcl::PointXYZ> cloud_;
-  pcl::PointXYZ pt;
-  pt.x = res.point.x;
-  pt.y = res.point.y;
-  pt.z = res.point.z;
-  cloud_.points.resize(0);
-  cloud_.points.push_back(pt);
-
-  n3d_.setInputCloud (boost::make_shared<pcl::PointCloud<pcl::PointXYZ > > (cloud_));
-  pcl::PointCloud<pcl::Normal> cloud_normals;
-  n3d_.compute (cloud_normals);
-
-  res.vector.x = cloud_normals.points[0].normal_x;
-  res.vector.y = cloud_normals.points[0].normal_y;
-  res.vector.z = cloud_normals.points[0].normal_z;
-
-  if((res.point.x * res.vector.x + res.point.y * res.vector.y + res.point.z * res.vector.z) < 0) {
-    res.vector.x *= -1;
-    res.vector.y *= -1;
-    res.vector.z *= -1;
-  }
-
-  if (publish_point_) {
-    geometry_msgs::PointStamped ps;
-    ps.header = header_;
-    ps.point.x = res.point.x;
-    ps.point.y = res.point.y;
-    ps.point.z = res.point.z;
-    pub_point_.publish(ps);
-  }
-
-  return true;
-}
-
-void jsk_pcl_ros::PointcloudScreenpoint::points_cb(const sensor_msgs::PointCloud2ConstPtr &msg) {
-  ROS_DEBUG("PointcloudScreenpoint::points_cb, width=%d, height=%d, fields=%d", msg->width, msg->height, msg->fields.size());
-  //boost::mutex::scoped_lock lock(this->mutex_callback_);
-  header_ = msg->header;
-  pcl::fromROSMsg (*msg, pts_);
-}
-
-void jsk_pcl_ros::PointcloudScreenpoint::extract_rect (const sensor_msgs::PointCloud2ConstPtr& points_ptr,
-                                                       int st_x, int st_y, int ed_x, int ed_y) {
   if ( st_x < 0 ) st_x = 0;
   if ( st_y < 0 ) st_y = 0;
   if ( ed_x >= points_ptr->width ) ed_x = points_ptr->width -1;
@@ -271,18 +536,17 @@ void jsk_pcl_ros::PointcloudScreenpoint::extract_rect (const sensor_msgs::PointC
   int rstep = points_ptr->row_step;
   int pstep = points_ptr->point_step;
 
-  sensor_msgs::PointCloud2 pt;
-  pt.header = points_ptr->header;
-  pt.width = ed_x - st_x + 1;
-  pt.height = ed_y - st_y + 1;
-  pt.row_step = pt.width * pstep;
-  pt.point_step = pstep;
-  pt.is_bigendian = false;
-  pt.fields = points_ptr->fields;
-  pt.is_dense = false;
-  pt.data.resize(pt.row_step * pt.height);
+  out_pts.header = points_ptr->header;
+  out_pts.width = ed_x - st_x + 1;
+  out_pts.height = ed_y - st_y + 1;
+  out_pts.row_step = out_pts.width * pstep;
+  out_pts.point_step = pstep;
+  out_pts.is_bigendian = false;
+  out_pts.fields = points_ptr->fields;
+  out_pts.is_dense = false;
+  out_pts.data.resize(out_pts.row_step * out_pts.height);
 
-  unsigned char * dst_ptr = &(pt.data[0]);
+  unsigned char * dst_ptr = &(out_pts.data[0]);
 
   for (size_t idx_y = st_y; idx_y <= ed_y; idx_y++) {
     for (size_t idx_x = st_x; idx_x <= ed_x; idx_x++) {
@@ -291,130 +555,9 @@ void jsk_pcl_ros::PointcloudScreenpoint::extract_rect (const sensor_msgs::PointC
       dst_ptr += pstep;
     }
   }
-
-  pub_points_.publish (pt);
 }
 
-void jsk_pcl_ros::PointcloudScreenpoint::point_cb (const geometry_msgs::PointStampedConstPtr& pt_ptr) {
-  if (publish_point_) {
-    geometry_msgs::PointStamped ps;
-    bool ret; float rx, ry, rz;
-    ret = extract_point (pts_, pt_ptr->point.x, pt_ptr->point.y, rx, ry, rz);
+} // namespace jsk_pcl_ros
 
-    if (ret) {
-      ps.point.x = rx; ps.point.y = ry; ps.point.z = rz;
-      ps.header = header_;
-      pub_point_.publish (ps);
-    }
-  }
-}
-
-void jsk_pcl_ros::PointcloudScreenpoint::callback_point (const sensor_msgs::PointCloud2ConstPtr& points_ptr,
-                                                         const geometry_msgs::PointStampedConstPtr& pt_ptr) {
-  point_cb (pt_ptr);
-
-  if (publish_points_) {
-    int st_x = pt_ptr->point.x - crop_size_;
-    int st_y = pt_ptr->point.y - crop_size_;
-    int ed_x = pt_ptr->point.x + crop_size_;
-    int ed_y = pt_ptr->point.y + crop_size_;
-
-    extract_rect (points_ptr, st_x, st_y, ed_x, ed_y);
-  }
-}
-
-void jsk_pcl_ros::PointcloudScreenpoint::point_array_cb (const sensor_msgs::PointCloud2ConstPtr& pt_arr_ptr) {
-  if (publish_points_) {
-    pcl::PointCloud<pcl::PointXY>::Ptr point_array_cloud(new pcl::PointCloud<pcl::PointXY>);
-    pcl::fromROSMsg(*pt_arr_ptr, *point_array_cloud);
-    pcl::PointCloud<pcl::PointXYZ>::Ptr result_cloud(new pcl::PointCloud<pcl::PointXYZ>);
-    result_cloud->header = pcl_conversions::toPCL(header_); // if hydro
-    for (size_t i = 0; i < point_array_cloud->points.size(); i++) {
-      pcl::PointXY point = point_array_cloud->points[i];
-      geometry_msgs::PointStamped ps;
-      bool ret; float rx, ry, rz;
-      ret = extract_point (pts_, point.x, point.y, rx, ry, rz);
-      if (ret) {
-        pcl::PointXYZ point_on_screen;
-        point_on_screen.x = rx;
-        point_on_screen.y = ry;
-        point_on_screen.z = rz;
-        result_cloud->points.push_back(point_on_screen);
-      }
-    }
-    sensor_msgs::PointCloud2::Ptr ros_cloud(new sensor_msgs::PointCloud2);
-    pcl::toROSMsg(*result_cloud, *ros_cloud);
-    ros_cloud->header = header_;
-    pub_points_.publish(ros_cloud);
-  }
-}
-void jsk_pcl_ros::PointcloudScreenpoint::callback_point_array (const sensor_msgs::PointCloud2ConstPtr& points_ptr,
-                                                               const sensor_msgs::PointCloud2ConstPtr& pt_arr_ptr) {
-  point_array_cb(pt_arr_ptr);
-}
-
-void jsk_pcl_ros::PointcloudScreenpoint::rect_cb (const geometry_msgs::PolygonStampedConstPtr& array_ptr) {
-  if (array_ptr->polygon.points.size() > 1) {
-    int st_x = array_ptr->polygon.points[0].x;
-    int st_y = array_ptr->polygon.points[0].y;
-    int ed_x = array_ptr->polygon.points[1].x;
-    int ed_y = array_ptr->polygon.points[1].y;
-    if (publish_point_) {
-      geometry_msgs::PointStamped ps;
-      bool ret; float rx, ry, rz;
-      ret = extract_point (pts_, (st_x + ed_x) / 2, (st_y + ed_y) / 2, rx, ry, rz);
-
-      if (ret) {
-        ps.point.x = rx; ps.point.y = ry; ps.point.z = rz;
-        ps.header = header_;
-        pub_point_.publish (ps);
-      }
-    }
-  }
-}
-
-void jsk_pcl_ros::PointcloudScreenpoint::poly_cb(const geometry_msgs::PolygonStampedConstPtr& array_ptr) {
-  // publish polygon
-  geometry_msgs::PolygonStamped result_polygon;
-  result_polygon.header = header_;
-  for (size_t i = 0; i < array_ptr->polygon.points.size(); i++) {
-    geometry_msgs::Point32 p = array_ptr->polygon.points[i];
-    float rx, ry, rz;
-    bool ret = extract_point (pts_, p.x, p.y, rx, ry, rz);
-    if (!ret) {
-      NODELET_ERROR("Failed to project point");
-      return;
-    }
-    geometry_msgs::Point32 p_projected;
-    p_projected.x = rx;
-    p_projected.y = ry;
-    p_projected.z = rz;
-    result_polygon.polygon.points.push_back(p_projected);
-  }
-  pub_polygon_.publish(result_polygon);
-}
-
-void jsk_pcl_ros::PointcloudScreenpoint::callback_poly(const sensor_msgs::PointCloud2ConstPtr& points_ptr,
-                                                       const geometry_msgs::PolygonStampedConstPtr& array_ptr) {
-  poly_cb(array_ptr);
-}
-
-
-
-void jsk_pcl_ros::PointcloudScreenpoint::callback_rect(const sensor_msgs::PointCloud2ConstPtr& points_ptr,
-                                                       const geometry_msgs::PolygonStampedConstPtr& array_ptr) {
-  if (array_ptr->polygon.points.size() > 1) {
-    int st_x = array_ptr->polygon.points[0].x;
-    int st_y = array_ptr->polygon.points[0].y;
-    int ed_x = array_ptr->polygon.points[1].x;
-    int ed_y = array_ptr->polygon.points[1].y;
-
-    rect_cb (array_ptr);
-
-    if (publish_points_) {
-      extract_rect (points_ptr, st_x, st_y, ed_x, ed_y);
-    }
-  }
-}
-
-PLUGINLIB_EXPORT_CLASS (jsk_pcl_ros::PointcloudScreenpoint, nodelet::Nodelet);
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS (jsk_pcl_ros::PointcloudScreenpoint, nodelet::Nodelet)

--- a/jsk_recognition_msgs/srv/TransformScreenpoint.srv
+++ b/jsk_recognition_msgs/srv/TransformScreenpoint.srv
@@ -1,6 +1,7 @@
 # screen point
 float32 x
 float32 y
+bool no_update
 ---
 # position in actual world
 std_msgs/Header header


### PR DESCRIPTION
rebased version of #2268

```
Rewrite version of pointcloud_screenpoint using connection_based_nodelet.
This PR includes:

 - Applied connection_based_nodelet that replaces the existing nodelet which always subscribe pointcloud that makes serious overhead
 - Support dynamic reconfigure for changing parameters dynamically
```