### PR TITLE
Fix for AssertionError in fast_rcnn.py

### DIFF
--- a/jsk_perception/launch/fast_rcnn.launch
+++ b/jsk_perception/launch/fast_rcnn.launch
@@ -2,6 +2,7 @@
 
   <arg name="INPUT_IMAGE" />
   <arg name="MODEL" />
+  <arg name="GPU" default="0" />
 
   <node name="selective_search"
         pkg="jsk_perception" type="selective_search.py">
@@ -14,6 +15,7 @@
     <remap from="~input/rect_array" to="selective_search/output" />
     <rosparam subst_value="true">
       model: $(arg MODEL)
+      gpu: $(arg GPU)
     </rosparam>
   </node>
 

--- a/jsk_perception/node_scripts/fast_rcnn.py
+++ b/jsk_perception/node_scripts/fast_rcnn.py
@@ -174,10 +174,6 @@ def main():
         rospy.logerr('Unspecified rosparam: {0}'.format(e))
         sys.exit(1)
 
-    # FIXME: In CPU mode, there is no detections.
-    if not cuda.available:
-        rospy.logfatal('CUDA environment is required.')
-        sys.exit(1)
     gpu = rospy.get_param('~gpu', -1)
     use_gpu = True if gpu >= 0 else False
 

--- a/jsk_perception/node_scripts/fast_rcnn.py
+++ b/jsk_perception/node_scripts/fast_rcnn.py
@@ -151,13 +151,14 @@ class FastRCNN(ConnectionBasedTransport):
             x = Variable(x_data, volatile=True)
             rects_val = Variable(rects, volatile=True)
             self.model.train = False
+            cls_score, bbox_pred = self.model(x, rects_val)
         else:
             with chainer.using_config('train', False), \
                  chainer.no_backprop_mode():
                 x = Variable(x_data)
                 rects_val = Variable(rects)
+                cls_score, bbox_pred = self.model(x, rects_val)
 
-        cls_score, bbox_pred = self.model(x, rects_val)
         scores = cuda.to_cpu(cls_score.data)
         bbox_pred = cuda.to_cpu(bbox_pred.data)
         return scores, bbox_pred

--- a/jsk_perception/node_scripts/fast_rcnn.py
+++ b/jsk_perception/node_scripts/fast_rcnn.py
@@ -178,7 +178,8 @@ def main():
     if not cuda.available:
         rospy.logfatal('CUDA environment is required.')
         sys.exit(1)
-    use_gpu = True
+    gpu = rospy.get_param('~gpu', -1)
+    use_gpu = True if gpu >= 0 else False
 
     # setup model
     PKG = 'jsk_perception'
@@ -196,7 +197,7 @@ def main():
     rospy.loginfo('Loading chainermodel')
     S.load_hdf5(chainermodel, model)
     if use_gpu:
-        model.to_gpu()
+        model.to_gpu(gpu)
     rospy.loginfo('Finished loading chainermodel')
 
     # assumptions

--- a/jsk_perception/sample/sample_fast_rcnn.launch
+++ b/jsk_perception/sample/sample_fast_rcnn.launch
@@ -1,5 +1,7 @@
 <launch>
   <arg name="model" default="vgg_cnn_m_1024" />
+  <arg name="gui" default="true" />
+  <arg name="gpu" default="0" />
 
   <node name="image_publisher"
         pkg="jsk_perception" type="image_publisher.py">
@@ -13,6 +15,7 @@
   <include file="$(find jsk_perception)/launch/fast_rcnn.launch">
     <arg name="INPUT_IMAGE" value="image_publisher/output" />
     <arg name="MODEL" value="$(arg model)" />
+    <arg name="GPU" value="$(arg gpu)" />
   </include>
 
   <node name="draw_rects" pkg="jsk_perception" type="draw_rects"
@@ -25,9 +28,11 @@
     </rosparam>
   </node>
 
-  <node name="image_view"
-        pkg="image_view" type="image_view">
-    <remap from="image" to="draw_rects/output" />
-  </node>
+  <group if="$(arg gui)">
+    <node name="image_view"
+          pkg="image_view" type="image_view">
+      <remap from="image" to="draw_rects/output" />
+    </node>
+  </group>
 
 </launch>

--- a/jsk_recognition_utils/python/jsk_recognition_utils/chainermodels/vgg16_fast_rcnn.py
+++ b/jsk_recognition_utils/python/jsk_recognition_utils/chainermodels/vgg16_fast_rcnn.py
@@ -2,8 +2,6 @@ import chainer
 import chainer.functions as F
 import chainer.links as L
 
-from roi_pooling_2d import roi_pooling_2d
-
 
 class VGG16FastRCNN(chainer.Chain):
 
@@ -55,7 +53,7 @@ class VGG16FastRCNN(chainer.Chain):
         h = F.relu(self.conv5_1(h))
         h = F.relu(self.conv5_2(h))
         h = F.relu(self.conv5_3(h))
-        h = roi_pooling_2d(h, rois, 7, 7, spatial_scale=0.0625)
+        h = F.roi_pooling_2d(h, rois, 7, 7, spatial_scale=0.0625)
 
         h = F.dropout(F.relu(self.fc6(h)), ratio=0.5)
         h = F.dropout(F.relu(self.fc7(h)), ratio=0.5)

--- a/jsk_recognition_utils/python/jsk_recognition_utils/chainermodels/vgg_cnn_m_1024.py
+++ b/jsk_recognition_utils/python/jsk_recognition_utils/chainermodels/vgg_cnn_m_1024.py
@@ -5,8 +5,6 @@ import chainer.links as L
 from chainer import Variable
 from distutils.version import LooseVersion
 
-from roi_pooling_2d import roi_pooling_2d
-
 
 class VGG_CNN_M_1024(chainer.Chain):
 
@@ -45,7 +43,7 @@ class VGG_CNN_M_1024(chainer.Chain):
         h = self.conv5(h)
         h = F.relu(h)
 
-        h = roi_pooling_2d(h, rois, 6, 6, spatial_scale=0.0625)
+        h = F.roi_pooling_2d(h, rois, 6, 6, spatial_scale=0.0625)
 
         h = self.fc6(h)
         h = F.relu(h)


### PR DESCRIPTION
When executing `roslaunch jsk_perception sample_fast_rcnn.launch`, I encountered the following error messages.
This PR will fix this problem.
```
[ERROR] [WallTime: 1524824331.872704] bad callback: <bound method Subscriber.callback of <message_filters.Subscriber object at 0x7f0a3a6bb6d0>>
Traceback (most recent call last):
  File "/opt/ros/indigo/lib/python2.7/dist-packages/rospy/topics.py", line 720, in _invoke_callback
    cb(msg)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/message_filters/__init__.py", line 74, in callback
    self.signalMessage(msg)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/message_filters/__init__.py", line 56, in signalMessage
    cb(*(msg + args))
  File "/opt/ros/indigo/lib/python2.7/dist-packages/message_filters/__init__.py", line 199, in add
    self.signalMessage(*msgs)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/message_filters/__init__.py", line 56, in signalMessage
    cb(*(msg + args))
  File "/home/yuto/Projects/catkin_virtualenv_ws/src/jsk-ros-pkg/jsk_recognition/jsk_perception/node_scripts/fast_rcnn.py", line 92, in _detect
    scores, bbox_pred = self._im_detect(im, rects)
  File "/home/yuto/Projects/catkin_virtualenv_ws/src/jsk-ros-pkg/jsk_recognition/jsk_perception/node_scripts/fast_rcnn.py", line 160, in _im_detect
    cls_score, bbox_pred = self.model(x, rects_val)
  File "/home/yuto/Projects/catkin_virtualenv_ws/src/jsk-ros-pkg/jsk_recognition/jsk_recognition_utils/python/jsk_recognition_utils/chainermodels/vgg_cnn_m_1024.py", line 63, in __call__
    assert not chainer.config.train
AssertionError
```