### PR TITLE
Fix warnings of checkerboard_detector

### DIFF
--- a/checkerboard_detector/CMakeLists.txt
+++ b/checkerboard_detector/CMakeLists.txt
@@ -35,12 +35,6 @@ add_executable(objectdetection_transform_echo src/objectdetection_transform_echo
 target_link_libraries(objectdetection_transform_echo ${catkin_LIBRARIES})
 add_executable(checkerboard_calibration src/checkerboard_calibration.cpp)
 target_link_libraries(checkerboard_calibration ${catkin_LIBRARIES})
-add_dependencies(checkerboard_detector    posedetection_msgs_gencpp)
-add_dependencies(checkerboard_calibration posedetection_msgs_gencpp)
-add_dependencies(objectdetection_transform_echo posedetection_msgs_gencpp)
-add_dependencies(checkerboard_detector    jsk_recognition_msgs_gencpp)
-add_dependencies(checkerboard_calibration jsk_recognition_msgs_gencpp)
-add_dependencies(objectdetection_transform_echo jsk_recognition_msgs_gencpp)
 add_dependencies(checkerboard_detector ${PROJECT_NAME}_gencfg)
 
 install(TARGETS checkerboard_detector checkerboard_calibration


### PR DESCRIPTION
Close https://github.com/jsk-ros-pkg/jsk_recognition/issues/2289

Upstream package's message generation dependency is not required