### PR TITLE
fix xtion2 installation document

### DIFF
--- a/doc/install_xtion2.rst
+++ b/doc/install_xtion2.rst
@@ -32,7 +32,7 @@ Install SDK && Try Sample
   tar xf ASUS-Linux-x64-OpenNI2.2.tar.gz
   cd ASUS-Linux-x64-OpenNI2.2/
 
-  sudo apt-get install ros-indigo-openni2-launch ros-indigo-openni2-camera libopenni2-dev
+  sudo apt-get install ros-kinetic-openni2-launch ros-kinetic-openni2-camera libopenni2-dev
   sudo ./install.sh
   # you need to copy libSenDuck.so by manual
   sudo cp ASUS/Xtion2/lib/libSenDuck.so /usr/lib/OpenNI2/Drivers/
@@ -46,11 +46,11 @@ Use Xtion2 camera with ``openni2_camera`` ROS package
 
 .. code-block:: bash
 
-  cd ~/ros/indigo/src
+  cd ~/ros/kinetic/src
   wstool set ros-drivers/openni2_camera https://github.com/ros-drivers/openni2_camera.git --git -v 0.2.8 -y -u
 
-  source /opt/ros/indigo/setup.bash
+  source /opt/ros/kinetic/setup.bash
   catkin b
 
-  source ~/ros/indigo/devel/setup.bash
+  source ~/ros/kinetic/devel/setup.bash
   roslaunch openni2_launch openni2.launch

--- a/doc/install_xtion2.rst
+++ b/doc/install_xtion2.rst
@@ -32,7 +32,7 @@ Install SDK && Try Sample
   tar xf ASUS-Linux-x64-OpenNI2.2.tar.gz
   cd ASUS-Linux-x64-OpenNI2.2/
 
-  sudo apt-get install ros-kinetic-openni2-launch ros-kinetic-openni2-camera libopenni2-dev
+  sudo apt-get install ros-$(rosversion -d)-openni2-launch ros-$(rosversion -d)-openni2-camera libopenni2-dev
   sudo ./install.sh
   # you need to copy libSenDuck.so by manual
   sudo cp ASUS/Xtion2/lib/libSenDuck.so /usr/lib/OpenNI2/Drivers/
@@ -46,11 +46,11 @@ Use Xtion2 camera with ``openni2_camera`` ROS package
 
 .. code-block:: bash
 
-  cd ~/ros/kinetic/src
+  cd ~/ros/$(rosversion -d)/src
   wstool set ros-drivers/openni2_camera https://github.com/ros-drivers/openni2_camera.git --git -v 0.2.8 -y -u
 
-  source /opt/ros/kinetic/setup.bash
+  source /opt/ros/$(rosversion -d)/setup.bash
   catkin b
 
-  source ~/ros/kinetic/devel/setup.bash
+  source ~/ros/$(rosversion -d)/devel/setup.bash
   roslaunch openni2_launch openni2.launch

--- a/doc/install_xtion2.rst
+++ b/doc/install_xtion2.rst
@@ -29,10 +29,7 @@ Install SDK && Try Sample
 
   # Download SDK.zip from https://www.asus.com/3D-Sensor/Xtion-2/HelpDesk_Download/
   cd ~/Downloads
-  unzip SDK.zip
-  cd SDK/Linux
-
-  tar zxvf ASUS-Linux-x64-OpenNI2.2.tar.gz
+  tar xf ASUS-Linux-x64-OpenNI2.2.tar.gz
   cd ASUS-Linux-x64-OpenNI2.2/
 
   sudo apt-get install ros-indigo-openni2-launch ros-indigo-openni2-camera libopenni2-dev


### PR DESCRIPTION
fix xtion2 installation document because SDK files that can be downloaded from ASUS web sitte had changed. 