### PR TITLE
add line to preserve rgb data of pointcloud

### DIFF
--- a/jsk_pcl_ros/src/normal_estimation_omp_nodelet.cpp
+++ b/jsk_pcl_ros/src/normal_estimation_omp_nodelet.cpp
@@ -112,6 +112,7 @@ namespace jsk_pcl_ros
         p.x = cloud->points[i].x;
         p.y = cloud->points[i].y;
         p.z = cloud->points[i].z;
+        p.rgb = cloud->points[i].rgb;
         p.normal_x = normal_cloud->points[i].normal_x;
         p.normal_y = normal_cloud->points[i].normal_y;
         p.normal_z = normal_cloud->points[i].normal_z;


### PR DESCRIPTION
In `normal_estimation_omp_nodelet.launch`,  the output pointcloud doesn't take over the rgb data of the input pointcloud. This pull request will solve this issue.

I tested the result with `sample_door_handle_detector.bag` and checked if it works correctly.
Input pointcloud
<img src="https://user-images.githubusercontent.com/22876812/51465083-7371e280-1daa-11e9-8498-aad82fe68cb2.png" width="320px" />
The left is the previous output, and the right is the one with this pull request.
<img src="https://user-images.githubusercontent.com/22876812/51465089-77056980-1daa-11e9-8b73-a28f11d0eff9.png" width="320px" />　<img src="https://user-images.githubusercontent.com/22876812/51465092-7967c380-1daa-11e9-93bc-08e24927b2d0.png" width="320px" />

