### PR TITLE
Fix typos

### DIFF
--- a/doc/jsk_pcl_ros_utils/nodes/polygon_array_likelihood_filter.rst
+++ b/doc/jsk_pcl_ros_utils/nodes/polygon_array_likelihood_filter.rst
@@ -22,7 +22,7 @@ Subscribing Topics
 Publishing Topics
 -----------------
 
-* ``~output_polygon`` (``jsk_recognition_msgs/PolygonArray``)
+* ``~output_polygons`` (``jsk_recognition_msgs/PolygonArray``)
 
   Filtered polygon array. (Polygons are sorted by their likelihood.)
 

--- a/doc/jsk_recognition_utils/nodes/polygon_array_to_polygon.md
+++ b/doc/jsk_recognition_utils/nodes/polygon_array_to_polygon.md
@@ -2,12 +2,12 @@
 
 ## What is this?
 
-Convert `geometry_msgs/PolygonArray` to `geometry_msgs/PolygonStamped`.
+Convert `jsk_recognition_msgs/PolygonArray` to `geometry_msgs/PolygonStamped`.
 
 
 ## Subscribing Topic
 
-* `~input` (`geometry_msgs/PolygonArray`)
+* `~input` (`jsk_recognition_msgs/PolygonArray`)
 
   Input polygon array.
 

--- a/jsk_pcl_ros/cfg/OrganizedMultiPlaneSegmentation.cfg
+++ b/jsk_pcl_ros/cfg/OrganizedMultiPlaneSegmentation.cfg
@@ -13,7 +13,7 @@ gen.add("distance_threshold", double_t, 0, "distance threshold of organized plan
 gen.add("angular_threshold", double_t, 0, "angular threshold of organized plane segmentation", 0.05, 0, 0.1)
 gen.add("max_curvature", double_t, 0, "maximum curvature of organized plane segmentation", 0.001, 0, 10.0)
 gen.add("connect_plane_angle_threshold", double_t, 0, "plane angle threshold of connecting the planes", 0.2, 0, pi)
-gen.add("connect_distance_threshold", double_t, 0, "distance threshold of connectin the planes", 0.01, 0, 1.0)
+gen.add("connect_distance_threshold", double_t, 0, "distance threshold of connecting the planes", 0.01, 0, 1.0)
 estimation_method_enum = gen.enum([gen.const("AVERAGE_3D_GRADIENT", int_t, 0, "AVERAGE 3D GRADIENT, no curvature is available"),
                                    gen.const("COVARIANCE_MATRIX", int_t, 1, "COVARIANCE_MATRIX, curvature is available"),
                                    gen.const("AVERAGE_DEPTH_CHANGE", int_t, 2, "AVERAGE_DEPTH_CHANGE, no curvature is available")],


### PR DESCRIPTION
- Fix topic name `~output_polygon` -> `~output_polygons` in doc of `polygon_array_likelihood_filter`
https://github.com/jsk-ros-pkg/jsk_recognition/blob/1.2.5/jsk_pcl_ros_utils/src/polygon_array_likelihood_filter_nodelet.cpp#L51
- Fix typo `connectin` -> `connecting` in dynamic reconfigure cfg of `OrganizedMultiPlaneSegmentation`