### PR TITLE
[WIP] enable DEVELOPER_ERROR in kinetic and melodic

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,8 +3,8 @@
 	url = https://github.com/garaemon/SLIC-Superpixels.git
 [submodule ".travis"]
 	path = .travis
-	url = https://github.com/jsk-ros-pkg/jsk_travis.git
-	branch = 0.4.26
+	url = https://github.com/knorth55/jsk_travis.git
+	branch = developer-error
 [submodule "jsk_perception/node_scripts/deep_sort/deep_sort"]
 	path = jsk_perception/node_scripts/deep_sort/deep_sort
 	url = https://github.com/nwojke/deep_sort.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ env:
     - ROS_DISTRO=indigo ROS_REPOSITORY_PATH="http://packages.ros.org/ros/ubuntu"
     - ROS_DISTRO=indigo BEFORE_SCRIPT='$CI_SOURCE_PATH/.travis_before_script_opencv3.bash' BUILD_PKGS='checkerboard_detector imagesift jsk_perception jsk_recognition_utils resized_image_transport'
     - ROS_DISTRO=indigo BEFORE_SCRIPT='$CI_SOURCE_PATH/.travis_before_script_pcl1.8.bash' BUILD_PKGS='jsk_pcl_ros_utils jsk_pcl_ros' DOCKER_IMAGE_JENKINS='ros-indigo-pcl1.8'
-    - ROS_DISTRO=kinetic
-    - ROS_DISTRO=melodic
+    - ROS_DISTRO=kinetic DEVELOPER_ERROR=true
+    - ROS_DISTRO=melodic DEVELOPER_ERROR=true
 script:
   - source .travis/travis.sh
   - (cd $TRAVIS_BUILD_DIR/doc && source setup.sh && make html)


### PR DESCRIPTION
DO NOT MERGE YET
WAITING FOR UPSTREAM
This PR requires https://github.com/jsk-ros-pkg/jsk_travis/pull/372

enable `DEVELOPER_ERROR` option in kinetic

related to #2405 