### PR TITLE
run catkin with -Werror=dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ notifications:
 env:
   global:
     - ROS_PARALLEL_JOBS="-j8"
-    - CATKIN_PARALLEL_TEST_JOBS="-p1 -j1"
+    - CATKIN_PARALLEL_TEST_JOBS="-p1 -j1 --cmake-args -Werror=dev"
     - NOT_TEST_INSTALL=true
     - USE_JENKINS=true
     - USE_DEB=true


### PR DESCRIPTION
I am not sure if we should update jsk_travis to add options for --cmake-args