### PR TITLE
[jsk_perception] Support fcn8s_atonce model in fcn_object_segmentation.py

### DIFF
--- a/doc/jsk_perception/nodes/fcn_object_segmentation.rst
+++ b/doc/jsk_perception/nodes/fcn_object_segmentation.rst
@@ -34,6 +34,11 @@ Publishing Topic
 
   Label image each object in param ``~target_names`` is segmented.
 
+* ``~output/proba_image`` (``sensor_msgs/Image``)
+
+  Probability image of each object.
+  The encoding is ``32FCX``, where X is the length of ``~target_names``.
+
 
 Parameters
 ----------
@@ -55,7 +60,7 @@ Parameters
 
 * ``~model_name`` (String, Required)
 
-  Currently ``fcn8s``, ``fcn16s`` or ``fcn32s`` is only supported.
+  Currently ``fcn8s``, ``fcn8s_atonce``, ``fcn16s`` or ``fcn32s`` is only supported.
   See models in https://github.com/wkentaro/fcn/tree/master/fcn/models.
 
 * ``~model_file`` (String, Required)

--- a/doc/jsk_perception/nodes/fcn_object_segmentation.rst
+++ b/doc/jsk_perception/nodes/fcn_object_segmentation.rst
@@ -60,7 +60,7 @@ Parameters
 
 * ``~model_name`` (String, Required)
 
-  Currently ``fcn8s``, ``fcn8s_atonce``, ``fcn16s`` or ``fcn32s`` is only supported.
+  Currently ``fcn8s``, ``fcn8s_at_once``, ``fcn16s`` or ``fcn32s`` is only supported.
   See models in https://github.com/wkentaro/fcn/tree/master/fcn/models.
 
 * ``~model_file`` (String, Required)

--- a/doc/jsk_perception/training_scripts/train_fcn.md
+++ b/doc/jsk_perception/training_scripts/train_fcn.md
@@ -36,7 +36,7 @@ path_to_awesome_dataset/
 
 - `--model_name` (`string`, default: `fcn32s`)
 
-  Model name. Currently, `fcn32s`, `fcn16s`, `fcn8s` and `fcn8s_atonce` are supported.
+  Model name. Currently, `fcn32s`, `fcn16s`, `fcn8s` and `fcn8s_at_once` are supported.
 
 - `--gpu` (`int`, default: `0`)
 

--- a/jsk_perception/node_scripts/fcn_object_segmentation.py
+++ b/jsk_perception/node_scripts/fcn_object_segmentation.py
@@ -69,7 +69,7 @@ class FCNObjectSegmentation(ConnectionBasedTransport):
             self.model = fcn.models.FCN16s(n_class=n_class)
         elif model_name == 'fcn8s':
             self.model = fcn.models.FCN8s(n_class=n_class)
-        elif model_name == 'fcn8s_atonce':
+        elif model_name == 'fcn8s_at_once':
             self.model = fcn.models.FCN8sAtOnce(n_class=n_class)
         else:
             raise ValueError('Unsupported ~model_name: {}'.format(model_name))

--- a/jsk_perception/node_scripts/fcn_object_segmentation.py
+++ b/jsk_perception/node_scripts/fcn_object_segmentation.py
@@ -69,6 +69,8 @@ class FCNObjectSegmentation(ConnectionBasedTransport):
             self.model = fcn.models.FCN16s(n_class=n_class)
         elif model_name == 'fcn8s':
             self.model = fcn.models.FCN8s(n_class=n_class)
+        elif model_name == 'fcn8s_atonce':
+            self.model = fcn.models.FCN8sAtOnce(n_class=n_class)
         else:
             raise ValueError('Unsupported ~model_name: {}'.format(model_name))
         rospy.loginfo('Loading trained model: {0}'.format(model_file))

--- a/jsk_perception/scripts/train_fcn.py
+++ b/jsk_perception/scripts/train_fcn.py
@@ -39,7 +39,7 @@ class TrainFCN(object):
         # Model
         parser.add_argument(
             '--model_name', type=str, default='fcn32s',
-            choices=['fcn32s', 'fcn16s', 'fcn8s', 'fcn8s_atonce'])
+            choices=['fcn32s', 'fcn16s', 'fcn8s', 'fcn8s_at_once'])
 
         # Training parameters
         parser.add_argument('--gpu', type=int, default=0)
@@ -158,7 +158,7 @@ class TrainFCN(object):
             fcn16s_path = fcn16s.download()
             S.load_npz(fcn16s_path, fcn16s)
             self.model.init_from_fcn16s(fcn16s_path, fcn16s)
-        elif self.model_name == 'fcn8s_atonce':
+        elif self.model_name == 'fcn8s_at_once':
             self.model = fcn.models.FCN8sAtOnce(n_class=n_class)
             vgg = fcn.models.VGG16()
             vgg_path = vgg.download()


### PR DESCRIPTION
Network weight of FCN8s and FCN8sAtOnce are the same shape, but some parameters are different and should be distinguished.
The accuracy becomes very low if you use wrong model.

- correct
![fcn8s_atonce_correct](https://user-images.githubusercontent.com/22876283/49564245-37073600-f966-11e8-9d64-b0154b7ee46d.png)

- wrong
![fcn8s_atonce_wrong](https://user-images.githubusercontent.com/22876283/49564248-38d0f980-f966-11e8-9cff-89a0ff634931.png)

