### PR TITLE
Support passing Numpy_INCLUDE_DIRS externally

### DIFF
--- a/jsk_recognition_utils/python/jsk_recognition_utils/CMakeLists.txt
+++ b/jsk_recognition_utils/python/jsk_recognition_utils/CMakeLists.txt
@@ -1,10 +1,12 @@
-# Get Numpy include directories
-execute_process(
-  COMMAND python -c "import sys, numpy; sys.stdout.write(numpy.get_include())"
-  OUTPUT_VARIABLE Numpy_INCLUDE_DIRS
-  RESULT_VARIABLE retcode)
-if(NOT ${retcode} EQUAL 0)
-  message(FATAL_ERROR "Failed to get Numpy include dirs by numpy.get_include(). Exit code: ${retcode}")
+if(NOT DEFINED Numpy_INCLUDE_DIRS)
+  # Get Numpy include directories
+  execute_process(
+    COMMAND python -c "import sys, numpy; sys.stdout.write(numpy.get_include())"
+    OUTPUT_VARIABLE Numpy_INCLUDE_DIRS
+    RESULT_VARIABLE retcode)
+  if(NOT ${retcode} EQUAL 0)
+    message(FATAL_ERROR "Failed to get Numpy include dirs by numpy.get_include(). Exit code: ${retcode}")
+  endif()
 endif()
 # Compile nms.pyx
 include_directories(${Numpy_INCLUDE_DIRS})


### PR DESCRIPTION
This PR allows users to pass `Numpy_INCLUDIR_DIRS` externally, for example for cross compiling to a different target platform.