### PR TITLE
Correct md5 of install rosbag file

### DIFF
--- a/jsk_pcl_ros/scripts/install_sample_data.py
+++ b/jsk_pcl_ros/scripts/install_sample_data.py
@@ -30,7 +30,7 @@ def main():
     download_data(
         path='sample/data/2017-06-19-19-34-18_tabletop_coffeecup.tgz',
         url='https://drive.google.com/uc?id=0B5DV6gwLHtyJRTJ0eGdVYk43bEU',
-        md5='d58e894c853fc4485d08547b9fc2b640',
+        md5='58002c60761d192322413f799368ae88',
         extract=True,
     )
 


### PR DESCRIPTION
We could not download `2017-06-19-19-34-18_tabletop_coffeecup.tgz` by `install_sample_data.py`, because `md5` in `install_sample_data.py` was incorrect.
I fixed the `md5` in this Pull Request.