### PR TITLE
[audio_to_spectrogram] Add README for usage and scripts interface

### DIFF
--- a/audio_to_spectrogram/README.md
+++ b/audio_to_spectrogram/README.md
@@ -1,0 +1,86 @@
+# audio_to_spectrogram
+
+This package converts audio data to spectrum and spectrogram data.
+
+# Usage
+By following command, you can publish audio, spectrum and spectrogram topics. Please set correct args for your microphone configuration, such as mic\_sampling\_rate or bitdepth.
+
+```bash
+roslaunch audio_to_spectrogram audio_to_spectrogram.launch
+```
+
+Here is an example using rosbag with 300Hz audio.
+```bash
+roslaunch audio_to_spectrogram sample_audio_to_spectrogram.launch
+```
+
+|Spectrum|Spectrogram|
+|---|---|
+|![](https://user-images.githubusercontent.com/19769486/82075694-9a7ac300-9717-11ea-899c-db6119a76d52.png)|![](https://user-images.githubusercontent.com/19769486/82075685-96e73c00-9717-11ea-9abc-e6e74104d666.png)|
+
+# Scripts
+
+## audio_to_spectrum.py
+  A script to convert audio to spectrum.
+
+  - ### Publishing topics
+
+    - `~spectrum` (`jsk_recognition_msgs/Spectrum`)
+
+      Spectrum data calculated from audio by FFT.
+
+  - ### Subscribing topics
+    - `audio` (`audio_common_msgs/AudioData`)
+
+      Audio stream data from microphone. The audio format must be `wave`.
+
+  - ### Parameters
+    - `~mic_sampling_rate` (`Int`, default: `16000`)
+
+      Sampling rate [Hz] of microphone. Namely, sampling rate of audio topic.
+
+    - `~fft_sampling_period` (`Double`, default: `0.3`)
+
+      Period [s] to sample audio data for one FFT.
+
+    - `~depth` (`Int`, default: `16`)
+
+      Number of bits per audio data.
+
+    - `~high_cut_freq` (`Int`, default: `800`)
+
+      Threshold to limit the maximum frequency of the output spectrum.
+
+    - `~low_cut_freq` (`Int`, default: `1`)
+
+      Threshold to limit the minimum frequency of the output spectrum.
+
+## spectrum_to_spectrogram.py
+  A script to convert spectrum to spectrogram.
+
+  - ### Publishing topics
+    - `~spectrogram` (`sensor_msgs/Image`)
+
+      Spectrogram data, which is concatenation of spectrum in time series. Image format is 32FC1.
+
+  - ### Subscribing topics
+    - `~spectrum` (`jsk_recognition_msgs/Spectrum`)
+
+      Spectrum data calculated from audio by FFT.
+
+  - ### Parameters
+    - `~image_height` (`Int`, default: `300`)
+
+      Number of vertical (frequency axis) pixels in output spectrogram.
+
+    - `~image_width` (`Int`, default: `300`)
+
+      Number of horizontal (time axis) pixels in output spectrogram.
+
+    - `~spectrogram_period` (`Double`, default: `5`)
+
+      Period [s] to store spectrum data to create one spectrogram topic.
+
+    - `~publish_rate` (`Double`, default: `image_width / spectrogram_period`)
+
+      Publish rate [Hz] of spectrogram topic.

--- a/audio_to_spectrogram/launch/audio_to_spectrogram.launch
+++ b/audio_to_spectrogram/launch/audio_to_spectrogram.launch
@@ -2,17 +2,35 @@
 <!-- audio -> spectrum -> spectrogram -->
 
 <launch>
-  <arg name="gui" default="true" />
+  <arg name="launch_audio_capture" default="true" />
+
+  <arg name="bitdepth" default="16" />
+  <arg name="mic_sampling_rate" default="16000" />
+  <arg name="device" default="hw:0,0" />
   <arg name="audio_topic" default="/audio" />
+  <arg name="gui" default="true" />
+
+  <!-- Publish audio topic from microphone -->
+  <node name="audio_capture" pkg="audio_capture" type="audio_capture"
+        if="$(arg launch_audio_capture)"
+        respawn="true">
+    <rosparam subst_value="true">
+      format: wave
+      channels: 1
+      depth: $(arg bitdepth)
+      sample_rate: $(arg mic_sampling_rate)
+      device: $(arg device)
+    </rosparam>
+  </node>
 
   <!-- convert audio topic to spectrum topic -->
   <node pkg="audio_to_spectrogram" type="audio_to_spectrum.py" name="audio_to_spectrum" respawn="true">
     <remap from="~audio" to="$(arg audio_topic)" />
-    <rosparam>
+    <rosparam subst_value="true">
       <!-- meaning of rosparams below are described in audio_to_spectrum.py -->
-      mic_sampling_rate: 16000
+      mic_sampling_rate: $(arg mic_sampling_rate)
       fft_sampling_period: 0.3
-      bitdepth: 16
+      bitdepth: $(arg bitdepth)
       high_cut_freq: 800
       low_cut_freq: 1
       fft_exec_rate: 50

--- a/audio_to_spectrogram/launch/audio_to_spectrogram.launch
+++ b/audio_to_spectrogram/launch/audio_to_spectrogram.launch
@@ -30,7 +30,6 @@
   <node pkg="audio_to_spectrogram" type="audio_to_spectrum.py" name="audio_to_spectrum" respawn="true">
     <remap from="~audio" to="$(arg audio_topic)" />
     <rosparam subst_value="true">
-      <!-- meaning of rosparams below are described in audio_to_spectrum.py -->
       mic_sampling_rate: $(arg mic_sampling_rate)
       fft_sampling_period: 0.3
       bitdepth: $(arg bitdepth)
@@ -44,7 +43,6 @@
   <node pkg="audio_to_spectrogram" type="spectrum_to_spectrogram.py" name="spectrum_to_spectrogram" respawn="true">
     <remap from="~spectrum" to="/audio_to_spectrum/spectrum_filtered" />
     <rosparam subst_value="true">
-      <!-- meaning of rosparams below are described in spectrum_to_spectrogram.py -->
       image_height: 300
       image_width: 300
       spectrogram_period: $(arg spectrogram_period)

--- a/audio_to_spectrogram/launch/audio_to_spectrogram.launch
+++ b/audio_to_spectrogram/launch/audio_to_spectrogram.launch
@@ -8,6 +8,9 @@
   <arg name="mic_sampling_rate" default="16000" />
   <arg name="device" default="hw:0,0" />
   <arg name="audio_topic" default="/audio" />
+  <arg name="high_cut_freq" default="800" />
+  <arg name="low_cut_freq" default="1" />
+  <arg name="spectrogram_period" default="5" />
   <arg name="gui" default="true" />
 
   <!-- Publish audio topic from microphone -->
@@ -31,8 +34,8 @@
       mic_sampling_rate: $(arg mic_sampling_rate)
       fft_sampling_period: 0.3
       bitdepth: $(arg bitdepth)
-      high_cut_freq: 800
-      low_cut_freq: 1
+      high_cut_freq: $(arg high_cut_freq)
+      low_cut_freq: $(arg low_cut_freq)
       fft_exec_rate: 50
     </rosparam>
   </node>
@@ -40,11 +43,11 @@
   <!-- convert spectrum topic to spectrogram topic -->
   <node pkg="audio_to_spectrogram" type="spectrum_to_spectrogram.py" name="spectrum_to_spectrogram" respawn="true">
     <remap from="~spectrum" to="/audio_to_spectrum/spectrum_filtered" />
-    <rosparam>
+    <rosparam subst_value="true">
       <!-- meaning of rosparams below are described in spectrum_to_spectrogram.py -->
       image_height: 300
       image_width: 300
-      spectrogram_period: 5
+      spectrogram_period: $(arg spectrogram_period)
     </rosparam>
   </node>
 

--- a/audio_to_spectrogram/package.xml
+++ b/audio_to_spectrogram/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <run_depend>audio_capture</run_depend>
   <run_depend>audio_common_msgs</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>image_view</run_depend>

--- a/audio_to_spectrogram/sample/sample_audio_to_spectrogram.launch
+++ b/audio_to_spectrogram/sample/sample_audio_to_spectrogram.launch
@@ -12,6 +12,7 @@
         args="$(arg filename) --clock --loop"/>
 
   <include file="$(find audio_to_spectrogram)/launch/audio_to_spectrogram.launch" >
+    <arg name="launch_audio_capture" value="false" />
     <arg name="gui" value="$(arg gui)" />
   </include>
 


### PR DESCRIPTION
In this pull request, I did:
- Add `README.md` for usage and scripts interface (main part of this pull request)
- add arg to run `audio_capture` to `audio_to_spectrogram.launch`

I am sorry that I did not add `README.md` in the previous pull request.