### PR TITLE
Fix default of force_to_flip_z_axis in doc

### DIFF
--- a/doc/jsk_pcl_ros/nodes/cluster_point_indices_decomposer.md
+++ b/doc/jsk_pcl_ros/nodes/cluster_point_indices_decomposer.md
@@ -91,7 +91,7 @@ It also publishes tf of centroids of each cluster and oriented bounding box of t
 
    Run PCA algorithm on each cluster to estimate x and y direction.
 
-* `~force_to_flip_z_axis` (Boolean, default: `False`)
+* `~force_to_flip_z_axis` (Boolean, default: `True`)
 
    Flip z axis direction if this value is true.
 


### PR DESCRIPTION
Default value of force_to_flip_z_axis in `ClusterPointIndicesDecomposer` is true.
https://github.com/jsk-ros-pkg/jsk_recognition/blob/1.2.5/jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp#L101