### PR TITLE
add the on-off function of using use_pca in dynamic reconfigure

### DIFF
--- a/jsk_pcl_ros/cfg/ClusterPointIndicesDecomposer.cfg
+++ b/jsk_pcl_ros/cfg/ClusterPointIndicesDecomposer.cfg
@@ -8,5 +8,6 @@ from dynamic_reconfigure.parameter_generator_catkin import *;
 gen = ParameterGenerator ()
 gen.add("max_size", int_t, 0, "the max number of the points of each cluster", -1, 0, 100000)
 gen.add("min_size", int_t, 0, "the minimum number of the points of each cluster", -1, 0, 1000)
+gen.add("use_pca", bool_t, 0, "the use_pca parameter", False)
 
 exit (gen.generate (PACKAGE, "jsk_pcl_ros", "ClusterPointIndicesDecomposer"))

--- a/jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
+++ b/jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
@@ -126,6 +126,7 @@ namespace jsk_pcl_ros
     boost::mutex::scoped_lock(mutex_);
     max_size_ = config.max_size;
     min_size_ = config.min_size;
+    use_pca_ = config.use_pca;
   }
 
   void ClusterPointIndicesDecomposer::subscribe()

--- a/jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
+++ b/jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
@@ -101,7 +101,6 @@ namespace jsk_pcl_ros
     } else if (pnh_->hasParam("target_frame_id")) {
       NODELET_WARN("Rosparam ~target_frame_id is used only with ~align_boxes:=true and ~align_boxes_with_plane:=true, so ignoring it.");
     }
-    pnh_->param("use_pca", use_pca_, false);
     pnh_->param("force_to_flip_z_axis", force_to_flip_z_axis_, true);
     pnh_->param<std::string>("sort_by", sort_by_, "input_indices");
     // dynamic_reconfigure


### PR DESCRIPTION
When I created the simple picking program, I added on-off function of using use_pca in dynamic reconfigure. I think it is more convenient.