### PR TITLE
[jsk_perception/sample_mask_rcnn] Fixed typo. fps -> rate

### DIFF
--- a/jsk_perception/sample/sample_mask_rcnn_instance_segmentation.launch
+++ b/jsk_perception/sample/sample_mask_rcnn_instance_segmentation.launch
@@ -8,7 +8,7 @@
         clear_params="true">
     <rosparam subst_value="true">
       file_name: $(find jsk_perception)/sample/object_detection_example_1.jpg
-      fps: 30
+      rate: 30
     </rosparam>
   </node>
   <arg name="INPUT_IMAGE" value="image_publisher/output" />


### PR DESCRIPTION
```fps```  is not in ``image_publisher.py``'s rosparam.