### PR TITLE
use (MOVEIT_VERSION_MAJOR == 0 and MOVEIT_VERSION_MINOR < 6), since moveit is upgraded to 1.0

### DIFF
--- a/jsk_pcl_ros/include/jsk_pcl_ros/pointcloud_moveit_filter.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/pointcloud_moveit_filter.h
@@ -143,7 +143,7 @@ namespace jsk_pcl_ros
           return;
         }
         /* mask out points on the robot */
-#if (MOVEIT_VERSION_MINOR < 6)
+#if (MOVEIT_VERSION_MAJOR == 0 and MOVEIT_VERSION_MINOR < 6)
         shape_mask_->maskContainment(xyz_cloud, sensor_origin_eigen, 0.0,
                                      max_range_, mask_);
 #else   // from moveit 0.6 (indigo), PCL dependency is removed


### PR DESCRIPTION
fix http://jenkins.jsk.imi.i.u-tokyo.ac.jp:8080/job/bionic-travis-jsk-ros-pkg-jsk-recognition-melodic-deb-true-true/90/console

```
20:53:17    ^~~~~~~~~~~~~~~
20:53:17 /usr/include/pcl-1.8/pcl/sample_consensus/model_types.h:99:3: note: declared here
20:53:17 In file included from /workspace/ros/ws_jsk_recognition/src/jsk_recognition/jsk_pcl_ros/src/pointcloud_moveit_filter.cpp:206:0:
20:53:17 /opt/ros/melodic/include/class_loader/class_loader.h:36:2: warning: #warning Including header <class_loader/class_loader.h> is deprecated, include <class_loader/class_loader.hpp> instead. [-Wcpp]
20:53:17  #warning Including header <class_loader/class_loader.h> is deprecated, \
20:53:17   ^~~~~~~
20:53:17 In file included from /workspace/ros/ws_jsk_recognition/src/jsk_recognition/jsk_pcl_ros/src/pointcloud_moveit_filter.cpp:36:0:
20:53:17 /workspace/ros/ws_jsk_recognition/src/jsk_recognition/jsk_pcl_ros/include/jsk_pcl_ros/pointcloud_moveit_filter.h: In member function ?void jsk_pcl_ros::PointCloudMoveitFilter::cloudMsgCallback(const ConstPtr&)?:
20:53:17 /workspace/ros/ws_jsk_recognition/src/jsk_recognition/jsk_pcl_ros/include/jsk_pcl_ros/pointcloud_moveit_filter.h:148:55: error: no matching function for call to ?point_containment_filter::ShapeMask::maskContainment(pcl::PointCloud<pcl::PointXYZ>&, Eigen::Vector3d&, double, double&, std::vector<int>&)?
20:53:17                                       max_range_, mask_);
20:53:17                                                        ^
20:53:17 In file included from /workspace/ros/ws_jsk_recognition/src/jsk_recognition/jsk_pcl_ros/include/jsk_pcl_ros/pointcloud_moveit_filter.h:51:0,
20:53:17                  from /workspace/ros/ws_jsk_recognition/src/jsk_recognition/jsk_pcl_ros/src/pointcloud_moveit_filter.cpp:36:
20:53:17 /opt/ros/melodic/include/moveit/point_containment_filter/shape_mask.h:83:8: note: candidate: void point_containment_filter::ShapeMask::maskContainment(const PointCloud2&, const Vector3d&, double, double, std::vector<int>&)
20:53:17    void maskContainment(const sensor_msgs::PointCloud2& data_in, const Eigen::Vector3d& sensor_pos,
20:53:17         ^~~~~~~~~~~~~~~
20:53:17 /opt/ros/melodic/include/moveit/point_containment_filter/shape_mask.h:83:8: note:   no known conversion for argument 1 from ?pcl::PointCloud<pcl::PointXYZ>? to ?const PointCloud2& {aka const sensor_msgs::PointCloud2_<std::allocator<void> >&}?
20:53:17 make[2]: *** [CMakeFiles/jsk_pcl_ros_moveit.dir/src/pointcloud_moveit_filter.cpp.o] Error 1
20:53:17 make[1]: *** [CMakeFiles/jsk_pcl_ros_moveit.dir/all] Error 2
```
