### PR TITLE
Force overwrite during rosbag decompress

### DIFF
--- a/jsk_pcl_ros/scripts/install_sample_data.py
+++ b/jsk_pcl_ros/scripts/install_sample_data.py
@@ -84,9 +84,6 @@ def main():
         url='https://drive.google.com/uc?id=19VujodKsX7EJJwHetqFGCRYz0JBtZQ6h',
         md5='9bdc1500610a1a97480cae6fcf261811',
         extract=True,
-        compressed_bags=[
-            'sample/data/pr2_sink.bag',
-        ],
     )
 
     download_data(
@@ -110,9 +107,6 @@ def main():
         url='https://drive.google.com/uc?id=1r7Hj4ujB8Ml5QHg7_Q6kd3rbtL6kzTbh',
         md5='a6f4d560830c93e0710fef0e7518a099',
         extract=True,
-        compressed_bags=[
-            'sample/data/octomap_contact.bag',
-        ],
     )
 
     download_data(

--- a/jsk_pcl_ros/scripts/install_sample_data.py
+++ b/jsk_pcl_ros/scripts/install_sample_data.py
@@ -56,6 +56,7 @@ def main():
         compressed_bags=[
             'sample/data/2016-07-06-12-16-43-person-in-point-cloud/vision.compressed.bag',  # NOQA
         ],
+        force=True,
     )
 
     download_data(
@@ -77,6 +78,7 @@ def main():
         compressed_bags=[
             'sample/data/sample_add_color_from_image_20170319.bag',
         ],
+        force=False,
     )
 
     download_data(
@@ -100,6 +102,7 @@ def main():
         compressed_bags=[
             'sample/data/sample_door_handle_detector.bag',
         ],
+        force=False,
     )
 
     download_data(

--- a/jsk_perception/scripts/install_sample_data.py
+++ b/jsk_perception/scripts/install_sample_data.py
@@ -15,6 +15,7 @@ def main():
         compressed_bags=[
             'sample/data/2016-11-11-12-53-06_in_lab.bag',
         ],
+        force=False,
     )
 
     download_data(
@@ -26,6 +27,7 @@ def main():
         compressed_bags=[
             'sample/data/2016-10-15-23-21-42_moving_bottle.bag',
         ],
+        force=False,
     )
 
     download_data(

--- a/jsk_perception/scripts/install_test_data.py
+++ b/jsk_perception/scripts/install_test_data.py
@@ -13,6 +13,7 @@ def main():
         md5='9516566c66391835f85ac9cc44cbfc4b',
         extract=True,
         compressed_bags=['test_data/2016-04-05-17-19-43_draw_bbox/vision.bag'],
+        force=True,
     )
 
     download_data(
@@ -24,6 +25,7 @@ def main():
         compressed_bags=[
             'test_data/2016-04-06-08-16-08_img_cpi_decomposer/vision.bag',
         ],
+        force=True,
     )
 
 


### PR DESCRIPTION
Please merge this after https://github.com/jsk-ros-pkg/jsk_common/pull/1621

Fix #2420 

When a bzip2 compressed and gzip compressed rosbag file (i.e. `rosbag compress`-ed and `tar zcf`-ed archive) is downloaded by `install_xxxx_data.py`, decompressed bag file is overwritten by compressed bag file while tar decompressing (See #2420 ).
This PR will fix that issue.

Note: process of `install_xxxx_data.py` is below.
1. download from google drive
2. tar decompress if needed
3. rosbag decompress if needed

__Commit summary__
- Remove unnecessary `compressed_bags=[xxxx]` because they are not actually `rosbag compressed`-ed.
- Overwrite once `rosbag decompress`-ed bag file during next `rosbag decompress` in order to force decompress it.