### PR TITLE
[jsk_recognition_utils] add rect_array_to_cluster_point_indices.py

### DIFF
--- a/doc/jsk_recognition_utils/nodes/rect_array_to_cluster_point_indices.md
+++ b/doc/jsk_recognition_utils/nodes/rect_array_to_cluster_point_indices.md
@@ -1,0 +1,55 @@
+# rect_array_to_cluster_point_indices.py
+
+## What is this?
+
+Convert `jsk_recognition_msgs/RectArray` to `jsk_recognition_msgs/ClusterPointIndices`
+
+## Subscribing Topic
+
+* `~input` (`jsk_recognition_msgs/RectArray`)
+
+  Input rect array.
+
+* `~input/info` (`sensor_msgs/CameraInfo`)
+
+  Input camera info. Subscribe only when `use_info` is `true`.
+
+## Publishing Topic
+
+
+* `~output` (`jsk_recognition_msgs/ClusterPointIndices`)
+
+  Output cluster point indices.
+
+## Parameters
+
+* `~use_info` (Bool, Default: `false`)
+
+  Subscribe camera_info topic or not
+
+* `img_width`: (Int, required)
+
+  Image width. Required only when `use_info` is `false`.
+
+* `img_height`: (Int, required)
+
+  Image height. Required only when `use_info` is `false`.
+
+* `~queue_size` (Int, Default: `10`)
+
+  Queue size for `message_filters`. Used only when `use_info` is `true`.
+
+* `approximate_sync` (Bool, Default: `false`)
+
+  Use approximate_sync or not. Used only when `use_info` is `true`.
+
+* `slop` (Float, Default: `0.1`)
+
+  Slop size for `message_filters`. Used only when `use_info` is `true`.
+
+
+## Sample
+
+```bash
+roslaunch jsk_recognition_utils sample_rect_array_to_cluster_point_indices.launch
+```

--- a/doc/jsk_recognition_utils/nodes/rect_array_to_cluster_point_indices.md
+++ b/doc/jsk_recognition_utils/nodes/rect_array_to_cluster_point_indices.md
@@ -27,11 +27,11 @@ Convert `jsk_recognition_msgs/RectArray` to `jsk_recognition_msgs/ClusterPointIn
 
   Subscribe camera_info topic or not
 
-* `img_width`: (Int, required)
+* `~img_width`: (Int, required)
 
   Image width. Required only when `use_info` is `false`.
 
-* `img_height`: (Int, required)
+* `~img_height`: (Int, required)
 
   Image height. Required only when `use_info` is `false`.
 
@@ -39,11 +39,11 @@ Convert `jsk_recognition_msgs/RectArray` to `jsk_recognition_msgs/ClusterPointIn
 
   Queue size for `message_filters`. Used only when `use_info` is `true`.
 
-* `approximate_sync` (Bool, Default: `false`)
+* `~approximate_sync` (Bool, Default: `false`)
 
   Use approximate_sync or not. Used only when `use_info` is `true`.
 
-* `slop` (Float, Default: `0.1`)
+* `~slop` (Float, Default: `0.1`)
 
   Slop size for `message_filters`. Used only when `use_info` is `true`.
 

--- a/jsk_recognition_utils/node_scripts/rect_array_to_cluster_point_indices.py
+++ b/jsk_recognition_utils/node_scripts/rect_array_to_cluster_point_indices.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+import numpy as np
+
+import message_filters
+import rospy
+
+from jsk_recognition_msgs.msg import ClusterPointIndices
+from jsk_recognition_msgs.msg import RectArray
+from jsk_topic_tools import ConnectionBasedTransport
+from pcl_msgs.msg import PointIndices
+from sensor_msgs.msg import CameraInfo
+
+
+class RectArrayToClusterPointIndices(ConnectionBasedTransport):
+
+    def __init__(self):
+        super(RectArrayToClusterPointIndices, self).__init__()
+        self.pub = self.advertise('~output', ClusterPointIndices, queue_size=1)
+
+    def subscribe(self):
+        if rospy.get_param('~use_info', False):
+            sub_rects = message_filters.Subscriber('~input', RectArray)
+            sub_info = message_filters.Subscriber('~input/info', CameraInfo)
+            self.subs = [sub_rects, sub_info]
+            queue_size = rospy.get_param('~queue_size', 10)
+            if rospy.get_param('~approximate_sync', False):
+                slop = rospy.get_param('~slop', 0.1)
+                sync = message_filters.ApproximateTimeSynchronizer(
+                    self.subs, queue_size=queue_size, slop=slop)
+            else:
+                sync = message_filters.TimeSynchronizer(
+                    self.subs, queue_size=queue_size)
+            sync.registerCallback(self._convert_sync)
+        else:
+            self.img_height = rospy.get_param('~img_height')
+            self.img_width = rospy.get_param('~img_width')
+            sub_rects = rospy.Subscriber('~input', RectArray, self._convert)
+            self.subs = [sub_rects]
+
+    def unsubscribe(self):
+        for sub in self.subs:
+            sub.unregister()
+
+    def _convert_sync(self, rects_msg, info_msg):
+        H = info_msg.height
+        W = info_msg.width
+        self._convert(rects_msg, H, W)
+
+    def _convert(self, rects_msg, img_height=None, img_width=None):
+        if img_height is None:
+            H = self.img_height
+        if img_width is None:
+            W = self.img_width
+        cpi_msg = ClusterPointIndices(header=rects_msg.header)
+        for rect in rects_msg.rects:
+            indices_msg = PointIndices(header=rects_msg.header)
+            ymin = max(0, int(np.floor(rect.y)))
+            xmin = max(0, int(np.floor(rect.x)))
+            ymax = min(H, int(np.ceil(rect.y + rect.height)))
+            xmax = min(W, int(np.ceil(rect.x + rect.width)))
+            indices = [range(W*y+xmin, W*y+xmax) for y in range(ymin, ymax)]
+            indices_msg.indices = np.array(indices, dtype=np.int32).flatten()
+            cpi_msg.cluster_indices.append(indices_msg)
+        self.pub.publish(cpi_msg)
+
+
+if __name__ == '__main__':
+    rospy.init_node('rect_array_to_cluster_point_indices')
+    RectArrayToClusterPointIndices()
+    rospy.spin()

--- a/jsk_recognition_utils/node_scripts/rect_array_to_cluster_point_indices.py
+++ b/jsk_recognition_utils/node_scripts/rect_array_to_cluster_point_indices.py
@@ -48,10 +48,8 @@ class RectArrayToClusterPointIndices(ConnectionBasedTransport):
         self._convert(rects_msg, H, W)
 
     def _convert(self, rects_msg, img_height=None, img_width=None):
-        if img_height is None:
-            H = self.img_height
-        if img_width is None:
-            W = self.img_width
+        H = self.img_height if img_height is None else img_height
+        W = self.img_width if img_width is None else img_width
         cpi_msg = ClusterPointIndices(header=rects_msg.header)
         for rect in rects_msg.rects:
             indices_msg = PointIndices(header=rects_msg.header)

--- a/jsk_recognition_utils/sample/sample_rect_array_to_cluster_point_indices.launch
+++ b/jsk_recognition_utils/sample/sample_rect_array_to_cluster_point_indices.launch
@@ -1,0 +1,47 @@
+<launch>
+  <arg name="gui" default="true" />
+  <node name="image_publisher"
+        pkg="jsk_perception" type="image_publisher.py">
+    <rosparam subst_value="true">
+      publish_info: false
+      file_name: $(find jsk_recognition_utils)/sample/images/real_world_checkerboard_grid_7x6_size_0.108/rgb_image_raw.jpg
+    </rosparam>
+  </node>
+
+  <node name="rect_array_publisher"
+        pkg="rostopic" type="rostopic"
+        output="screen"
+        args="pub -r 0.5 -s /rect_array_publisher/output jsk_recognition_msgs/RectArray
+              '{header: {stamp: now, frame_id: camera_rgb_optical_frame},
+                rects: [{x: 50, y: 50, width: 200, height: 80},
+                        {x: 70, y: 100, width: 30, height: 120},
+                        {x: 140, y: 150, width: 90, height: 70}]}'"/>
+
+  <node name="rects_to_cpi"
+        pkg="jsk_recognition_utils" type="rect_array_to_cluster_point_indices.py"
+        output="screen">
+    <remap from="~input" to="rect_array_publisher/output"/>
+    <rosparam>
+      use_info: false
+      img_height: 480
+      img_width: 640
+    </rosparam>
+  </node>
+
+  <node name="image_cluster_indices_decomposer"
+        pkg="jsk_perception" type="image_cluster_indices_decomposer.py"
+        output="screen">
+    <remap from="~input" to="image_publisher/output" />
+    <remap from="~input/cluster_indices" to="rects_to_cpi/output" />
+    <rosparam>
+      approximate_sync: true
+      queue_size: 100
+      slop: 10.0
+    </rosparam>
+  </node>
+
+  <node name="image_view" pkg="image_view" type="image_view" if="$(arg gui)">
+    <remap from="image" to="image_cluster_indices_decomposer/output" />
+  </node>
+
+</launch>

--- a/jsk_recognition_utils/test/rect_array_to_cluster_point_indices.test
+++ b/jsk_recognition_utils/test/rect_array_to_cluster_point_indices.test
@@ -1,0 +1,19 @@
+<launch>
+
+  <include file="$(find jsk_recognition_utils)/sample/sample_rect_array_to_cluster_point_indices.launch" >
+    <arg name="gui" value="false" />
+  </include>
+
+  <test test-name="test_rect_array_to_cluster_point_indices"
+        name="test_rect_array_to_cluster_point_indices"
+        pkg="jsk_tools" type="test_topic_published.py"
+        time-limit="60" retry="3">
+    <rosparam>
+      topic_0: /rects_to_cpi/output
+      timeout_0: 60
+      topic_1: /image_cluster_indices_decomposer/output
+      timeout_0: 60
+    </rosparam>
+  </test>
+
+</launch>


### PR DESCRIPTION
add `rect_array_to_cluster_point_indices.py`
this node converts `RectArray` to `ClusterPointIndices`, which is useful for object detection nodes.

![rects_to_cpi](https://user-images.githubusercontent.com/9300063/84104694-336bd800-aa51-11ea-8332-70d16cdb09bf.png)

it is related to #2467 