### PR TITLE
Modified Docomentation on ClusterPointIndicesDecomposer

### DIFF
--- a/doc/jsk_pcl_ros/nodes/cluster_point_indices_decomposer.md
+++ b/doc/jsk_pcl_ros/nodes/cluster_point_indices_decomposer.md
@@ -76,7 +76,9 @@ It also publishes tf of centroids of each cluster and oriented bounding box of t
    Toggle `~output%02d` topics.
 
 * `~align_boxes` (Boolean, default: `False`):
-* `~align_boxes_with_plane` (Boolean, default: `True`):
+
+  * `~align_boxes_with_plane` (Boolean, default: `True`):
+    * Is enabled only if `~align_boxes` is `True`.
 
   * If `~align_boxes` is `True` and `~align_boxes_with_plane` is `True`:
     * Topics `~align_planes` and `~align_planes_coefficients` are enabled.


### PR DESCRIPTION
Add description on parameter `~align_boxes_with_plane` in `cluster_point_indices_decomposer`.
Clarified the relationship between   `~align_boxes_with_plane` and `~align_boxes`.

CC. @mmurooka @708yamaguchi 