### PR TITLE
kinfu.h depends on jsk_rviz_plugins

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -27,6 +27,7 @@ find_package(catkin REQUIRED COMPONENTS
   jsk_pcl_ros_utils
   # jsk_recognition_msgs
   jsk_recognition_utils
+  jsk_rviz_plugins # kinfu.h uses jsk_rviz_plugins/OverlayText.h
   jsk_topic_tools
   # kdl_conversions
   # kdl_parser

--- a/jsk_pcl_ros/package.xml
+++ b/jsk_pcl_ros/package.xml
@@ -23,6 +23,7 @@
   <build_depend>jsk_data</build_depend>
   <build_depend>jsk_pcl_ros_utils</build_depend>
   <build_depend>jsk_recognition_utils</build_depend>
+  <build_depend>jsk_rviz_plugins</build_depend>
   <build_depend version_gte="2.2.7">jsk_topic_tools</build_depend>
   <build_depend>laser_assembler</build_depend>
   <build_depend>moveit_ros_perception</build_depend>
@@ -48,6 +49,7 @@
   <run_depend>jsk_data</run_depend>
   <run_depend>jsk_footstep_msgs</run_depend>
   <run_depend>jsk_pcl_ros_utils</run_depend>
+  <run_depend>jsk_rviz_plugins</run_depend>
   <run_depend>jsk_recognition_msgs</run_depend>
   <run_depend>jsk_recognition_utils</run_depend>
   <run_depend version_gte="2.2.7">jsk_topic_tools</run_depend>


### PR DESCRIPTION
if you have `jsk_visualization` repository in same workspace, it fails as https://gist.github.com/5d108c9845887fbd1b73a940fab03dd2


so we need to add `jsk_rviz_plugins` to depends.

Cc: @sanketrahul

