### PR TITLE
[jsk_pcl_ros/cluster_point_indices_decomposer] Modified publishNegativeIndices to make it fast

### DIFF
--- a/jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
+++ b/jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
@@ -566,19 +566,19 @@ namespace jsk_pcl_ros
     const sensor_msgs::PointCloud2ConstPtr &input,
     const jsk_recognition_msgs::ClusterPointIndicesConstPtr &indices_input)
   {
-    std::set<int> all_indices;
+    std::vector<int> all_indices;
+
     boost::copy(
       boost::irange(0, (int)(input->width * input->height)),
       std::inserter(all_indices, all_indices.begin()));
+
     for (size_t i = 0; i < indices_input->cluster_indices.size(); i++) {
-      std::set<int> indices_set(indices_input->cluster_indices[i].indices.begin(),
-                                indices_input->cluster_indices[i].indices.end());
-      std::set<int> diff_indices;
-      std::set_difference(all_indices.begin(), all_indices.end(),
-                          indices_set.begin(), indices_set.end(),
-                          std::inserter(diff_indices, diff_indices.begin()));
-      all_indices = diff_indices;
+      for (size_t j = 0; j < indices_input->cluster_indices[i].indices.size(); ++j) {
+        all_indices[indices_input->cluster_indices[i].indices[j]] = -1;
+      }
     }
+    all_indices.erase(std::remove(all_indices.begin(), all_indices.end(), -1), all_indices.end());
+
     // publish all_indices
     pcl_msgs::PointIndices ros_indices;
     ros_indices.indices = std::vector<int>(all_indices.begin(), all_indices.end());

--- a/jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
+++ b/jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
@@ -566,6 +566,9 @@ namespace jsk_pcl_ros
     const sensor_msgs::PointCloud2ConstPtr &input,
     const jsk_recognition_msgs::ClusterPointIndicesConstPtr &indices_input)
   {
+    if (negative_indices_pub_.getNumSubscribers() <= 0) {
+      return;
+    }
     std::vector<int> all_indices;
 
     boost::copy(


### PR DESCRIPTION
Related to #2325 

This PR modified ```publishNegativeIndices``` function to make it faster than current implementation
and add publish ```~/output/negative_indices``` when subscriber connected.