### PR TITLE
[audio_to_spectrogram] Enable multi channel input by retrieving single channel data

### DIFF
--- a/audio_to_spectrogram/launch/audio_to_spectrogram.launch
+++ b/audio_to_spectrogram/launch/audio_to_spectrogram.launch
@@ -6,6 +6,7 @@
 
   <arg name="bitdepth" default="16" />
   <arg name="mic_sampling_rate" default="16000" />
+  <arg name="n_channel" default="1" />
   <arg name="device" default="hw:0,0" />
   <arg name="audio_topic" default="/audio" />
   <arg name="high_cut_freq" default="800" />
@@ -19,7 +20,7 @@
         respawn="true">
     <rosparam subst_value="true">
       format: wave
-      channels: 1
+      channels: $(arg n_channel)
       depth: $(arg bitdepth)
       sample_rate: $(arg mic_sampling_rate)
       device: $(arg device)
@@ -30,6 +31,7 @@
   <node pkg="audio_to_spectrogram" type="audio_to_spectrum.py" name="audio_to_spectrum" respawn="true">
     <remap from="~audio" to="$(arg audio_topic)" />
     <rosparam subst_value="true">
+      n_channel: $(arg n_channel)
       mic_sampling_rate: $(arg mic_sampling_rate)
       fft_sampling_period: 0.3
       bitdepth: $(arg bitdepth)

--- a/audio_to_spectrogram/scripts/audio_to_spectrum.py
+++ b/audio_to_spectrogram/scripts/audio_to_spectrum.py
@@ -8,7 +8,6 @@ from jsk_recognition_msgs.msg import Spectrum
 
 
 # This node execute FFT to audio (audio_common_msgs/AudioData)
-# The number of audio channel is assumed to be 1.
 # The format of audio topic is assumed to be wave.
 
 class AudioToSpectrum(object):
@@ -17,6 +16,8 @@ class AudioToSpectrum(object):
         super(AudioToSpectrum, self).__init__()
 
         # Audio topic config
+        # The number of channels in audio data
+        self.n_channel = rospy.get_param('~n_channel', 1)
         # Sampling rate of microphone (namely audio topic).
         mic_sampling_rate = rospy.get_param('~mic_sampling_rate', 16000)
         # Period[s] to sample audio data for one fft
@@ -61,9 +62,12 @@ class AudioToSpectrum(object):
         rospy.Timer(rospy.Duration(1. / self.fft_exec_rate), self.timer_cb)
 
     def audio_cb(self, msg):
-        # Save audio msg to audio_buffer
+        # Convert audio buffer to int array
         data = msg.data
         audio_buffer = np.frombuffer(data, dtype=self.dtype)
+        # Retreive one channel data
+        audio_buffer = audio_buffer[0::self.n_channel]
+        # Save audio msg to audio_buffer
         self.audio_buffer = np.append(
             self.audio_buffer, audio_buffer)
         self.audio_buffer = self.audio_buffer[


### PR DESCRIPTION
In this pull request, I enable multi channel audio input by retrieving single channel data, like
https://github.com/jsk-ros-pkg/jsk_3rdparty/blob/cf5948cf5a592ae6fe44ecc69c16ddba81cf6bf5/ros_speech_recognition/scripts/speech_recognition_node.py#L103