### PR TITLE
add --download-dir option to install_sample_data.py, so that we can s…

### DIFF
--- a/jsk_pcl_ros_utils/CMakeLists.txt
+++ b/jsk_pcl_ros_utils/CMakeLists.txt
@@ -65,7 +65,7 @@ ENDIF()
 # ------------------------------------------------------------------------------------
 
 # download and install sample data
-add_custom_target(install_sample_data ALL COMMAND ${PROJECT_SOURCE_DIR}/scripts/install_sample_data.py)
+add_custom_target(install_sample_data ALL COMMAND ${PROJECT_SOURCE_DIR}/scripts/install_sample_data.py --download-dir ${PROJECT_SOURCE_DIR})
 
 # generate the dynamic_reconfigure config file
 generate_dynamic_reconfigure_options(

--- a/jsk_pcl_ros_utils/scripts/install_sample_data.py
+++ b/jsk_pcl_ros_utils/scripts/install_sample_data.py
@@ -1,35 +1,45 @@
 #!/usr/bin/env python
 
 from jsk_data import download_data
+import os, argparse
 
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--download-dir', dest='download_dir', type=str,
+                        help='root directory to store download data')
+    args = parser.parse_args();
+    if args.download_dir :
+        download_base_dir = args.download_dir + '/'
+    else:
+        download_base_dir = ''
+        print(args)
     PKG = 'jsk_pcl_ros_utils'
 
     download_data(
         pkg_name=PKG,
-        path='sample/data/2017-02-05-16-11-09_shelf_bin.bag',
+        path=download_base_dir+'sample/data/2017-02-05-16-11-09_shelf_bin.bag',
         url='https://drive.google.com/uc?id=0B9P1L--7Wd2vYWI2NnZrekEwSmc',
         md5='44427634f57ac76111edabd7b1f4e140',
     )
 
     download_data(
         pkg_name=PKG,
-        path='sample/data/bunny_marker_array.bag',
+        path=download_base_dir+'sample/data/bunny_marker_array.bag',
         url='https://drive.google.com/uc?id=0B9P1L--7Wd2vdW1NMlhiRU9KZDQ',
         md5='e7dc29d21bdd30c769396c361e4350fd',
     )
 
     download_data(
         pkg_name=PKG,
-        path='sample/data/bunny.pcd',
+        path=download_base_dir+'sample/data/bunny.pcd',
         url='https://raw.githubusercontent.com/PointCloudLibrary/pcl/pcl-1.8.0/test/bunny.pcd',
         md5='a4e58778ba12d3f26304127f6be82897',
     )
 
     download_data(
         pkg_name=PKG,
-        path='sample/data/arc2017_4objects.bag',
+        path=download_base_dir+'sample/data/arc2017_4objects.bag',
         url='https://drive.google.com/uc?id=0B9P1L--7Wd2vakpvU0wtMFNCTkk',
         md5='2c3af4482cd2e0ee95b58848ae48afaf',
     )


### PR DESCRIPTION
…pecify the root direcoty for download sample data

when we use 'catkin_make' . I think this will not happen when we use 'catkin build', but in theory, I think when we run 'catkin_make',( i.e. `cmake' and `make`), we should not assume `ROS_PACKAGE_PATH`, (and `rospack find`), they should work as 'pure' cmake program, so need to use `PROJECT_SOURCE_DIR` instead of `rospack find`.

cc: @sanketrahul
```
[jsk_pcl_ros_utils:make] [/home/k-okada/.ros/data/jsk_pcl_ros_utils/2017-02-05-16-11-09_shelf_bin.bag] Checking md5sum (44427634f57ac76111edabd7b1f4e140)
[build] Interrupted by user!                                                   
[build] Summary: 0 of 1 packages succeeded.                                    
[build]   Ignored:   1 packages were skipped or are blacklisted.               
[build]   Warnings:  1 packages succeeded with warnings.                       
[build]   Abandoned: 1 packages were abandoned.                                
[build]   Failed:    None.                                                     
[build] Runtime: 7.5 seconds total.                                            
k-okada@p51s:/tmp/fuga/src/jsk_pcl_ros_utils$ (cd ../../build/jsk_pcl_ros_utils/; make install_sample_data)
cache_file= /home/k-okada/.ros/data/jsk_pcl_ros_utils/2017-02-05-16-11-09_shelf_bin.bag
[/home/k-okada/.ros/data/jsk_pcl_ros_utils/2017-02-05-16-11-09_shelf_bin.bag] Checking md5sum (44427634f57ac76111edabd7b1f4e140)
[/home/k-okada/.ros/data/jsk_pcl_ros_utils/2017-02-05-16-11-09_shelf_bin.bag] Finished checking md5sum
path= /opt/ros/kinetic/share/jsk_pcl_ros_utils/sample/data/2017-02-05-16-11-09_shelf_bin.bag
Traceback (most recent call last):
  File "/tmp/fuga/src/jsk_pcl_ros_utils/scripts/install_sample_data.py", line 39, in <module>
    main()
  File "/tmp/fuga/src/jsk_pcl_ros_utils/scripts/install_sample_data.py", line 13, in main
    md5='44427634f57ac76111edabd7b1f4e140',
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/jsk_data/download_data.py", line 171, in download_data
    os.symlink(cache_file, path)  # create link
OSError: [Errno 13] Permission denied
CMakeFiles/install_sample_data.dir/build.make:57: recipe for target 'CMakeFiles/install_sample_data' failed
```