### PR TITLE
add QT_LIBRARIES Qt5::Widgets to fix 'cannot find -lQt5::Widgets' error on debian stretch

### DIFF
--- a/jsk_recognition_utils/CMakeLists.txt
+++ b/jsk_recognition_utils/CMakeLists.txt
@@ -91,6 +91,10 @@ add_library(jsk_recognition_utils SHARED
 
 if (CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
+  if("$ENV{ROS_DISTRO}" STRGREATER "indigo") # kinetic and later uses qt5
+    find_package(Qt5Widgets REQUIRED)
+    set(QT_LIBRARIES Qt5::Widgets)
+  endif()
   add_rostest_gtest(test_tf_listener_singleton test/tf_listener_singleton.test src/tests/test_tf_listener_singleton.cpp)
   target_link_libraries(test_tf_listener_singleton ${PROJECT_NAME} ${catkin_LIBRARIES})
   catkin_add_gtest(test_cv_utils src/tests/test_cv_utils.cpp)


### PR DESCRIPTION
will fix http://build.ros.org/job/Mbin_ds_dS64__jsk_recognition_utils__debian_stretch_amd64__binary/7/console