### PR TITLE
fix print syntax in train_ssd.py

### DIFF
--- a/jsk_perception/scripts/train_ssd.py
+++ b/jsk_perception/scripts/train_ssd.py
@@ -162,7 +162,7 @@ def main():
     elif (args.dataset_type == 'bbox'):
         train_dataset = BboxDetectionDataset(args.train_dataset_dir)
     else:
-        print 'unsuppported dataset type'
+        print('unsuppported dataset type')
         return
 
     fg_label_names = train_dataset.fg_class_names


### PR DESCRIPTION
Because of `jsk_perception/scripts/train_ssd.py` 's syntax error in l165, the error message couldn't be shown correctly. This python2 script includes `print_function` from `__future__`, so I think my style is correct. I confirmed work correctly.

Before
```bash
$ rosrun jsk_perception train_ssd.py dataset_voc/
  File "/home/yoshiki/research_ws/src/jsk_recognition/jsk_perception/scripts/train_ssd.py", line 165
    print 'unsuppported dataset type'
                                    ^
SyntaxError: invalid syntax
```

After
```bash
$ rosrun jsk_perception train_ssd.py dataset_voc/
Please install CuPy

    sudo pip install cupy-cuda[your cuda version]
i.e.
    sudo pip install cupy-cuda91
```

Thanks.