### PR TITLE
[jsk_pcl_ros/pointcloud_moveit_filter] build support moveit > 1.0.0

### DIFF
--- a/jsk_pcl_ros/include/jsk_pcl_ros/pointcloud_moveit_filter.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/pointcloud_moveit_filter.h
@@ -39,7 +39,7 @@
 
 #include <ros/ros.h>
 #include <tf/tf.h>
-#if ROS_VERSION_MINIMUM(1,14,0) // melodic
+#if (ROS_VERSION_MINIMUM(1,14,0) || MOVEIT_VERSION_MAJOR >= 1) // melodic or MoveIt 1.0
 #include <tf2_ros/message_filter.h>
 #else
 #include <tf/message_filter.h>
@@ -77,7 +77,7 @@ namespace jsk_pcl_ros
   protected:
     virtual void stopHelper();
     virtual bool getShapeTransform(ShapeHandle h,
-#if ROS_VERSION_MINIMUM(1,14,0) // melodic
+#if (ROS_VERSION_MINIMUM(1,14,0) || MOVEIT_VERSION_MAJOR >= 1) // melodic or MoveIt 1.0
                                    Eigen::Isometry3d &transform) const;
 #else
                                    Eigen::Affine3d &transform) const;
@@ -96,7 +96,7 @@ namespace jsk_pcl_ros
           if (tf_) {
             try
             {
-#if ROS_VERSION_MINIMUM(1,14,0) // melodic
+#if (ROS_VERSION_MINIMUM(1,14,0) || MOVEIT_VERSION_MAJOR >= 1) // melodic or MoveIt 1.0
               tf::transformStampedMsgToTF(tf_->lookupTransform(monitor_->getMapFrame(),
                                           cloud_msg->header.frame_id,
                                           cloud_msg->header.stamp),
@@ -175,7 +175,7 @@ namespace jsk_pcl_ros
     ////////////////////////////////////////////////////////
     ros::NodeHandle root_nh_;
     ros::NodeHandle private_nh_;
-#if ROS_VERSION_MINIMUM(1,14,0) // melodic
+#if (ROS_VERSION_MINIMUM(1,14,0) || MOVEIT_VERSION_MAJOR >= 1) // melodic and MoveIt 1.0
     std::shared_ptr<tf2_ros::Buffer> tf_;
 #else
     boost::shared_ptr<tf::Transformer> tf_;
@@ -189,7 +189,7 @@ namespace jsk_pcl_ros
     ros::Publisher filtered_cloud_publisher_;
 
     message_filters::Subscriber<sensor_msgs::PointCloud2> *point_cloud_subscriber_;
-#if ROS_VERSION_MINIMUM(1,14,0) // melodic
+#if (ROS_VERSION_MINIMUM(1,14,0) || MOVEIT_VERSION_MAJOR >= 1) // melodic or MoveIt 1.0
     tf2_ros::MessageFilter<sensor_msgs::PointCloud2> *point_cloud_filter_;
 #else
     tf::MessageFilter<sensor_msgs::PointCloud2> *point_cloud_filter_;

--- a/jsk_pcl_ros/include/jsk_pcl_ros/pointcloud_moveit_filter.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/pointcloud_moveit_filter.h
@@ -39,11 +39,6 @@
 
 #include <ros/ros.h>
 #include <tf/tf.h>
-#if (ROS_VERSION_MINIMUM(1,14,0) || MOVEIT_VERSION_MAJOR >= 1) // melodic or MoveIt 1.0
-#include <tf2_ros/message_filter.h>
-#else
-#include <tf/message_filter.h>
-#endif
 #include <message_filters/subscriber.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <moveit/version.h>
@@ -55,6 +50,12 @@
 #include <pcl/point_cloud.h>
 #include <pcl_conversions/pcl_conversions.h>
 #include <pcl/filters/extract_indices.h>
+
+#if (ROS_VERSION_MINIMUM(1,14,0) || MOVEIT_VERSION_MAJOR >= 1) // melodic or MoveIt 1.0
+#include <tf2_ros/message_filter.h>
+#else
+#include <tf/message_filter.h>
+#endif
 
 namespace jsk_pcl_ros
 {

--- a/jsk_pcl_ros/src/pointcloud_moveit_filter.cpp
+++ b/jsk_pcl_ros/src/pointcloud_moveit_filter.cpp
@@ -103,7 +103,7 @@ namespace jsk_pcl_ros
     return true;
   }
 
-#if ROS_VERSION_MINIMUM(1,14,0) // melodic
+#if (ROS_VERSION_MINIMUM(1,14,0) || MOVEIT_VERSION_MAJOR >= 1) // melodic or MoveIt 1.0
   bool PointCloudMoveitFilter::getShapeTransform(ShapeHandle h, Eigen::Isometry3d &transform) const
 #else
   bool PointCloudMoveitFilter::getShapeTransform(ShapeHandle h, Eigen::Affine3d &transform) const
@@ -148,7 +148,7 @@ namespace jsk_pcl_ros
     if (tf_ && !monitor_->getMapFrame().empty())
     {
       point_cloud_filter_
-#if ROS_VERSION_MINIMUM(1,14,0) // melodic
+#if (ROS_VERSION_MINIMUM(1,14,0) || MOVEIT_VERSION_MAJOR >= 1) // melodic or MoveIt 1.0
         = new tf2_ros::MessageFilter<sensor_msgs::PointCloud2>(
           *point_cloud_subscriber_, *tf_, monitor_->getMapFrame(), 5, nullptr);
 #else


### PR DESCRIPTION
current implementation cause build failure with `moveit` `1.0.0`.
I change to be build with `moveit` `1.0.0`.
I build Kinetic with `moveit` `1.0.2`.