### PR TITLE
Publish organized pointcloud in DepthImageCreator

### DIFF
--- a/jsk_pcl_ros/src/depth_image_creator_nodelet.cpp
+++ b/jsk_pcl_ros/src/depth_image_creator_nodelet.cpp
@@ -331,13 +331,14 @@ void jsk_pcl_ros::DepthImageCreator::publish_points(const sensor_msgs::CameraInf
         for (int x = 0; x < (int)rangeImagePP.width; x++ ) {
           pcl::PointWithRange pt_from = rangeImagePP.points[rangeImagePP.width * y + x];
           cv::Vec3b rgb = color_mat.at<cv::Vec3b>(y, x);
-          Point pt_to = cloud_out[rangeImagePP.width * y + x];
+          Point pt_to;
           pt_to.x = pt_from.x;
           pt_to.y = pt_from.y;
           pt_to.z = pt_from.z;
           pt_to.r = rgb[0];
           pt_to.g = rgb[1];
           pt_to.b = rgb[2];
+          cloud_out.points[rangeImagePP.width * y + x] = pt_to;
         }
       }
       pub_cloud_.publish(boost::make_shared<PointCloud>(cloud_out));

--- a/jsk_pcl_ros/src/depth_image_creator_nodelet.cpp
+++ b/jsk_pcl_ros/src/depth_image_creator_nodelet.cpp
@@ -326,7 +326,9 @@ void jsk_pcl_ros::DepthImageCreator::publish_points(const sensor_msgs::CameraInf
     if (proc_cloud) {
       PointCloud cloud_out;
       cloud_out.header = rangeImagePP.header;
-      cloud_out.resize(rangeImagePP.points.size());
+      cloud_out.width = rangeImagePP.width;
+      cloud_out.height = rangeImagePP.height;
+      cloud_out.resize(cloud_out.width * cloud_out.height);
       for (int y = 0; y < (int)rangeImagePP.height; y++ ) {
         for (int x = 0; x < (int)rangeImagePP.width; x++ ) {
           pcl::PointWithRange pt_from = rangeImagePP.points[rangeImagePP.width * y + x];

--- a/jsk_pcl_ros/src/depth_image_creator_nodelet.cpp
+++ b/jsk_pcl_ros/src/depth_image_creator_nodelet.cpp
@@ -329,6 +329,7 @@ void jsk_pcl_ros::DepthImageCreator::publish_points(const sensor_msgs::CameraInf
       cloud_out.width = rangeImagePP.width;
       cloud_out.height = rangeImagePP.height;
       cloud_out.resize(cloud_out.width * cloud_out.height);
+      cloud_out.is_dense = true;
       for (int y = 0; y < (int)rangeImagePP.height; y++ ) {
         for (int x = 0; x < (int)rangeImagePP.width; x++ ) {
           pcl::PointWithRange pt_from = rangeImagePP.points[rangeImagePP.width * y + x];
@@ -341,6 +342,9 @@ void jsk_pcl_ros::DepthImageCreator::publish_points(const sensor_msgs::CameraInf
           pt_to.g = rgb[1];
           pt_to.b = rgb[2];
           cloud_out.points[rangeImagePP.width * y + x] = pt_to;
+          if (std::isnan(pt_to.x) || std::isnan(pt_to.y) || std::isnan(pt_to.z)) {
+            cloud_out.is_dense = false;
+          }
         }
       }
       pub_cloud_.publish(boost::make_shared<PointCloud>(cloud_out));


### PR DESCRIPTION
Fix https://github.com/jsk-ros-pkg/jsk_recognition/issues/2368

cc. @yuki-shark 

## Example

### Input
![depth_image_creator2_input](https://user-images.githubusercontent.com/22876283/63320563-26161d80-c359-11e9-98b7-a7681e84c613.png)
```
$ rostopic echo -n1 --noarr /concatenate_data/output 
header: 
  seq: 11641
  stamp: 
    secs: 1542364423
    nsecs: 329729788
  frame_id: /camera1_rgb_optical_frame
height: 1
width: 614400
is_bigendian: False
point_step: 32
row_step: 20480
is_dense: False
---
```

### Output before this PR
![depth_image_creator2_before](https://user-images.githubusercontent.com/22876283/63320515-fc5cf680-c358-11e9-835f-b7657123f8c6.png)
```
$ rostopic echo -n1 --noarr /depth_image_creator/output_cloud 
header: 
  seq: 27856
  stamp: 
    secs: 1542364429
    nsecs: 846039000
  frame_id: static_virtual_camera
height: 1
width: 153600
is_bigendian: False
point_step: 32
row_step: 4915200
is_dense: True
---
```
Positions of all points in this pointcloud are `(0, 0, 0)`, so they are shown at the origin of camera.
Also it is unorganized.

### Output after this PR
![depth_image_creator2_after](https://user-images.githubusercontent.com/22876283/63320584-33cba300-c359-11e9-8b37-a56cf2a301f4.png)
```
$ rostopic echo -n1 --noarr /depth_image_creator2/output_cloud 
header: 
  seq: 177
  stamp: 
    secs: 1542364425
    nsecs:  76445000
  frame_id: static_virtual_camera
height: 640
width: 240
is_bigendian: False
point_step: 32
row_step: 7680
is_dense: False
---
```
Points inside the virtual camera corn are correctly projected, and the pointcloud is organized as we expected.