### PR TITLE
Add method to convert jsk_recognition_msgs/BoundingBox to cube in euslisp

### DIFF
--- a/jsk_pcl_ros/euslisp/bounding-box-to-cube.l
+++ b/jsk_pcl_ros/euslisp/bounding-box-to-cube.l
@@ -1,0 +1,9 @@
+#!/usr/bin/env roseus
+
+(ros::load-ros-manifest "jsk_recognition_msgs")
+
+(defun bounding-box->cube (b)
+  (let* ((dims (ros::tf-point->pos (send b :dimensions)))
+         (cube (make-cube (elt dims 0) (elt dims 1) (elt dims 2))))
+    (send cube :newcoords (ros::tf-pose->coords (send b :pose)))
+    cube))

--- a/jsk_pcl_ros/euslisp/display-bounding-box-array.l
+++ b/jsk_pcl_ros/euslisp/display-bounding-box-array.l
@@ -1,6 +1,6 @@
 #!/usr/bin/env runeus
 
-(ros::load-ros-manifest "jsk_pcl_ros")
+(ros::load-ros-manifest "jsk_recognition_msgs")
 
 (defvar *topic-name* "/cluster_decomposer/boxes")
 (defvar *bounding-box-list* nil)
@@ -22,7 +22,7 @@
     (send *irtviewer* :viewer :viewsurface :flush)
     ))
 
-(ros::subscribe *topic-name* jsk_pcl_ros::BoundingBoxArray #'bounding-box-array-cb 1)
+(ros::subscribe *topic-name* jsk_recognition_msgs::BoundingBoxArray #'bounding-box-array-cb 1)
 
 (unless (boundp '*irtviewer*) (make-irtviewer))
 

--- a/jsk_pcl_ros/euslisp/display-bounding-box-array.l
+++ b/jsk_pcl_ros/euslisp/display-bounding-box-array.l
@@ -11,16 +11,16 @@
   (setq *bounding-box-list* (send msg :boxes))
   (when *bounding-box-list*
     (send *irtviewer* :draw-objects :flush nil)
-    (mapcar #'(lambda (b)
-                (let* ((dims (ros::tf-point->pos (send b :dimensions)))
-                       (bx (make-cube (elt dims 0) (elt dims 1) (elt dims 2))))
-                  (send bx :newcoords (ros::tf-pose->coords (send b :pose)))
-                  (send bx :worldcoords)
-                  (send bx :draw-on :flush nil :color #f(1 0 0))
-                  bx))
-            *bounding-box-list*)
+    (dolist (cube (mapcar #'bounding-box->cube *bounding-box-list*))
+      (send cube :draw-on :flush nil :color #f(1 0 0)))
     (send *irtviewer* :viewer :viewsurface :flush)
     ))
+
+(defun bounding-box->cube (b)
+  (let* ((dims (ros::tf-point->pos (send b :dimensions)))
+         (cube (make-cube (elt dims 0) (elt dims 1) (elt dims 2))))
+    (send cube :newcoords (ros::tf-pose->coords (send b :pose)))
+    cube))
 
 (ros::subscribe *topic-name* jsk_recognition_msgs::BoundingBoxArray #'bounding-box-array-cb 1)
 

--- a/jsk_pcl_ros/euslisp/display-bounding-box-array.l
+++ b/jsk_pcl_ros/euslisp/display-bounding-box-array.l
@@ -1,9 +1,9 @@
 #!/usr/bin/env runeus
 
-(ros::load-ros-manifest "jsk_recognition_msgs")
-
 (defvar *topic-name* "/cluster_decomposer/boxes")
 (defvar *bounding-box-list* nil)
+
+(load "package://jsk_pcl_ros/euslisp/bounding-box-to-cube.l")
 
 (ros::roseus "boundingboxarray_subscriber")
 
@@ -15,12 +15,6 @@
       (send cube :draw-on :flush nil :color #f(1 0 0)))
     (send *irtviewer* :viewer :viewsurface :flush)
     ))
-
-(defun bounding-box->cube (b)
-  (let* ((dims (ros::tf-point->pos (send b :dimensions)))
-         (cube (make-cube (elt dims 0) (elt dims 1) (elt dims 2))))
-    (send cube :newcoords (ros::tf-pose->coords (send b :pose)))
-    cube))
 
 (ros::subscribe *topic-name* jsk_recognition_msgs::BoundingBoxArray #'bounding-box-array-cb 1)
 


### PR DESCRIPTION
This Pull Request is re-submission of https://github.com/jsk-ros-pkg/jsk_roseus/pull/584

I added a method to convert jsk_recognition_msgs/BoundingBox into cube in euslisp.

BoundingBox in Rviz
![49071527-81efc200-f271-11e8-996b-049e1f4be1ff](https://user-images.githubusercontent.com/19769486/50545566-3dce5380-0c5b-11e9-8107-1e26b16179a8.png)


BoundingBox in euslisp
![49071546-89af6680-f271-11e8-87bc-17c47187db32](https://user-images.githubusercontent.com/19769486/50545568-42930780-0c5b-11e9-995f-166c5d8f2f4b.png)
