### PR TITLE
[jsk_recognition_utils] Fix ear clipping triangulation to support concave polygon

### DIFF
--- a/jsk_recognition_utils/include/jsk_recognition_utils/pcl/ear_clipping_patched.h
+++ b/jsk_recognition_utils/include/jsk_recognition_utils/pcl/ear_clipping_patched.h
@@ -120,6 +120,17 @@ namespace pcl
         return p1[0]*p2[1] - p1[1]*p2[0];
       }
 
+      /** \brief Check if two line segments intersect by themselves.
+        * \param[in] p0 an end of the first line segment
+        * \param[in] p1 the other end of the first line segment
+        * \param[in] p2 an end of the second line segment
+        * \param[in] p3 the other end of the second line segment
+        */
+      bool
+      intersect (const Eigen::Vector3f& p0,
+                 const Eigen::Vector3f& p1,
+                 const Eigen::Vector3f& p2,
+                 const Eigen::Vector3f& p3);
   };
 
 }

--- a/jsk_recognition_utils/include/jsk_recognition_utils/pcl/ear_clipping_patched.h
+++ b/jsk_recognition_utils/include/jsk_recognition_utils/pcl/ear_clipping_patched.h
@@ -87,7 +87,7 @@ namespace pcl
         * \param[out] output the resultant polygonal mesh
         */
       size_t
-      triangulate (std::vector<uint32_t>& vertices, PolygonMesh& output);
+      triangulateClockwiseVertices (std::vector<uint32_t>& vertices, PolygonMesh& output);
 
       /** \brief Check if the triangle (u,v,w) is an ear. 
         * \param[in] u the first triangle vertex 

--- a/jsk_recognition_utils/include/jsk_recognition_utils/pcl/ear_clipping_patched.h
+++ b/jsk_recognition_utils/include/jsk_recognition_utils/pcl/ear_clipping_patched.h
@@ -82,11 +82,12 @@ namespace pcl
       void
       triangulate (const Vertices& vertices, PolygonMesh& output);
 
-      /** \brief Compute the signed area of a polygon. 
-        * \param[in] vertices the vertices representing the polygon 
+      /** \brief Triangulate one polygon, assume the vertices are clockwise. 
+        * \param[in] vertices the set of vertices
+        * \param[out] output the resultant polygonal mesh
         */
-      float
-      area (const std::vector<uint32_t>& vertices);
+      size_t
+      triangulate (std::vector<uint32_t>& vertices, PolygonMesh& output);
 
       /** \brief Check if the triangle (u,v,w) is an ear. 
         * \param[in] u the first triangle vertex 

--- a/jsk_recognition_utils/src/pcl/ear_clipping_patched.cpp
+++ b/jsk_recognition_utils/src/pcl/ear_clipping_patched.cpp
@@ -218,8 +218,14 @@ pcl::EarClippingPatched::intersect (const Eigen::Vector3f& p0,
   Eigen::Vector3f b = p3 - p2;
   Eigen::Vector3f c = p2 - p0;
 
+  // Parallel line segments do not intersect each other.
+  if (a.cross(b).norm() == 0)
+    return (false);
+
+  // Compute intersection of two lines.
   float s = (c.cross(b)).dot(a.cross(b)) / ((a.cross(b)).norm() * (a.cross(b)).norm());
   float t = (c.cross(a)).dot(a.cross(b)) / ((a.cross(b)).norm() * (a.cross(b)).norm());
 
+  // Check if the intersection is inside the line segments.
   return ((s >= 0 && s <= 1) && (t >= 0 && t <= 1));
 }

--- a/jsk_recognition_utils/src/pcl/ear_clipping_patched.cpp
+++ b/jsk_recognition_utils/src/pcl/ear_clipping_patched.cpp
@@ -81,7 +81,7 @@ pcl::EarClippingPatched::triangulate (const Vertices& vertices, PolygonMesh& out
   // if the input vertices order is anti-clockwise, it always left a
   // convex polygon and start infinite loops, which means will left more
   // than 3 points.
-  if(remaining_vertices.size() < 3)return;
+  if (remaining_vertices.size() < 3) return;
 
   output.polygons.erase(output.polygons.end(), output.polygons.end() + count);
   remaining_vertices.resize(n_vertices);

--- a/jsk_recognition_utils/src/pcl/ear_clipping_patched.cpp
+++ b/jsk_recognition_utils/src/pcl/ear_clipping_patched.cpp
@@ -76,7 +76,7 @@ pcl::EarClippingPatched::triangulate (const Vertices& vertices, PolygonMesh& out
   }
 
   std::vector<uint32_t> remaining_vertices = vertices.vertices;
-  size_t count = triangulate(remaining_vertices, output);
+  size_t count = triangulateClockwiseVertices(remaining_vertices, output);
 
   // if the input vertices order is anti-clockwise, it always left a
   // convex polygon and start infinite loops, which means will left more
@@ -87,12 +87,12 @@ pcl::EarClippingPatched::triangulate (const Vertices& vertices, PolygonMesh& out
   remaining_vertices.resize(n_vertices);
   for (size_t v = 0; v < n_vertices; v++)
       remaining_vertices[v] = vertices.vertices[n_vertices - 1 - v];
-  triangulate(remaining_vertices, output);
+  triangulateClockwiseVertices(remaining_vertices, output);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 size_t
-pcl::EarClippingPatched::triangulate (std::vector<uint32_t>& vertices, PolygonMesh& output)
+pcl::EarClippingPatched::triangulateClockwiseVertices (std::vector<uint32_t>& vertices, PolygonMesh& output)
 {
   // triangles count
   size_t count = 0;


### PR DESCRIPTION
Fix https://github.com/jsk-ros-pkg/jsk_visualization/issues/738

Current triangulation does not work correctly when concave polygon is passed.
The problem can be seen when the polygon is visualized in rviz (with `jsk_rviz_plugins`) like figures below.

This PR (based on https://github.com/PointCloudLibrary/pcl/pull/2743) will fix the problem, but there are a few differences not to use c++11.
- Do not use `cend()` for std::vector. Use `end()` instead.
- Do not use `emplace_back` for std::vector. Keep using `push_back`.

### Polygon edge (OK)
![fix_ear_clipping1](https://user-images.githubusercontent.com/22876283/63785525-7548e900-c92b-11e9-8474-19fe1a1ea3fa.png)
![fix_ear_clipping3](https://user-images.githubusercontent.com/22876283/63785526-7548e900-c92b-11e9-97ed-083087ceb724.png)

### Polygon surface before this PR (wrong)
__alpha = 1.0__
![polygon_wrongly_filled2](https://user-images.githubusercontent.com/22876283/63785424-4f234900-c92b-11e9-8d75-093b493eb76a.png)
![polygon_wrongly_filled4](https://user-images.githubusercontent.com/22876283/63785425-4f234900-c92b-11e9-8d51-48524c310c57.png)

__alpha = 0.5__
![polygon_wrongly_filled5](https://user-images.githubusercontent.com/22876283/64086852-7a67c700-cd75-11e9-9b17-ec456ba2a5c7.png)
![polygon_wrongly_filled6](https://user-images.githubusercontent.com/22876283/64086853-7a67c700-cd75-11e9-86d6-7962524184ea.png)

### Polygon surface after this PR (OK)
__alpha = 1.0__
![fix_ear_clipping2](https://user-images.githubusercontent.com/22876283/63785455-59454780-c92b-11e9-8947-d7935d8a5f6e.png)
![fix_ear_clipping4](https://user-images.githubusercontent.com/22876283/63785456-59ddde00-c92b-11e9-9609-de13e8b3369c.png)

__alpha = 0.5__
![polygon_wrongly_filled7](https://user-images.githubusercontent.com/22876283/64086889-a2efc100-cd75-11e9-8db2-fd3b25fc38de.png)
![polygon_wrongly_filled8](https://user-images.githubusercontent.com/22876283/64086890-a3885780-cd75-11e9-9962-f43210c70ade.png)
