### PR TITLE
Fix jsk_recognition_utils for ROS noetic

### DIFF
--- a/jsk_recognition_utils/package.xml
+++ b/jsk_recognition_utils/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="3">
   <name>jsk_recognition_utils</name>
   <version>1.2.10</version>
   <description>C++ library about sensor model, geometrical modeling and perception. </description>
@@ -30,24 +30,25 @@
   <build_depend>visualization_msgs</build_depend>
   <build_depend>yaml-cpp</build_depend>
   <build_depend>message_generation</build_depend>
-  <run_depend>eigen_conversions</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>image_geometry</run_depend>
-  <run_depend>image_view</run_depend>
-  <run_depend>jsk_recognition_msgs</run_depend>
-  <run_depend>jsk_topic_tools</run_depend>
-  <run_depend>pcl_msgs</run_depend>
-  <run_depend>pcl_ros</run_depend>
-  <run_depend version_lt="7.0.0">python-chainer-pip</run_depend>
-  <run_depend>python-skimage</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>tf2_ros</run_depend>
-  <run_depend>tf_conversions</run_depend>
-  <run_depend>tf</run_depend>
-  <run_depend>visualization_msgs</run_depend>
-  <run_depend>yaml-cpp</run_depend>
-  <run_depend>message_runtime</run_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-skimage</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-skimage</exec_depend>
+  <exec_depend version_lt="7.0.0">python-chainer-pip</exec_depend>
+  <exec_depend>eigen_conversions</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>image_geometry</exec_depend>
+  <exec_depend>image_view</exec_depend>
+  <exec_depend>jsk_recognition_msgs</exec_depend>
+  <exec_depend>jsk_topic_tools</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>pcl_msgs</exec_depend>
+  <exec_depend>pcl_ros</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>tf</exec_depend>
+  <exec_depend>tf_conversions</exec_depend>
+  <exec_depend>visualization_msgs</exec_depend>
+  <exec_depend>yaml-cpp</exec_depend>
   <test_depend>jsk_tools</test_depend>
   <export>
   </export>

--- a/jsk_recognition_utils/python/jsk_recognition_utils/CMakeLists.txt
+++ b/jsk_recognition_utils/python/jsk_recognition_utils/CMakeLists.txt
@@ -1,7 +1,8 @@
 if(NOT DEFINED Numpy_INCLUDE_DIRS)
   # Get Numpy include directories
+  set(PYTHON_VERSION "$ENV{ROS_PYTHON_VERSION}" CACHE STRING "Specify specific Python version to use ('major.minor' or 'major')")
   execute_process(
-    COMMAND python -c "import sys, numpy; sys.stdout.write(numpy.get_include())"
+    COMMAND python${PYTHON_VERSION} -c "import sys, numpy; sys.stdout.write(numpy.get_include())"
     OUTPUT_VARIABLE Numpy_INCLUDE_DIRS
     RESULT_VARIABLE retcode)
   if(NOT ${retcode} EQUAL 0)

--- a/jsk_recognition_utils/src/cv_utils.cpp
+++ b/jsk_recognition_utils/src/cv_utils.cpp
@@ -141,7 +141,7 @@ namespace jsk_recognition_utils
     }
     
     cv::rectangle(image, cv::Point(left, height), cv::Point(right, height - top),
-                  color, CV_FILLED);
+                  color, cv::FILLED);
   }
 
   void labelToRGB(const cv::Mat src, cv::Mat& dst)


### PR DESCRIPTION
This PR fixes building jsk_recognition_utils for ROS noetic. I haven't tested this for older distros. Which distros are still supported by jsk, from kinetic onwards?