### PR TITLE
re-enable ml_classifiers

### DIFF
--- a/jsk_pcl_ros/CMakeLists.txt
+++ b/jsk_pcl_ros/CMakeLists.txt
@@ -20,6 +20,14 @@ elseif(COMPILER_SUPPORTS_CXX0X)
 else()
   message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
 endif()
+find_package(PkgConfig)
+pkg_check_modules(ml_classifiers ml_classifiers QUIET)
+message(STATUS "Check if ml_classifiers exists ${ml_classifiers_FOUND}")
+if(ml_classifiers_FOUND)
+  set(ML_CLASSIFIERS ml_classifiers) ## hydro and later
+else()
+  set(ML_CLASSIFIERS )
+endif()
 
 find_package(catkin REQUIRED COMPONENTS
   cv_bridge
@@ -49,9 +57,9 @@ find_package(catkin REQUIRED COMPONENTS
   tf
   # tf2_ros
   tf_conversions
+  #
+  ${ML_CLASSIFIERS}
   )
-find_package(PkgConfig)
-pkg_check_modules(ml_classifieres ml_classifiers QUIET)
 # only run in hydro
 find_package(PCL REQUIRED)
 find_package(OpenMP)

--- a/jsk_pcl_ros_utils/CMakeLists.txt
+++ b/jsk_pcl_ros_utils/CMakeLists.txt
@@ -24,12 +24,6 @@ else()
   set(PCL_MSGS pcl_msgs) ## hydro and later
 endif()
 
-if($ENV{ROS_DISTRO} STREQUAL "groovy")
-  set(ML_CLASSIFIERS )
-else()
-  set(ML_CLASSIFIERS ml_classifiers) ## hydro and later
-endif()
-
 find_package(catkin REQUIRED COMPONENTS
   jsk_recognition_utils
   dynamic_reconfigure pcl_ros nodelet message_generation genmsg
@@ -48,7 +42,6 @@ find_package(catkin REQUIRED COMPONENTS
   kdl_conversions
   )
 find_package(PkgConfig)
-pkg_check_modules(${ML_CLASSIFIERS} ml_classifiers QUIET)
 # only run in hydro
 if(NOT $ENV{ROS_DISTRO} STREQUAL "groovy")
   find_package(PCL REQUIRED)

--- a/jsk_pcl_ros_utils/package.xml
+++ b/jsk_pcl_ros_utils/package.xml
@@ -38,7 +38,6 @@
   <build_depend>boost</build_depend>
   <build_depend>rosboost_cfg</build_depend>
   <build_depend>cv_bridge</build_depend>
-  <build_depend>ml_classifiers</build_depend>
   <build_depend>diagnostic_updater</build_depend>
   <build_depend>diagnostic_msgs</build_depend>
   <build_depend>jsk_topic_tools</build_depend>
@@ -85,7 +84,6 @@
   <run_depend>rosboost_cfg</run_depend>
   <run_depend>rviz</run_depend>
   <run_depend>cv_bridge</run_depend>
-  <run_depend>ml_classifiers</run_depend>
   <run_depend>diagnostic_updater</run_depend>
   <run_depend>diagnostic_msgs</run_depend>
   <run_depend>python-sklearn</run_depend>


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/jsk_recognition/issues/2359#issuecomment-466803378

- jsk_pcl_ros_utils does not require ml_classifiers
- jsk_pcl_ros : try to find ml_classfier as catkin packages