### PR TITLE
Revert "kinfu.h depends on jsk_rviz_plugins"

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -34,7 +34,6 @@ find_package(catkin REQUIRED COMPONENTS
   jsk_pcl_ros_utils
   # jsk_recognition_msgs
   jsk_recognition_utils
-  jsk_rviz_plugins # kinfu.h uses jsk_rviz_plugins/OverlayText.h
   jsk_topic_tools
   # kdl_conversions
   # kdl_parser

--- a/jsk_pcl_ros/package.xml
+++ b/jsk_pcl_ros/package.xml
@@ -23,7 +23,6 @@
   <build_depend>jsk_data</build_depend>
   <build_depend>jsk_pcl_ros_utils</build_depend>
   <build_depend>jsk_recognition_utils</build_depend>
-  <build_depend>jsk_rviz_plugins</build_depend>
   <build_depend version_gte="2.2.7">jsk_topic_tools</build_depend>
   <build_depend>laser_assembler</build_depend>
   <build_depend>moveit_ros_perception</build_depend>
@@ -49,7 +48,6 @@
   <run_depend>jsk_data</run_depend>
   <run_depend>jsk_footstep_msgs</run_depend>
   <run_depend>jsk_pcl_ros_utils</run_depend>
-  <run_depend>jsk_rviz_plugins</run_depend>
   <run_depend>jsk_recognition_msgs</run_depend>
   <run_depend>jsk_recognition_utils</run_depend>
   <run_depend version_gte="2.2.7">jsk_topic_tools</run_depend>


### PR DESCRIPTION
Reverts jsk-ros-pkg/jsk_recognition#2310

Jsk_recognition should not depends on jsk_visualization, because jsk_visualization depends on jsk_recognition and this brings curcular dependency
https://github.com/jsk-ros-pkg/jsk_visualization/pull/644