### PR TITLE
[jsk_pcl_ros/package.xml] Add checkerborad_detecotr's dependency

### DIFF
--- a/jsk_pcl_ros/package.xml
+++ b/jsk_pcl_ros/package.xml
@@ -34,6 +34,7 @@
   <build_depend>yaml-cpp</build_depend>
 
   <run_depend>boost</run_depend>
+  <run_depend>checkerboard_detector</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>diagnostic_msgs</run_depend>


### PR DESCRIPTION
There is a dependency of checkerboard detector.
https://github.com/jsk-ros-pkg/jsk_recognition/blob/master/jsk_pcl_ros/launch/depth_error.launch#L21
https://github.com/jsk-ros-pkg/jsk_recognition/blob/master/jsk_pcl_ros/launch/pr2_pointcloud_error_visualization.launch#L10
https://github.com/jsk-ros-pkg/jsk_recognition/blob/master/jsk_pcl_ros/launch/capture/capture_multisense.launch#L3