### PR TITLE
[jsk_pcl_ros] add tf_duration parameter in depth_image_creator

### DIFF
--- a/doc/jsk_pcl_ros/nodes/depth_image_creator.md
+++ b/doc/jsk_pcl_ros/nodes/depth_image_creator.md
@@ -74,6 +74,10 @@ Currently it supports `pcl::PointXYZ` and `pcl::PointXYZRGB` as the input.
 
    Whether to organize `~output_cloud` or not.
 
+* `~tf_duration` (float, default: `0.001`):
+
+  TF Lookup transform duration. This value is only used when `use_fixed_transform` is `false`.
+
 ## Sample
 
 ```bash

--- a/jsk_pcl_ros/include/jsk_pcl_ros/depth_image_creator.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/depth_image_creator.h
@@ -96,6 +96,7 @@ namespace jsk_pcl_ros
     tf::StampedTransform fixed_transform;
     tf::TransformListener* tf_listener_;
     double scale_depth;
+    double tf_duration_;
     float fill_value;
     typedef pcl::PointXYZRGB Point;
     typedef pcl::PointCloud< Point > PointCloud;

--- a/jsk_pcl_ros/src/depth_image_creator_nodelet.cpp
+++ b/jsk_pcl_ros/src/depth_image_creator_nodelet.cpp
@@ -85,6 +85,7 @@ void jsk_pcl_ros::DepthImageCreator::onInit () {
   tf::Vector3 btp(trans_pos[0], trans_pos[1], trans_pos[2]);
   fixed_transform.setOrigin(btp);
   fixed_transform.setRotation(btq);
+  pnh_->param("tf_duration", tf_duration_, 0.001);
 
   pub_depth_ = advertise<sensor_msgs::Image> (*pnh_, "output", max_pub_queue_size_);
   pub_image_ = advertise<sensor_msgs::Image> (*pnh_, "output_image", max_pub_queue_size_);
@@ -219,7 +220,7 @@ void jsk_pcl_ros::DepthImageCreator::publish_points(const sensor_msgs::CameraInf
         tf_listener_->waitForTransform(pcloud2_ptr->header.frame_id,
                                        info->header.frame_id,
                                        info->header.stamp,
-                                       ros::Duration(0.001));
+                                       ros::Duration(tf_duration_));
         tf_listener_->lookupTransform(pcloud2_ptr->header.frame_id,
                                       info->header.frame_id,
                                       info->header.stamp, transform);


### PR DESCRIPTION
depth_image_creator waits for TF transform only 0.001 second.
I change to modify this duration to a parameter, and we can change it easily.
I also update the doc.
![depth_image_creator_tf_duration_doc](https://user-images.githubusercontent.com/42209144/95425193-ddfff300-097e-11eb-8e53-6607164140d8.png)
