### PR TITLE
fix arm build regressions, closes #2396

### DIFF
--- a/imagesift/CMakeLists.txt
+++ b/imagesift/CMakeLists.txt
@@ -38,7 +38,16 @@ macro(jsk_feature detector extractor exec_name)
   set(EXEC_NAME ${exec_name})
   configure_file(src/imagefeatures.cpp.in src/${exec_name}.cpp) #${CMAKE_CURRENT_BINARY_DIR}/
   add_executable(${exec_name} src/${exec_name}.cpp)
-  set_target_properties(${exec_name} PROPERTIES COMPILE_FLAGS "-msse2 -O3" LINK_FLAGS "-msse2 -O3")
+  # https://stackoverflow.com/questions/28939652/how-to-detect-sse-sse2-avx-avx2-avx-512-avx-128-fma-kcvi-availability-at-compile
+  execute_process(
+    COMMAND gcc -dM -E -
+    COMMAND grep SSE
+    INPUT_FILE /dev/null
+    RESULT_VARIABLE GCC_SUPPORT_SSE)
+  message(STATUS "Check GCC supports SSE ${GCC_SUPPORT_SSE}")
+  if(NOT ${GCC_SUPPORT_SSE})
+    set_target_properties(${exec_name} PROPERTIES COMPILE_FLAGS "-msse2 -O3" LINK_FLAGS "-msse2 -O3")
+  endif()
   if($ENV{ROS_DISTRO} STREQUAL "groovy" OR $ENV{ROS_DISTRO} STREQUAL "hydro")
     set_target_properties(${exec_name} PROPERTIES COMPILE_FLAGS "-DOPENCV_NON_FREE")
   endif()


### PR DESCRIPTION
use https://stackoverflow.com/questions/28939652/how-to-detect-sse-sse2-avx-avx2-avx-512-avx-128-fma-kcvi-availability-at-compile to check if gcc supports sse

```
23:36:54 ccache /usr/lib/ccache/aarch64-linux-gnu-g++   -DROSCONSOLE_BACKEND_LOG4CXX -DROS_PACKAGE_NAME=\"imagesift\" -I/tmp/binarydeb/ros-kinetic-imagesift-1.2.7/include -I/opt/ros/kinetic/include -I/opt/ros/kinetic/share/xmlrpcpp/cmake/../../../include/xmlrpcpp -isystem /opt/ros/kinetic/include/opencv-3.3.1-dev -isystem /opt/ros/kinetic/include/opencv-3.3.1-dev/opencv -I/usr/include/eigen3 -I/usr/include/pcl-1.7 -I/usr/include/ni -I/usr/include/vtk-6.2 -I/usr/include/jsoncpp -I/usr/include/libxml2 -I/usr/include/aarch64-linux-gnu -I/usr/include/freetype2 -I/usr/include/python2.7 -I/usr/lib/openmpi/include/openmpi/opal/mca/event/libevent2021/libevent -I/usr/lib/openmpi/include/openmpi/opal/mca/event/libevent2021/libevent/include -I/usr/lib/openmpi/include -I/usr/lib/openmpi/include/openmpi -I/usr/include/tcl  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -DNDEBUG -Wdate-time -D_FORTIFY_SOURCE=2    -O2 -g -msse2 -O3 -o CMakeFiles/imagebrisk.dir/src/imagebrisk.cpp.o -c /tmp/binarydeb/ros-kinetic-imagesift-1.2.7/obj-aarch64-linux-gnu/src/imagebrisk.cpp
23:36:54 aarch64-linux-gnu-g++: error: unrecognized command line option ‘-msse2’
```

Closes #2396