### PR TITLE
Re-enable pointcloud_to_pcd.test

### DIFF
--- a/jsk_pcl_ros_utils/CMakeLists.txt
+++ b/jsk_pcl_ros_utils/CMakeLists.txt
@@ -266,13 +266,9 @@ if (CATKIN_ENABLE_TESTING)
     add_rostest(test/add_point_indices.test)
     roslaunch_add_file_check(test/add_point_indices.test)
     add_rostest(test/cluster_point_indices_to_point_indices.test)
-    # unexpected error
     add_rostest(test/point_indices_to_mask_image.test)
-    # because of unreleased topic_tools/transform on hydro
-    # TODO(iory): Fix this. (https://github.com/jsk-ros-pkg/jsk_recognition/issues/2339)
-    # add_rostest(test/pointcloud_to_pcd.test)
+    add_rostest(test/pointcloud_to_pcd.test)
     add_rostest(test/pointcloud_to_point_indices.test)
-    # because of unreleased jsk_tools/test_topic_published.py on hydro
     add_rostest(test/bounding_box_array_to_bounding_box.test)
     add_rostest(test/evaluate_box_segmentation_by_gt_box.test)
     add_rostest(test/evaluate_voxel_segmentation_by_gt_box.test)


### PR DESCRIPTION
Fix #2339 

I could not reproduce the test failure described in https://github.com/jsk-ros-pkg/jsk_recognition/issues/2339#issue-366148593 on my environment (Ubuntu16.04 + kinetic + latest master branch of jsk_recognition (commit: f3ed340)).
So I re-enabled pointcloud_to_pcd.test to check why the failure occured on travis build.

If pointcloud_to_pcd.test does not fail, please merge this PR.