### PR TITLE
[jsk_pcl_ros/DepthImageCreator] Add ~fill_value to specify initial value of depth image

### DIFF
--- a/doc/jsk_pcl_ros/nodes/depth_image_creator.md
+++ b/doc/jsk_pcl_ros/nodes/depth_image_creator.md
@@ -62,6 +62,10 @@ Currently it supports `pcl::PointXYZ` and `pcl::PointXYZRGB` as the input.
    Queue length of topic subscribers.
    Default is value set for `max_queue_size_`.
 
+* `~fill_value` (float, default: `nan`):
+
+   Initial value of depth image. The pixels where there is no corresponding point
+   are filled by this value.
 
 ## Sample
 

--- a/jsk_pcl_ros/include/jsk_pcl_ros/depth_image_creator.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/depth_image_creator.h
@@ -95,6 +95,7 @@ namespace jsk_pcl_ros
     tf::StampedTransform fixed_transform;
     tf::TransformListener* tf_listener_;
     double scale_depth;
+    float fill_value;
     typedef pcl::PointXYZRGB Point;
     typedef pcl::PointCloud< Point > PointCloud;
 

--- a/jsk_pcl_ros/src/depth_image_creator_nodelet.cpp
+++ b/jsk_pcl_ros/src/depth_image_creator_nodelet.cpp
@@ -62,6 +62,8 @@ void jsk_pcl_ros::DepthImageCreator::onInit () {
   pnh_->param("use_approximate", use_approximate, false);
   ROS_INFO("use_approximate : %d", use_approximate);
 
+  pnh_->param("fill_value", fill_value, std::numeric_limits<float>::quiet_NaN());
+
   pnh_->param("info_throttle", info_throttle_, 0);
   info_counter_ = 0;
   pnh_->param("max_queue_size", max_queue_size_, 3);
@@ -273,7 +275,7 @@ void jsk_pcl_ros::DepthImageCreator::publish_points(const sensor_msgs::CameraInf
   // Create color and depth image from point cloud
   cv::Mat color_mat = cv::Mat::zeros(rangeImageP.height, rangeImageP.width, CV_8UC3);
   cv::Mat depth_mat(rangeImageP.height, rangeImageP.width, CV_32FC1);
-  depth_mat.setTo(std::numeric_limits<float>::quiet_NaN());
+  depth_mat.setTo(fill_value);
   for (size_t i=0; i<pointCloud.size(); i++) {
     Point pt = pointCloud[i];
 


### PR DESCRIPTION
* Add ~fill_value parameter (default is nan) to specify initial value
  of depth image.