### PR TITLE
set chainer version less than 7.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_script:
   - if [[ "$ROS_DISTRO" == "melodic" && "$DOCKER_IMAGE_JENKINS" == "" ]]; then export export DOCKER_IMAGE_JENKINS='ros-ubuntu:18.04-pcl'; fi
 script:
   # use https://github.com/ros-infrastructure/rosdep/pull/694 to respect version_lt for python pip, some package requries python3
-  - export BEFORE_SCRIPT="sudo apt-get install -y patchutils; curl -sL https://patch-diff.githubusercontent.com/raw/ros-infrastructure/rosdep/pull/753.diff | sudo patch -d /usr/lib/python2.7/dist-packages/ -p2; curl -sL https://patch-diff.githubusercontent.com/raw/ros-infrastructure/rosdep/pull/694.diff | filterdiff --exclude='a/test/*' | sudo patch -d /usr/lib/python2.7/dist-packages/ -p2; $BEFORE_SCRIPT"
+  - export BEFORE_SCRIPT="sudo apt-get install -y patchutils; curl -sL https://patch-diff.githubusercontent.com/raw/ros-infrastructure/rosdep/pull/753.diff | sudo patch -d /usr/lib/python2.7/dist-packages/ -p2; curl -sL https://patch-diff.githubusercontent.com/raw/ros-infrastructure/rosdep/pull/694.diff | filterdiff --exclude='a/test/*' | sudo patch -d /usr/lib/python2.7/dist-packages/ -p2; sudo pip install chainer==6.7.0; $BEFORE_SCRIPT"
   - source .travis/travis.sh
   - (cd $TRAVIS_BUILD_DIR/doc && source setup.sh && make html)
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ before_script:
   - if [[ "$ROS_DISTRO" == "melodic" && "$DOCKER_IMAGE_JENKINS" == "" ]]; then export export DOCKER_IMAGE_JENKINS='ros-ubuntu:18.04-pcl'; fi
 script:
   # use https://github.com/ros-infrastructure/rosdep/pull/694 to respect version_lt for python pip, some package requries python3
-  - export BEFORE_SCRIPT="sudo apt-get install -y patchutils; curl -sL https://patch-diff.githubusercontent.com/raw/ros-infrastructure/rosdep/pull/753.diff | sudo patch -d /usr/lib/python2.7/dist-packages/ -p2; curl -sL https://patch-diff.githubusercontent.com/raw/ros-infrastructure/rosdep/pull/694.diff | filterdiff --exclude='a/test/*' | sudo patch -d /usr/lib/python2.7/dist-packages/ -p2; sudo pip install chainer==6.7.0; $BEFORE_SCRIPT"
+  - export BEFORE_SCRIPT="sudo pip install chainer==6.7.0; $BEFORE_SCRIPT"
+  - if [[ "$ROS_DISTRO" == "kinetic" && "$ROS_DISTRO" == "melodic" ]]; then export BEFORE_SCRIPT="sudo apt-get install -y patchutils; curl -sL https://patch-diff.githubusercontent.com/raw/ros-infrastructure/rosdep/pull/753.diff | sudo patch -d /usr/lib/python2.7/dist-packages/ -p2; curl -sL https://patch-diff.githubusercontent.com/raw/ros-infrastructure/rosdep/pull/694.diff | filterdiff --exclude='a/test/*' | sudo patch -d /usr/lib/python2.7/dist-packages/ -p2; $BEFORE_SCRIPT"; fi
   - source .travis/travis.sh
   - (cd $TRAVIS_BUILD_DIR/doc && source setup.sh && make html)
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ before_script:
   - if [[ "$ROS_DISTRO" == "kinetic" && "$DOCKER_IMAGE_JENKINS" == "" ]]; then export export DOCKER_IMAGE_JENKINS='ros-ubuntu:16.04-pcl'; fi
   - if [[ "$ROS_DISTRO" == "melodic" && "$DOCKER_IMAGE_JENKINS" == "" ]]; then export export DOCKER_IMAGE_JENKINS='ros-ubuntu:18.04-pcl'; fi
 script:
+  # use https://github.com/ros-infrastructure/rosdep/pull/694 to respect version_lt for python pip, some package requries python3
+  - export BEFORE_SCRIPT="sudo apt-get install -y patchutils; curl -sL https://patch-diff.githubusercontent.com/raw/ros-infrastructure/rosdep/pull/753.diff | sudo patch -d /usr/lib/python2.7/dist-packages/ -p2; curl -sL https://patch-diff.githubusercontent.com/raw/ros-infrastructure/rosdep/pull/694.diff | filterdiff --exclude='a/test/*' | sudo patch -d /usr/lib/python2.7/dist-packages/ -p2; $BEFORE_SCRIPT"
   - source .travis/travis.sh
   - (cd $TRAVIS_BUILD_DIR/doc && source setup.sh && make html)
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_script:
   - if [[ "$ROS_DISTRO" == "melodic" && "$DOCKER_IMAGE_JENKINS" == "" ]]; then export export DOCKER_IMAGE_JENKINS='ros-ubuntu:18.04-pcl'; fi
 script:
   # use https://github.com/ros-infrastructure/rosdep/pull/694 to respect version_lt for python pip, some package requries python3
-  - export BEFORE_SCRIPT="sudo pip install chainer==6.7.0; $BEFORE_SCRIPT"
+  - export BEFORE_SCRIPT="sudo pip install fcn chainercv chainer==6.7.0; $BEFORE_SCRIPT"
   - if [[ "$ROS_DISTRO" == "kinetic" && "$ROS_DISTRO" == "melodic" ]]; then export BEFORE_SCRIPT="sudo apt-get install -y patchutils; curl -sL https://patch-diff.githubusercontent.com/raw/ros-infrastructure/rosdep/pull/753.diff | sudo patch -d /usr/lib/python2.7/dist-packages/ -p2; curl -sL https://patch-diff.githubusercontent.com/raw/ros-infrastructure/rosdep/pull/694.diff | filterdiff --exclude='a/test/*' | sudo patch -d /usr/lib/python2.7/dist-packages/ -p2; $BEFORE_SCRIPT"; fi
   - source .travis/travis.sh
   - (cd $TRAVIS_BUILD_DIR/doc && source setup.sh && make html)

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_script:
   - if [[ "$ROS_DISTRO" == "melodic" && "$DOCKER_IMAGE_JENKINS" == "" ]]; then export export DOCKER_IMAGE_JENKINS='ros-ubuntu:18.04-pcl'; fi
 script:
   # use https://github.com/ros-infrastructure/rosdep/pull/694 to respect version_lt for python pip, some package requries python3
+  - export BEFORE_SCRIPT="sudo pip install numpy==1.16.6; $BEFORE_SCRIPT"
   - export BEFORE_SCRIPT="sudo pip install fcn chainercv chainer==6.7.0; $BEFORE_SCRIPT"
   - if [[ "$ROS_DISTRO" == "kinetic" && "$ROS_DISTRO" == "melodic" ]]; then export BEFORE_SCRIPT="sudo apt-get install -y patchutils; curl -sL https://patch-diff.githubusercontent.com/raw/ros-infrastructure/rosdep/pull/753.diff | sudo patch -d /usr/lib/python2.7/dist-packages/ -p2; curl -sL https://patch-diff.githubusercontent.com/raw/ros-infrastructure/rosdep/pull/694.diff | filterdiff --exclude='a/test/*' | sudo patch -d /usr/lib/python2.7/dist-packages/ -p2; $BEFORE_SCRIPT"; fi
   - source .travis/travis.sh

--- a/checkerboard_detector/test/objectdetection_tf_publisher.test
+++ b/checkerboard_detector/test/objectdetection_tf_publisher.test
@@ -17,7 +17,7 @@
   <test test-name="test_objectdetection_tf_publisher"
         name="test_objectdetection_tf_publisher"
         pkg="jsk_tools" type="test_topic_published.py"
-        time-limit="10" retry="3">
+        time-limit="15" retry="3">
     <rosparam>
       topic_0: /tf_to_transform_map_to_checkerboard/output
       timeout_0: 10

--- a/jsk_pcl_ros/test/test_depth_calibration.test
+++ b/jsk_pcl_ros/test/test_depth_calibration.test
@@ -7,7 +7,7 @@
   <test test-name="test_depth_calibration"
         name="test_depth_calibration"
         pkg="jsk_tools" type="test_topic_published.py"
-        retry="3">
+        time-limit="35" retry="3">
     <rosparam>
       topic_0: /depth_calibration/output
       timeout_0: 30

--- a/jsk_pcl_ros/test/test_linemod_trainer.test
+++ b/jsk_pcl_ros/test/test_linemod_trainer.test
@@ -8,7 +8,8 @@
 
   <test test-name="test_linemod_trainer"
         name="test_linemod_trainer"
-        pkg="jsk_pcl_ros" type="test_linemod_trainer.py">
+        pkg="jsk_pcl_ros" type="test_linemod_trainer.py"
+        time-limit="70" retry="3">
     <rosparam subst_value="true">
       linemod_path: $(arg output_path).linemod
       pcd_path: $(arg output_path).pcd

--- a/jsk_pcl_ros_utils/test/depth_image_error.test
+++ b/jsk_pcl_ros_utils/test/depth_image_error.test
@@ -7,7 +7,7 @@
   <test test-name="test_depth_image_error"
         name="test_depth_image_error"
         pkg="jsk_tools" type="test_topic_published.py"
-        retry="3">
+        time-limit="35" retry="3">
     <rosparam>
       topic_0: /depth_image_error/output
       timeout_0: 30

--- a/jsk_perception/package.xml
+++ b/jsk_perception/package.xml
@@ -99,6 +99,7 @@
   <run_depend>sound_play</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>tf</run_depend>
+  <run_depend>tf2_geometry_msgs</run_depend>
   <run_depend>topic_tools</run_depend>
   <run_depend>robot_self_filter</run_depend>
   <run_depend>yaml-cpp</run_depend>

--- a/jsk_perception/package.xml
+++ b/jsk_perception/package.xml
@@ -77,7 +77,7 @@
   <run_depend>posedetection_msgs</run_depend>
   <!-- install chainer {{ -->
   <run_depend>python-h5py</run_depend>
-  <run_depend>python-chainer-pip</run_depend>
+  <run_depend version_lt="7.0.0">python-chainer-pip</run_depend>
   <run_depend>python-chainercv-pip</run_depend>
   <!-- }} install chainer -->
   <run_depend>python-dlib</run_depend>  <!-- pip -->

--- a/jsk_perception/test/bing.test
+++ b/jsk_perception/test/bing.test
@@ -4,15 +4,22 @@
     <arg name="gui" value="false" />
   </include>
 
-  <test test-name="test_bing"
-        name="test_bing"
+  <test test-name="test_bing_output"
+        name="test_bing_output"
         pkg="jsk_tools" type="test_topic_published.py"
         time-limit="45" retry="6">
     <rosparam>
       topic_0: /bing/output
       timeout_0: 30
-      topic_1: /bing/output/objectness
-      timeout_1: 30
+    </rosparam>
+  </test>
+  <test test-name="test_bing_objectness"
+        name="test_bing_objectness"
+        pkg="jsk_tools" type="test_topic_published.py"
+        time-limit="45" retry="6">
+    <rosparam>
+      topic_0: /bing/output/objectness
+      timeout_0: 30
     </rosparam>
   </test>
 

--- a/jsk_perception/test/bing.test
+++ b/jsk_perception/test/bing.test
@@ -7,7 +7,7 @@
   <test test-name="test_bing"
         name="test_bing"
         pkg="jsk_tools" type="test_topic_published.py"
-        retry="6">
+        time-limit="45" retry="6">
     <rosparam>
       topic_0: /bing/output
       timeout_0: 30

--- a/jsk_perception/test/draw_classification_result.test
+++ b/jsk_perception/test/draw_classification_result.test
@@ -6,7 +6,8 @@
 
   <test test-name="test_draw_classification_result"
         name="test_draw_classification_result"
-        pkg="jsk_tools" type="test_topic_published.py">
+        pkg="jsk_tools" type="test_topic_published.py"
+        time-limit="15" retry="3">
     <rosparam>
       topic_0: /draw_classification_result/output
       timeout_0: 10

--- a/jsk_perception/test/pointit.test
+++ b/jsk_perception/test/pointit.test
@@ -7,7 +7,7 @@
   <test test-name="test_pointit"
         name="test_pointit"
         pkg="jsk_tools" type="test_topic_published.py"
-        retry="3">
+        time-limit="35" retry="3">
     <rosparam>
       topic_0: /pointit/output
       timeout_0: 30

--- a/jsk_recognition_msgs/test/plot_data_to_csv.test
+++ b/jsk_recognition_msgs/test/plot_data_to_csv.test
@@ -8,7 +8,7 @@
   <test test-name="test_plot_data_to_csv"
         name="test_plot_data_to_csv"
         pkg="jsk_recognition_msgs" type="test_plot_data_to_csv.py"
-        time-limit="10">
+        time-limit="10" retry="3" >
     <rosparam subst_value="true">
       csv_path: $(arg csv_path)
       timeout: 5.0

--- a/jsk_recognition_utils/package.xml
+++ b/jsk_recognition_utils/package.xml
@@ -38,7 +38,7 @@
   <run_depend>jsk_topic_tools</run_depend>
   <run_depend>pcl_msgs</run_depend>
   <run_depend>pcl_ros</run_depend>
-  <run_depend>python-chainer-pip</run_depend>
+  <run_depend version_lt="7.0.0">python-chainer-pip</run_depend>
   <run_depend>python-skimage</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>


### PR DESCRIPTION
rewrited version of #2480 with https://github.com/ros-infrastructure/rosdep/pull/694 (support version_lt for pip)

- use https://github.com/ros-infrastructure/rosdep/pull/694 to respect  version_lt for python pip, some package requries python3
- set chainer version less than 7.0.0