### PR TITLE
Add six==1.15.0 to doc/requirements.txt

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,5 @@
 recommonmark==0.5.0
+six==1.15.0
 Sphinx==3.3.0
 sphinx-markdown-tables==0.0.9
 sphinx_rtd_theme==0.4.3


### PR DESCRIPTION
## Problem

Travis fails because `six` is not installed.
https://github.com/jsk-ros-pkg/jsk_recognition/pull/2553
https://travis-ci.org/github/jsk-ros-pkg/jsk_recognition/builds/746245872
```
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/home/travis/build/jsk-ros-pkg/jsk_recognition/doc/venv/lib/python3.5/site-packages/sphinx/config.py", line 319, in eval_config_file
    execfile_(filename, namespace)
  File "/home/travis/build/jsk-ros-pkg/jsk_recognition/doc/venv/lib/python3.5/site-packages/sphinx/util/pycompat.py", line 89, in execfile_
    exec(code, _globals)
  File "/home/travis/build/jsk-ros-pkg/jsk_recognition/doc/conf.py", line 42, in <module>
    import add_img_tables_to_index
  File "/home/travis/build/jsk-ros-pkg/jsk_recognition/doc/add_img_tables_to_index.py", line 16, in <module>
    import six
ImportError: No module named 'six'

Makefile:58: recipe for target 'html' failed
make: *** [html] Error 2
travis_time:end:2d4a39f5:start=1606550559963658202,finish=1606550570310394301,duration=10346736099,event=script
[0K[31;1mThe command "(cd $TRAVIS_BUILD_DIR/doc && source setup.sh && make html)" exited with 2.[0m
```

On the other hand, until recently, travis has passed.
https://github.com/jsk-ros-pkg/jsk_recognition/pull/2541
https://travis-ci.org/github/jsk-ros-pkg/jsk_recognition/builds/744665515

This is because newer version (20.5) of `packaging` package is released on Nov 28, 2020 (Today!) and this version `packaging` does not depend on `six`.
In other words, `six` is no longer installed from `packaging` dependencies.
https://pypi.org/project/packaging/#history
https://github.com/pypa/packaging/commit/39a70cce69d9b08cc4d02b225114d556d5b59ada
```
$ pipdeptree -p packaging
packaging==20.4
  - pyparsing [required: >=2.0.2, installed: 2.4.6]
  - six [required: Any, installed: 1.10.0]
```
```
$ pipdeptree -p packaging
packaging==20.5
  - pyparsing [required: >=2.0.2, installed: 2.4.6]
```

## What I did
Add `six==1.15.0` to doc/requirements.txt
The `six` version is copied from here.
https://travis-ci.org/github/jsk-ros-pkg/jsk_recognition/jobs/744665525
```
Collecting six
  Downloading six-1.15.0-py2.py3-none-any.whl (10 kB)
```