### PR TITLE
[jsk_pcl_ros] add approximate_sync with ClusterPointIndicesDecomposer + jsk_recognition_msgs::PolygonArray, + jsk_recognition_msgs::ModelCoefficientsArray

### DIFF
--- a/jsk_pcl_ros/include/jsk_pcl_ros/cluster_point_indices_decomposer.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/cluster_point_indices_decomposer.h
@@ -81,6 +81,11 @@ namespace jsk_pcl_ros
       jsk_recognition_msgs::ClusterPointIndices,
       jsk_recognition_msgs::PolygonArray,
       jsk_recognition_msgs::ModelCoefficientsArray> SyncAlignPolicy;
+    typedef message_filters::sync_policies::ApproximateTime<
+      sensor_msgs::PointCloud2,
+      jsk_recognition_msgs::ClusterPointIndices,
+      jsk_recognition_msgs::PolygonArray,
+      jsk_recognition_msgs::ModelCoefficientsArray> ApproximateSyncAlignPolicy;
     virtual void onInit();
     virtual void extract(const sensor_msgs::PointCloud2ConstPtr &point,
                          const jsk_recognition_msgs::ClusterPointIndicesConstPtr &indices,
@@ -157,6 +162,7 @@ namespace jsk_pcl_ros
     boost::shared_ptr<message_filters::Synchronizer<SyncPolicy> >sync_;
     boost::shared_ptr<message_filters::Synchronizer<ApproximateSyncPolicy> >async_;
     boost::shared_ptr<message_filters::Synchronizer<SyncAlignPolicy> >sync_align_;
+    boost::shared_ptr<message_filters::Synchronizer<ApproximateSyncAlignPolicy> >async_align_;
     std::vector<ros::Publisher> publishers_;
     ros::Publisher pc_pub_, box_pub_, mask_pub_, label_pub_, centers_pub_, negative_indices_pub_, indices_pub_;
     boost::shared_ptr<tf::TransformBroadcaster> br_;

--- a/jsk_pcl_ros/sample/sample_cluster_point_indices_decomposer.launch
+++ b/jsk_pcl_ros/sample/sample_cluster_point_indices_decomposer.launch
@@ -2,6 +2,7 @@
 
   <arg name="gui" default="true" />
   <arg name="use_pca" default="true" />
+  <arg name="approximate_sync" default="true" />
 
   <param name="/use_sim_time" value="true" />
   <node name="rosbag_play"
@@ -18,6 +19,7 @@
       align_boxes: false
       align_boxes_with_plane: false
       use_pca: $(arg use_pca)
+      approximate_sync: $(arg approximate_sync)
     </rosparam>
   </node>
 
@@ -32,6 +34,7 @@
       align_boxes: true
       align_boxes_with_plane: true
       use_pca: $(arg use_pca)
+      approximate_sync: $(arg approximate_sync)
     </rosparam>
   </node>
 
@@ -45,6 +48,7 @@
       align_boxes_with_plane: false
       target_frame_id: base
       use_pca: $(arg use_pca)
+      approximate_sync: $(arg approximate_sync)
     </rosparam>
   </node>
 


### PR DESCRIPTION
support approximate_sync for `ClusterPointIndicesDecomposer` with `jsk_recognition_msgs::PolygonArray` + `jsk_recognition_msgs::ModelCoefficientsArray`