### PR TITLE
Always include cython3 when searching

### DIFF
--- a/jsk_recognition_utils/cmake/FindCython.cmake
+++ b/jsk_recognition_utils/cmake/FindCython.cmake
@@ -28,7 +28,7 @@ find_package( PythonInterp )
 if( PYTHONINTERP_FOUND )
   get_filename_component( _python_path ${PYTHON_EXECUTABLE} PATH )
   find_program( CYTHON_EXECUTABLE
-    NAMES cython cython.bat
+    NAMES cython cython.bat cython3
     HINTS ${_python_path}
     )
 else()


### PR DESCRIPTION
When using jsk recognition on 20.04, where there is no python or cython 2, it failed to find cython3. This fixes that issue.