### PR TITLE
[jsk_pcl_ros] Delete subclass's updateDiagnostic method

### DIFF
--- a/jsk_pcl_ros/include/jsk_pcl_ros/depth_calibration.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/depth_calibration.h
@@ -68,8 +68,6 @@ namespace jsk_pcl_ros
     virtual void subscribe();
     virtual void unsubscribe();
     virtual void printModel();
-    virtual void updateDiagnostic(
-      diagnostic_updater::DiagnosticStatusWrapper &stat);
     virtual inline double applyModel(double z, int u, int v, double cu, double cv) {
       double z2 = z * z;
       double uu, vv;

--- a/jsk_pcl_ros/include/jsk_pcl_ros/line_segment_collector.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/line_segment_collector.h
@@ -128,8 +128,6 @@ namespace jsk_pcl_ros
       const jsk_recognition_msgs::ModelCoefficientsArray::ConstPtr& coefficients_msg);
     virtual void subscribe();
     virtual void unsubscribe();
-    virtual void updateDiagnostic(
-      diagnostic_updater::DiagnosticStatusWrapper &stat);
     virtual void triggerCallback(
       const jsk_recognition_msgs::TimeRange::ConstPtr& trigger);
     virtual void cleanupBuffers(

--- a/jsk_pcl_ros/include/jsk_pcl_ros/line_segment_detector.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/line_segment_detector.h
@@ -112,8 +112,6 @@ namespace jsk_pcl_ros
     ////////////////////////////////////////////////////////
     virtual void subscribe();
     virtual void unsubscribe();
-    virtual void updateDiagnostic(
-      diagnostic_updater::DiagnosticStatusWrapper &stat);
     virtual void onInit();
     virtual void segment(const sensor_msgs::PointCloud2::ConstPtr& cloud_msg,
                          const jsk_recognition_msgs::ClusterPointIndices::ConstPtr& cluster_msg);

--- a/jsk_pcl_ros/src/depth_calibration_nodelet.cpp
+++ b/jsk_pcl_ros/src/depth_calibration_nodelet.cpp
@@ -155,11 +155,6 @@ namespace jsk_pcl_ros
     pub_.publish(ros_image);
   }
 
-  void DepthCalibration::updateDiagnostic(
-      diagnostic_updater::DiagnosticStatusWrapper &stat)
-  {
-  }
-
 }
 #include <pluginlib/class_list_macros.h>
 PLUGINLIB_EXPORT_CLASS (jsk_pcl_ros::DepthCalibration,

--- a/jsk_pcl_ros/src/line_segment_collector_nodelet.cpp
+++ b/jsk_pcl_ros/src/line_segment_collector_nodelet.cpp
@@ -194,12 +194,6 @@ namespace jsk_pcl_ros
     sub_coefficients_.unsubscribe();
     sub_trigger_.shutdown();
   }
-  
-  void LineSegmentCollector::updateDiagnostic(
-    diagnostic_updater::DiagnosticStatusWrapper &stat)
-  {
-
-  }
 
   void LineSegmentCollector::cleanupBuffers(
       const ros::Time& stamp)

--- a/jsk_pcl_ros/src/line_segment_detector_nodelet.cpp
+++ b/jsk_pcl_ros/src/line_segment_detector_nodelet.cpp
@@ -200,11 +200,6 @@ namespace jsk_pcl_ros
     sub_indices_.unsubscribe();
   }
 
-  void LineSegmentDetector::updateDiagnostic(
-    diagnostic_updater::DiagnosticStatusWrapper &stat)
-  {
-  }
-
   void LineSegmentDetector::publishResult(
     const std_msgs::Header& header,
     const pcl::PointCloud<PointT>::Ptr& cloud,


### PR DESCRIPTION
In jsk_pcl_ros, depth_calibration_nodelet, line_segment_detector_nodelet and line_segment_collector_nodelet are not updating diagnostics. 
Before this PR, they output error of diagnostics with "No message was set" message and
we can not change the error level.
Like this

![image](https://user-images.githubusercontent.com/4690682/44565933-ba30c180-a7a5-11e8-849f-6d04efe45e0c.png)

After this PR, we can change the error level.

![image](https://user-images.githubusercontent.com/4690682/44565992-ffed8a00-a7a5-11e8-91b5-1059c75e4200.png)

