### PR TITLE
[jsk_pcl_ros/multi_plane_extraction] Initialize viewpoint by zeros to avoid flip of surface normal direction

### DIFF
--- a/jsk_pcl_ros/src/multi_plane_extraction_nodelet.cpp
+++ b/jsk_pcl_ros/src/multi_plane_extraction_nodelet.cpp
@@ -239,7 +239,7 @@ namespace jsk_pcl_ros
     }
 
     // set viewpoint to determine normal axes of the planes
-    Eigen::Vector3f viewpoint;
+    Eigen::Vector3f viewpoint = Eigen::Vector3f::Zero();
     if (use_sensor_frame_) {
       try {
         tf::StampedTransform transform


### PR DESCRIPTION
Related to following issue and PR.
https://github.com/jsk-ros-pkg/jsk_recognition/issues/2186
https://github.com/jsk-ros-pkg/jsk_recognition/pull/2191

Without applying this patch, 
If ~use_sensor_frame and ~use_coefficients are false,  the z-axis of plane may be flipped on each detection. (reported a following comment https://github.com/jsk-ros-pkg/jsk_recognition/pull/2191#issuecomment-321966823)

This flipping is caused by no initialization of viewpoint. 
viewpoint was used for chaning viewpoint of  ```pcl::ExtractPolygonalPrismData<pcl::PointXYZRGB>```.
https://github.com/jsk-ros-pkg/jsk_recognition/blob/master/jsk_pcl_ros/src/multi_plane_extraction_nodelet.cpp#L310
pcl::ExtractPolygonalPrismData's default viewpoint is [0, 0, 0]. So this PR fixes the default behavior to match ExtractPolygonalPrismData's defautl behaviour.