### PR TITLE
[jsk_perception/image_publisher.py] Add fov parameter for publishing valid camera info parameters

### DIFF
--- a/doc/jsk_perception/nodes/image_publisher.md
+++ b/doc/jsk_perception/nodes/image_publisher.md
@@ -24,7 +24,7 @@ Publish image from loaded file.
 * `~fovx` (Float default: `None`)
 * `~fovy` (Float default: `None`)
 
-  If `~publish_info` is `True` and `~fovx` and `~fovy` are specified,
+  If `~publish_info` is `True` and `~fovx`[degree] and `~fovy`[degree] are specified,
   calculate camera intrinsic parameter and publish it as a values of
   `~output/camera_info`.
 

--- a/doc/jsk_perception/nodes/image_publisher.md
+++ b/doc/jsk_perception/nodes/image_publisher.md
@@ -21,6 +21,13 @@ Publish image from loaded file.
 * `~frame_id` (str default: `camera`)
 * `~rate` (Float default: `1.0`)
 
+* `~fovx` (Float default: `None`)
+* `~fovy` (Float default: `None`)
+
+  If `publish_info` is `True` and `fovx` and `fovy` are specified,
+  calculate camera intrinsic parameter and publish it as a values of
+  `~output/camera_info`.
+
 ## Sample
 
 ```bash

--- a/doc/jsk_perception/nodes/image_publisher.md
+++ b/doc/jsk_perception/nodes/image_publisher.md
@@ -13,7 +13,7 @@ Publish image from loaded file.
 * `~file_name` (str default: `image.png`)
 
   full path to the file to be loaded
-* `publish_info` (bool default: `True`)
+* `~publish_info` (bool default: `True`)
 
   publish `~output/camera_info` if true
 

--- a/doc/jsk_perception/nodes/image_publisher.md
+++ b/doc/jsk_perception/nodes/image_publisher.md
@@ -24,7 +24,7 @@ Publish image from loaded file.
 * `~fovx` (Float default: `None`)
 * `~fovy` (Float default: `None`)
 
-  If `publish_info` is `True` and `fovx` and `fovy` are specified,
+  If `~publish_info` is `True` and `~fovx` and `~fovy` are specified,
   calculate camera intrinsic parameter and publish it as a values of
   `~output/camera_info`.
 

--- a/jsk_perception/node_scripts/image_publisher.py
+++ b/jsk_perception/node_scripts/image_publisher.py
@@ -25,6 +25,10 @@ class ImagePublisher(object):
         self.frame_id = rospy.get_param('~frame_id', 'camera')
         self.fovx = rospy.get_param('~fovx', None)
         self.fovy = rospy.get_param('~fovy', None)
+        if (self.fovx is None) != (self.fovy is None):
+            rospy.logwarn('fovx and fovy should be specified, but '
+                          'specified only {}'
+                          .format('fovx' if self.fovx else 'fovy'))
         dynamic_reconfigure.server.Server(
             ImagePublisherConfig, self._cb_dyn_reconfig)
         self.pub = rospy.Publisher('~output', Image, queue_size=1)

--- a/jsk_perception/sample/sample_image_publisher.launch
+++ b/jsk_perception/sample/sample_image_publisher.launch
@@ -11,6 +11,8 @@
       file_name: $(find jsk_perception)/sample/kiva_pod_image_color.jpg
       encoding: bgr8
       publish_info: true
+      fovx: 84.1
+      fovy: 53.8
     </rosparam>
   </node>
 
@@ -22,6 +24,8 @@
       file_name: $(find jsk_perception)/sample/kiva_pod_image_color.jpg
       encoding: rgb8
       publish_info: true
+      fovx: 84.1
+      fovy: 53.8
     </rosparam>
   </node>
 
@@ -33,6 +37,8 @@
       file_name: $(find jsk_perception)/sample/kiva_pod_mask.jpg
       encoding: mono8
       publish_info: true
+      fovx: 84.1
+      fovy: 53.8
     </rosparam>
   </node>
 
@@ -44,6 +50,8 @@
       file_name: $(find jsk_perception)/sample/kiva_pod_image_depth.jpg
       encoding: 16UC1
       publish_info: true
+      fovx: 84.1
+      fovy: 53.8
     </rosparam>
   </node>
 
@@ -55,6 +63,8 @@
       file_name: $(find jsk_perception)/sample/kiva_pod_image_depth.jpg
       encoding: 32FC1
       publish_info: true
+      fovx: 84.1
+      fovy: 53.8
     </rosparam>
   </node>
 
@@ -65,6 +75,8 @@
     <rosparam>
       publish_info: true
       always_subscribe: true
+      fovx: 84.1
+      fovy: 53.8
     </rosparam>
   </node>
 


### PR DESCRIPTION
I added a ```fov``` parameter (```fovx``` and ```fovy```) to  ```image_publisher.py``` .
In current ```image_publisher.py```publishes ```sensor_msgs/CameraInfo``` and its intrinsic parameters are zero values.
With this patch, we can calculate intrinsic parameter from ```fov```.

Below picture is rviz's image visualized by jsk_rviz_plugins' camera info.

![selection_034](https://user-images.githubusercontent.com/4690682/46571106-062c7400-c9aa-11e8-8d4a-29935eb44a47.png)
