### PR TITLE
Refactor CMakeLists.txt and package.xml of jsk_perception

### DIFF
--- a/imagesift/CMakeLists.txt
+++ b/imagesift/CMakeLists.txt
@@ -17,7 +17,7 @@ catkin_package(
     CATKIN_DEPENDS roscpp sensor_msgs posedetection_msgs image_transport cv_bridge
     LIBRARIES ${PROJECT_NAME}
     INCLUDE_DIRS include
-    DEPENDS OpenCV libsiftfast
+    DEPENDS OpenCV
 )
 
 catkin_python_setup()
@@ -42,7 +42,6 @@ macro(jsk_feature detector extractor exec_name)
   if($ENV{ROS_DISTRO} STREQUAL "groovy" OR $ENV{ROS_DISTRO} STREQUAL "hydro")
     set_target_properties(${exec_name} PROPERTIES COMPILE_FLAGS "-DOPENCV_NON_FREE")
   endif()
-  add_dependencies(${exec_name} posedetection_msgs_generate_messages_cpp libsiftfast)
 endmacro(jsk_feature detector extractor exec_name)
 
 message(STATUS "OpenCV_VERSION: ${OpenCV_VERSION}")
@@ -68,7 +67,6 @@ add_library(${PROJECT_NAME} SHARED ${nodelet_sources})
 add_definitions("-O2 -g")
 include_directories(include ${catkin_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${OpenCV_LIBS})
-add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
 
 
 install(TARGETS ${PROJECT_NAME} ${jsk_exec}

--- a/imagesift/package.xml
+++ b/imagesift/package.xml
@@ -22,6 +22,7 @@
   <build_depend>posedetection_msgs</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>jsk_recognition_utils</build_depend>
+  <build_depend>jsk_topic_tools</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>libsiftfast</build_depend>
   <build_depend>nodelet</build_depend>
@@ -34,6 +35,8 @@
   <run_depend>cv_bridge</run_depend>
   <run_depend>libsiftfast</run_depend>
   <run_depend>nodelet</run_depend>
+
+  <test_depend>rostest</test_depend>
 
   <export>
     <nodelet plugin="${prefix}/nodelet.xml"/>


### PR DESCRIPTION
To suppress following warnings:

**With catkin build**

```
Warnings   << imagesift:cmake /root/catkin_ws/logs/imagesift/build.cmake.000.log
CMake Warning at /opt/ros/kinetic/share/catkin/cmake/catkin_package.cmake:166 (message):
  catkin_package() DEPENDS on 'libsiftfast' but neither
  'libsiftfast_INCLUDE_DIRS' nor 'libsiftfast_LIBRARIES' is defined.
Call Stack (most recent call first):
  /opt/ros/kinetic/share/catkin/cmake/catkin_package.cmake:102 (_catkin_package)
  CMakeLists.txt:16 (catkin_package)

CMake Warning (dev) at CMakeLists.txt:71 (add_dependencies):
  Policy CMP0046 is not set: Error on non-existent dependency in
  add_dependencies.  Run "cmake --help-policy CMP0046" for policy details.
  Use the cmake_policy command to set the policy and suppress this warning.

  The dependency target "imagesift_gencfg" of target "imagesift" does not
  exist.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at CMakeLists.txt:45 (add_dependencies):
  Policy CMP0046 is not set: Error on non-existent dependency in
  add_dependencies.  Run "cmake --help-policy CMP0046" for policy details.
  Use the cmake_policy command to set the policy and suppress this warning.

  The dependency target "libsiftfast" of target "imagebrisk" does not exist.
Call Stack (most recent call first):
  CMakeLists.txt:56 (jsk_feature)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

**With catkin lint**

Before

```
% catkin lint .
imagesift: error: missing build_depend on 'rostest'
imagesift: error: missing build_depend on 'jsk_topic_tools'
imagesift: error: unconfigured build_depend on 'libsiftfast'
imagesift: error: installed target 'imagesift_exec' is not defined
imagesift: CMakeLists.txt(16): error: catkin_package() lists 'libsiftfast' as system package but it is not
imagesift: CMakeLists.txt(25): error: variable ENV{PKG_CONFIG_PATH} is modified
imagesift: CMakeLists.txt(40): error: add_executable() needs missing file 'src/imagesurf.cpp'
imagesift: CMakeLists.txt(40): error: add_executable() needs missing file 'src/imagestar.cpp'
imagesift: CMakeLists.txt(40): error: add_executable() needs missing file 'src/imagesift_surf.cpp'
imagesift: CMakeLists.txt(40): error: add_executable() needs missing file 'src/imagesift_sift.cpp'
imagesift: CMakeLists.txt(40): error: add_executable() needs missing file 'src/imageorb.cpp'
imagesift: CMakeLists.txt(40): error: add_executable() needs missing file 'src/imagebrisk.cpp'
imagesift: CMakeLists.txt(91): error: missing test_depend on 'rostest'
imagesift: warning: file 'setup.py' is executable but not installed
imagesift: CMakeLists.txt(25): warning: environment variables should not be used
imagesift: CMakeLists.txt(30): warning: use of link_directories() is strongly discouraged
imagesift: CMakeLists.txt(42): warning: environment variables should not be used
imagesift: CMakeLists.txt(42): warning: environment variables should not be used
imagesift: CMakeLists.txt(42): warning: environment variables should not be used
imagesift: CMakeLists.txt(42): warning: environment variables should not be used
imagesift: CMakeLists.txt(42): warning: environment variables should not be used
imagesift: CMakeLists.txt(42): warning: environment variables should not be used
imagesift: CMakeLists.txt(88): warning: environment variables should not be used
catkin_lint: checked 1 packages and found 23 problems
catkin_lint: 26 notices have been ignored. Use -W2 to see them
```

After

```
% catkin lint .
imagesift: error: unconfigured build_depend on 'libsiftfast'
imagesift: error: installed target 'imagesift_exec' is not defined
imagesift: CMakeLists.txt(25): error: variable ENV{PKG_CONFIG_PATH} is modified
imagesift: CMakeLists.txt(40): error: add_executable() needs missing file 'src/imagesurf.cpp'
imagesift: CMakeLists.txt(40): error: add_executable() needs missing file 'src/imagestar.cpp'
imagesift: CMakeLists.txt(40): error: add_executable() needs missing file 'src/imagesift_surf.cpp'
imagesift: CMakeLists.txt(40): error: add_executable() needs missing file 'src/imagesift_sift.cpp'
imagesift: CMakeLists.txt(40): error: add_executable() needs missing file 'src/imageorb.cpp'
imagesift: CMakeLists.txt(40): error: add_executable() needs missing file 'src/imagebrisk.cpp'
imagesift: warning: file 'setup.py' is executable but not installed
imagesift: CMakeLists.txt(25): warning: environment variables should not be used
imagesift: CMakeLists.txt(30): warning: use of link_directories() is strongly discouraged
imagesift: CMakeLists.txt(42): warning: environment variables should not be used
imagesift: CMakeLists.txt(42): warning: environment variables should not be used
imagesift: CMakeLists.txt(42): warning: environment variables should not be used
imagesift: CMakeLists.txt(42): warning: environment variables should not be used
imagesift: CMakeLists.txt(42): warning: environment variables should not be used
imagesift: CMakeLists.txt(42): warning: environment variables should not be used
imagesift: CMakeLists.txt(86): warning: environment variables should not be used
catkin_lint: checked 1 packages and found 19 problems
catkin_lint: 26 notices have been ignored. Use -W2 to see them
```