### PR TITLE
add pointcloud xyzi to xyz

### DIFF
--- a/jsk_pcl_ros_utils/CMakeLists.txt
+++ b/jsk_pcl_ros_utils/CMakeLists.txt
@@ -156,6 +156,8 @@ jsk_pcl_util_nodelet(src/pointcloud_xyz_to_xyzrgb_nodelet.cpp
   "jsk_pcl_utils/PointCloudXYZToXYZRGB" "pointcloud_xyz_to_xyzrgb")
 jsk_pcl_util_nodelet(src/pointcloud_xyzrgb_to_xyz_nodelet.cpp
   "jsk_pcl_utils/PointCloudXYZRGBToXYZ" "pointcloud_xyzrgb_to_xyz")
+jsk_pcl_util_nodelet(src/pointcloud_xyzi_to_xyz_nodelet.cpp
+  "jsk_pcl_utils/PointCloudXYZIToXYZ" "pointcloud_xyzi_to_xyz")
 jsk_pcl_util_nodelet(src/pointcloud_to_cluster_point_indices_nodelet.cpp
   "jsk_pcl_utils/PointCloudToClusterPointIndices" "pointcloud_to_cluster_point_indices")
 jsk_pcl_util_nodelet(src/pointcloud_to_mask_image_nodelet.cpp

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pointcloud_xyzi_to_xyz.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pointcloud_xyzi_to_xyz.h
@@ -1,0 +1,62 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#ifndef JSK_PCL_ROS_UTILS_POINTCLOUD_XYZI_TO_XYZ_H_
+#define JSK_PCL_ROS_UTILS_POINTCLOUD_XYZI_TO_XYZ_H_
+
+#include <jsk_topic_tools/diagnostic_nodelet.h>
+
+#include <sensor_msgs/PointCloud2.h>
+
+namespace jsk_pcl_ros_utils
+{
+
+class PointCloudXYZIToXYZ: public jsk_topic_tools::DiagnosticNodelet
+{
+public:
+  PointCloudXYZIToXYZ(): DiagnosticNodelet("PointCloudXYZIToXYZ") { }
+protected:
+  virtual void onInit();
+  virtual void subscribe();
+  virtual void unsubscribe();
+  virtual void convert(const sensor_msgs::PointCloud2::ConstPtr& cloud_msg);
+
+  ros::Subscriber sub_;
+  ros::Publisher pub_;
+private:
+};
+
+}  // namespace jsk_pcl_ros_utils
+
+#endif  // JSK_PCL_ROS_UTILS_POINTCLOUD_XYZI_TO_XYZ_H_

--- a/jsk_pcl_ros_utils/jsk_pcl_nodelets.xml
+++ b/jsk_pcl_ros_utils/jsk_pcl_nodelets.xml
@@ -79,19 +79,19 @@
       publish the centroid of the pointcloud to /tf
     </description>
   </class>
-  <class name="jsk_pcl_utils/PolygonArrayDistanceLikelihood" 
+  <class name="jsk_pcl_utils/PolygonArrayDistanceLikelihood"
          type="jsk_pcl_ros_utils::PolygonArrayDistanceLikelihood"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl_utils/PolygonArrayAreaLikelihood" 
+  <class name="jsk_pcl_utils/PolygonArrayAreaLikelihood"
          type="jsk_pcl_ros_utils::PolygonArrayAreaLikelihood"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl_utils/PolygonArrayAngleLikelihood" 
+  <class name="jsk_pcl_utils/PolygonArrayAngleLikelihood"
          type="jsk_pcl_ros_utils::PolygonArrayAngleLikelihood"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl_utils/PolygonArrayFootAngleLikelihood" 
+  <class name="jsk_pcl_utils/PolygonArrayFootAngleLikelihood"
          type="jsk_pcl_ros_utils::PolygonArrayFootAngleLikelihood"
          base_class_type="nodelet::Nodelet">
   </class>
@@ -99,7 +99,7 @@
          type="jsk_pcl_ros_utils::PolygonArrayLikelihoodFilter"
          base_class_type="nodelet::Nodelet">
   </class>
-  <class name="jsk_pcl_utils/PoseWithCovarianceStampedToGaussianPointCloud" 
+  <class name="jsk_pcl_utils/PoseWithCovarianceStampedToGaussianPointCloud"
          type="jsk_pcl_ros_utils::PoseWithCovarianceStampedToGaussianPointCloud"
          base_class_type="nodelet::Nodelet">
   </class>
@@ -176,6 +176,10 @@
   </class>
   <class name="jsk_pcl_utils/PointCloudXYZRGBToXYZ"
          type="jsk_pcl_ros_utils::PointCloudXYZRGBToXYZ"
+         base_class_type="nodelet::Nodelet">
+  </class>
+  <class name="jsk_pcl_utils/PointCloudXYZIToXYZ"
+         type="jsk_pcl_ros_utils::PointCloudXYZIToXYZ"
          base_class_type="nodelet::Nodelet">
   </class>
   <class name="jsk_pcl_utils/PointCloudToClusterPointIndices"

--- a/jsk_pcl_ros_utils/src/pointcloud_xyzi_to_xyz_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/pointcloud_xyzi_to_xyz_nodelet.cpp
@@ -1,0 +1,88 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#define BOOST_PARAMETER_MAX_ARITY 7
+
+#include <pcl_conversions/pcl_conversions.h>
+
+#include "jsk_pcl_ros_utils/pointcloud_xyzi_to_xyz.h"
+
+namespace jsk_pcl_ros_utils
+{
+
+void PointCloudXYZIToXYZ::onInit()
+{
+  DiagnosticNodelet::onInit();
+  pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);
+  onInitPostProcess();
+}
+
+void PointCloudXYZIToXYZ::subscribe()
+{
+  sub_ = pnh_->subscribe("input", 1, &PointCloudXYZIToXYZ::convert, this);
+}
+
+void PointCloudXYZIToXYZ::unsubscribe()
+{
+  sub_.shutdown();
+}
+
+void PointCloudXYZIToXYZ::convert(const sensor_msgs::PointCloud2::ConstPtr& cloud_msg)
+{
+  vital_checker_->poke();
+  pcl::PointCloud<pcl::PointXYZI>::Ptr cloud_xyzi(new pcl::PointCloud<pcl::PointXYZI>);
+  pcl::fromROSMsg(*cloud_msg, *cloud_xyzi);
+
+  pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_xyz(new pcl::PointCloud<pcl::PointXYZ>);
+  cloud_xyz->points.resize(cloud_xyzi->points.size());
+  cloud_xyz->is_dense = cloud_xyzi->is_dense;
+  cloud_xyz->width = cloud_xyzi->width;
+  cloud_xyz->height = cloud_xyzi->height;
+  for (size_t i = 0; i < cloud_xyzi->points.size(); i++) {
+    pcl::PointXYZ p;
+    p.x = cloud_xyzi->points[i].x;
+    p.y = cloud_xyzi->points[i].y;
+    p.z = cloud_xyzi->points[i].z;
+    cloud_xyz->points[i] = p;
+  }
+  sensor_msgs::PointCloud2 out_cloud_msg;
+  pcl::toROSMsg(*cloud_xyz, out_cloud_msg);
+  out_cloud_msg.header = cloud_msg->header;
+  pub_.publish(out_cloud_msg);
+}
+
+}  // namespace jsk_pcl_ros_utils
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(jsk_pcl_ros_utils::PointCloudXYZIToXYZ, nodelet::Nodelet);


### PR DESCRIPTION
This nodelet is for converting pointcloud from PointXYZI to PointXYZ.
It is useful when we use pointcloud from laser.

I made sure this branch successfully built and the new nodelet ran well.