### PR TITLE
[jsk_pcl_ros] Add nearest plane index label to cluster_point_indices_decomposer

### DIFF
--- a/doc/jsk_pcl_ros/nodes/cluster_point_indices_decomposer.md
+++ b/doc/jsk_pcl_ros/nodes/cluster_point_indices_decomposer.md
@@ -27,6 +27,8 @@ It also publishes tf of centroids of each cluster and oriented bounding box of t
 
    Array of oriented bounding box for each segmented cluster.
 
+   If `~align_boxes` and `~align_boxes_with_plane` are `True`, each box(`jsk_recognition_msgs/BoundingBox`)'s label indicates nearest plane index.
+
 * `~label` (`sensor_msgs/Image`):
 
    Label image for each cluster point indices.

--- a/doc/jsk_pcl_ros/nodes/cluster_point_indices_decomposer.md
+++ b/doc/jsk_pcl_ros/nodes/cluster_point_indices_decomposer.md
@@ -27,7 +27,7 @@ It also publishes tf of centroids of each cluster and oriented bounding box of t
 
    Array of oriented bounding box for each segmented cluster.
 
-   If `~align_boxes`, `~align_boxes_with_plane` and `~fill_bba_label_with_nearest_plane_index` are `True`,
+   If `~align_boxes`, `~align_boxes_with_plane` and `~fill_boxes_label_with_nearest_plane_index` are `True`,
    each box(`jsk_recognition_msgs/BoundingBox`)'s label indicates nearest plane index.
 
 * `~label` (`sensor_msgs/Image`):
@@ -109,7 +109,7 @@ It also publishes tf of centroids of each cluster and oriented bounding box of t
     - `z_axis`: sort by z axis of cloud
     - `cloud_size`: sort by size of cloud
 
-* `~fill_bba_label_with_nearest_plane_index` (Boolean, default: `False`):
+* `~fill_boxes_label_with_nearest_plane_index` (Boolean, default: `False`):
 
     If `~align_boxes`, `~align_boxes_with_plane` and this value are `True`,
     each box(`jsk_recognition_msgs/BoundingBox`)'s label indicates nearest plane index.

--- a/doc/jsk_pcl_ros/nodes/cluster_point_indices_decomposer.md
+++ b/doc/jsk_pcl_ros/nodes/cluster_point_indices_decomposer.md
@@ -27,7 +27,8 @@ It also publishes tf of centroids of each cluster and oriented bounding box of t
 
    Array of oriented bounding box for each segmented cluster.
 
-   If `~align_boxes` and `~align_boxes_with_plane` are `True`, each box(`jsk_recognition_msgs/BoundingBox`)'s label indicates nearest plane index.
+   If `~align_boxes`, `~align_boxes_with_plane` and `~fill_bba_label_with_nearest_plane_index` are `True`,
+   each box(`jsk_recognition_msgs/BoundingBox`)'s label indicates nearest plane index.
 
 * `~label` (`sensor_msgs/Image`):
 
@@ -107,6 +108,11 @@ It also publishes tf of centroids of each cluster and oriented bounding box of t
     - `input_indices`: same order as the input cluster indices
     - `z_axis`: sort by z axis of cloud
     - `cloud_size`: sort by size of cloud
+
+* `~fill_bba_label_with_nearest_plane_index` (Boolean, default: `False`):
+
+    If `~align_boxes`, `~align_boxes_with_plane` and this value are `True`,
+    each box(`jsk_recognition_msgs/BoundingBox`)'s label indicates nearest plane index.
 
 ## Sample
 

--- a/jsk_pcl_ros/cfg/ClusterPointIndicesDecomposer.cfg
+++ b/jsk_pcl_ros/cfg/ClusterPointIndicesDecomposer.cfg
@@ -9,7 +9,7 @@ gen = ParameterGenerator ()
 gen.add("max_size", int_t, 0, "the max number of the points of each cluster", -1, 0, 100000)
 gen.add("min_size", int_t, 0, "the minimum number of the points of each cluster", -1, 0, 1000)
 gen.add("use_pca", bool_t, 0, "the use_pca parameter", False)
-gen.add("fill_bba_label_with_nearest_plane_index",
+gen.add("fill_boxes_label_with_nearest_plane_index",
         bool_t, 0, "Fill bounding box label with nearest plane index", False)
 
 exit (gen.generate (PACKAGE, "jsk_pcl_ros", "ClusterPointIndicesDecomposer"))

--- a/jsk_pcl_ros/cfg/ClusterPointIndicesDecomposer.cfg
+++ b/jsk_pcl_ros/cfg/ClusterPointIndicesDecomposer.cfg
@@ -9,5 +9,7 @@ gen = ParameterGenerator ()
 gen.add("max_size", int_t, 0, "the max number of the points of each cluster", -1, 0, 100000)
 gen.add("min_size", int_t, 0, "the minimum number of the points of each cluster", -1, 0, 1000)
 gen.add("use_pca", bool_t, 0, "the use_pca parameter", False)
+gen.add("fill_bba_label_with_nearest_plane_index",
+        bool_t, 0, "Fill bounding box label with nearest plane index", False)
 
 exit (gen.generate (PACKAGE, "jsk_pcl_ros", "ClusterPointIndicesDecomposer"))

--- a/jsk_pcl_ros/include/jsk_pcl_ros/cluster_point_indices_decomposer.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/cluster_point_indices_decomposer.h
@@ -172,6 +172,7 @@ namespace jsk_pcl_ros
     std::string target_frame_id_;
     tf::TransformListener* tf_listener_;
     bool use_pca_;
+    bool fill_bba_label_with_nearest_plane_index_;
     int max_size_;
     int min_size_;
     std::string sort_by_;

--- a/jsk_pcl_ros/include/jsk_pcl_ros/cluster_point_indices_decomposer.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/cluster_point_indices_decomposer.h
@@ -172,7 +172,7 @@ namespace jsk_pcl_ros
     std::string target_frame_id_;
     tf::TransformListener* tf_listener_;
     bool use_pca_;
-    bool fill_bba_label_with_nearest_plane_index_;
+    bool fill_boxes_label_with_nearest_plane_index_;
     int max_size_;
     int min_size_;
     std::string sort_by_;

--- a/jsk_pcl_ros/include/jsk_pcl_ros/cluster_point_indices_decomposer.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/cluster_point_indices_decomposer.h
@@ -124,7 +124,8 @@ namespace jsk_pcl_ros
       const jsk_recognition_msgs::PolygonArrayConstPtr& planes,
       const jsk_recognition_msgs::ModelCoefficientsArrayConstPtr& coefficients,
       Eigen::Matrix4f& m4,
-      Eigen::Quaternionf& q);
+      Eigen::Quaternionf& q,
+      int& nearest_plane_index);
     
     virtual int findNearestPlane(const Eigen::Vector4f& center,
                                  const jsk_recognition_msgs::PolygonArrayConstPtr& planes,

--- a/jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
+++ b/jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
@@ -323,9 +323,10 @@ namespace jsk_pcl_ros
     const jsk_recognition_msgs::PolygonArrayConstPtr& planes,
     const jsk_recognition_msgs::ModelCoefficientsArrayConstPtr& coefficients,
     Eigen::Matrix4f& m4,
-    Eigen::Quaternionf& q)
+    Eigen::Quaternionf& q,
+    int& nearest_plane_index)
   {
-    int nearest_plane_index = findNearestPlane(center, planes, coefficients);
+    nearest_plane_index = findNearestPlane(center, planes, coefficients);
     if (nearest_plane_index == -1) {
       segmented_cloud_transformed = segmented_cloud;
       NODELET_ERROR("no planes to align boxes are given");
@@ -429,11 +430,13 @@ namespace jsk_pcl_ros
     // align boxes if possible
     Eigen::Matrix4f m4 = Eigen::Matrix4f::Identity();
     Eigen::Quaternionf q = Eigen::Quaternionf::Identity();
+    int nearest_plane_index = 0;
     if (align_boxes_) {
       if (align_boxes_with_plane_) {
         is_center_valid = pcl::compute3DCentroid(*segmented_cloud, center) != 0;
         bool success = transformPointCloudToAlignWithPlane(segmented_cloud, segmented_cloud_transformed,
-                                                           center, planes, coefficients, m4, q);
+                                                           center, planes, coefficients, m4, q,
+                                                           nearest_plane_index);
         if (!success) {
           return false;
         }
@@ -495,7 +498,8 @@ namespace jsk_pcl_ros
         planes_by_frame->polygons.push_back(plane_by_frame);
         //
         bool success = transformPointCloudToAlignWithPlane(segmented_cloud, segmented_cloud_transformed,
-                                                           center, planes_by_frame, coefficients_by_frame, m4, q);
+                                                           center, planes_by_frame, coefficients_by_frame, m4, q,
+                                                           nearest_plane_index);
         if (!success) {
           return false;
         }
@@ -548,6 +552,7 @@ namespace jsk_pcl_ros
     bounding_box.dimensions.x = xwidth;
     bounding_box.dimensions.y = ywidth;
     bounding_box.dimensions.z = zwidth;
+    bounding_box.label = nearest_plane_index;
     return true;
   }
 

--- a/jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
+++ b/jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
@@ -126,7 +126,7 @@ namespace jsk_pcl_ros
     max_size_ = config.max_size;
     min_size_ = config.min_size;
     use_pca_ = config.use_pca;
-    fill_bba_label_with_nearest_plane_index_ = config.fill_bba_label_with_nearest_plane_index;
+    fill_boxes_label_with_nearest_plane_index_ = config.fill_boxes_label_with_nearest_plane_index;
   }
 
   void ClusterPointIndicesDecomposer::subscribe()
@@ -555,7 +555,7 @@ namespace jsk_pcl_ros
     bounding_box.dimensions.z = zwidth;
     if (align_boxes_ &&
         align_boxes_with_plane_ &&
-        fill_bba_label_with_nearest_plane_index_) {
+        fill_boxes_label_with_nearest_plane_index_) {
       bounding_box.label = nearest_plane_index;
     }
     return true;

--- a/jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
+++ b/jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
@@ -126,6 +126,7 @@ namespace jsk_pcl_ros
     max_size_ = config.max_size;
     min_size_ = config.min_size;
     use_pca_ = config.use_pca;
+    fill_bba_label_with_nearest_plane_index_ = config.fill_bba_label_with_nearest_plane_index;
   }
 
   void ClusterPointIndicesDecomposer::subscribe()
@@ -552,7 +553,11 @@ namespace jsk_pcl_ros
     bounding_box.dimensions.x = xwidth;
     bounding_box.dimensions.y = ywidth;
     bounding_box.dimensions.z = zwidth;
-    bounding_box.label = nearest_plane_index;
+    if (align_boxes_ &&
+        align_boxes_with_plane_ &&
+        fill_bba_label_with_nearest_plane_index_) {
+      bounding_box.label = nearest_plane_index;
+    }
     return true;
   }
 


### PR DESCRIPTION
Currently, each box label of output boxes of cluster_point_indices_descomposer is always 0.
With this PR, If `~align_boxes` and `~align_boxes_with_plane` are `True`, each 
box(`jsk_recognition_msgs/BoundingBox`)'s label indicates nearest plane index.

The visualized results as follows:
With this PR
![Selection_002](https://user-images.githubusercontent.com/4690682/69005646-773da980-0968-11ea-9578-d02727fb425e.png)

Without this PR
![Selection_001](https://user-images.githubusercontent.com/4690682/69005647-7dcc2100-0968-11ea-9254-3a21e0d58052.png)
