### PR TITLE
remove packages=['jsk_perceptoin']

### DIFF
--- a/jsk_perception/setup.py
+++ b/jsk_perception/setup.py
@@ -3,8 +3,6 @@
 from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
-d = generate_distutils_setup(
-    packages=['jsk_perception']
-)
+d = generate_distutils_setup()
 
 setup(**d)


### PR DESCRIPTION
fix

```
+ /usr/bin/env PYTHONPATH=/opt/ros/melodic/lib/python2.7/dist-packages:/tmp/jsk_recognition-release/obj-x86_64-linux-gnu/lib/python2.7/dist-packages:/opt/ros/melodic/lib/python2.7/dist-packages:/home/k-okada/pynaoqi/pynaoqi-python2.7-2.5.5.5-linux64/lib/python2.7/site-packages CATKIN_BINARY_DIR=/tmp/jsk_recognition-release/obj-x86_64-linux-gnu /usr/bin/python2 /tmp/jsk_recognition-release/setup.py egg_info --egg-base /tmp/jsk_recognition-release/obj-x86_64-linux-gnu build --build-base /tmp/jsk_recognition-release/obj-x86_64-linux-gnu install --root=/tmp/jsk_recognition-release/debian/ros-melodic-jsk-perception --install-layout=deb --prefix=/opt/ros/melodic --install-scripts=/opt/ros/melodic/bin
running egg_info
creating /tmp/jsk_recognition-release/obj-x86_64-linux-gnu/jsk_perception.egg-info
writing /tmp/jsk_recognition-release/obj-x86_64-linux-gnu/jsk_perception.egg-info/PKG-INFO
writing top-level names to /tmp/jsk_recognition-release/obj-x86_64-linux-gnu/jsk_perception.egg-info/top_level.txt
writing dependency_links to /tmp/jsk_recognition-release/obj-x86_64-linux-gnu/jsk_perception.egg-info/dependency_links.txt
writing manifest file '/tmp/jsk_recognition-release/obj-x86_64-linux-gnu/jsk_perception.egg-info/SOURCES.txt'
error: package directory 'jsk_perception' does not exist
CMake Error at catkin_generated/safe_execute_install.cmake:4 (message):

  execute_process(/tmp/jsk_recognition-release/obj-x86_64-linux-gnu/catkin_generated/python_distutils_install.sh)
  returned error code
Call Stack (most recent call first):
  cmake_install.cmake:41 (include)

Makefile:97: recipe for target 'install' failed
```