### PR TITLE
set chainer version less than 7.0.0

### DIFF
--- a/jsk_perception/package.xml
+++ b/jsk_perception/package.xml
@@ -77,7 +77,7 @@
   <run_depend>posedetection_msgs</run_depend>
   <!-- install chainer {{ -->
   <run_depend>python-h5py</run_depend>
-  <run_depend>python-chainer-pip</run_depend>
+  <run_depend version_lt="7.0.0">python-chainer-pip</run_depend>
   <run_depend>python-chainercv-pip</run_depend>
   <!-- }} install chainer -->
   <run_depend>python-dlib</run_depend>  <!-- pip -->

--- a/jsk_perception/package.xml
+++ b/jsk_perception/package.xml
@@ -77,7 +77,11 @@
   <run_depend>posedetection_msgs</run_depend>
   <!-- install chainer {{ -->
   <run_depend>python-h5py</run_depend>
-  <run_depend version_lt="7.0.0">python-chainer-pip</run_depend>
+  <!-- Install chainer manually because chainer>=7.0.0 does not work on python 2-->
+  <!-- see: https://github.com/chainer/chainer/pull/8517 -->
+  <!-- Also, rosdep install packages on latest version -->
+  <!-- see: https://github.com/ros-infrastructure/rosdep/pull/694 -->
+  <!-- run_depend version_lt="7.0.0">python-chainer-pip</run_depend -->
   <run_depend>python-chainercv-pip</run_depend>
   <!-- }} install chainer -->
   <run_depend>python-dlib</run_depend>  <!-- pip -->

--- a/jsk_recognition_utils/package.xml
+++ b/jsk_recognition_utils/package.xml
@@ -38,7 +38,7 @@
   <run_depend>jsk_topic_tools</run_depend>
   <run_depend>pcl_msgs</run_depend>
   <run_depend>pcl_ros</run_depend>
-  <run_depend>python-chainer-pip</run_depend>
+  <run_depend version_lt="7.0.0">python-chainer-pip</run_depend>
   <run_depend>python-skimage</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>

--- a/jsk_recognition_utils/package.xml
+++ b/jsk_recognition_utils/package.xml
@@ -38,7 +38,11 @@
   <run_depend>jsk_topic_tools</run_depend>
   <run_depend>pcl_msgs</run_depend>
   <run_depend>pcl_ros</run_depend>
-  <run_depend version_lt="7.0.0">python-chainer-pip</run_depend>
+  <!-- Install chainer manually because chainer>=7.0.0 does not work on python 2-->
+  <!-- see: https://github.com/chainer/chainer/pull/8517 -->
+  <!-- Also, rosdep install packages on latest version -->
+  <!-- see https://github.com/ros-infrastructure/rosdep/pull/694 -->
+  <!-- run_depend version_lt="7.0.0">python-chainer-pip</run_depend -->
   <run_depend>python-skimage</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>


### PR DESCRIPTION
chainer v7.0.0 drops python2.7 support.

I don't know why these people love breaking dependencies... :(