### PR TITLE
[resized_image_transport] Changed diagnostic error level

### DIFF
--- a/resized_image_transport/src/image_processing_nodelet.cpp
+++ b/resized_image_transport/src/image_processing_nodelet.cpp
@@ -172,13 +172,13 @@ namespace resized_image_transport
     stat.add("output image", pnh_->resolveName("output/image"));
     // summary
     if (!image_vital_->isAlive()) {
-      stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR,
+      stat.summary(diagnostic_error_level_,
                    "no image input. Is " + pnh_->resolveName("input/image") + " active?");
     }
     else {
       if (use_camera_info_) {
         if (!info_vital_->isAlive()) {
-          stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR,
+          stat.summary(diagnostic_error_level_,
                        "no info input. Is " + camera_info_sub_.getTopic() + " active?");
         }
         else {


### PR DESCRIPTION
In this [PR](https://github.com/jsk-ros-pkg/jsk_common/pull/1585),
diagnostics nodelet's warn level are changable by user.

image_processing_nodelet's warn level is always ERROR.
Applying this PR, we can change the warn level by ```use_warn``` option.
