### PR TITLE
support _image_transport:=compress for imagesift

### DIFF
--- a/doc/imagesift/nodes/imagesift.rst
+++ b/doc/imagesift/nodes/imagesift.rst
@@ -29,12 +29,22 @@ Publishing Topic
 
    This appears with both inputs ``image`` and ``camera_info``.
 
+Parameters
+----------
+
+- ``~image_transport`` (``String``, default: ``raw``)
+
+  Set `compressed` or `theora` to subscribe compressed images
 
 Run
 ---
 You can run executable like below::
 
     $ rosrun imagesift imagesift
+
+To subscribe compressed image, run executable like below::
+
+    $ rosrun imagesift imagesift _image_transport:=compressed
 
 
 Sample

--- a/imagesift/include/imagesift/imagesift.h
+++ b/imagesift/include/imagesift/imagesift.h
@@ -70,6 +70,7 @@ namespace imagesift
     bool _useMask;
     boost::mutex _mutex;
     boost::shared_ptr<image_transport::ImageTransport> _it;
+    image_transport::TransportHints _hints;
     image_transport::Subscriber _subImage;
     // for useMask
     message_filters::Subscriber<sensor_msgs::Image> _subImageWithMask;

--- a/imagesift/sample/imagesift_sample.launch
+++ b/imagesift/sample/imagesift_sample.launch
@@ -1,6 +1,7 @@
 <launch>
 
   <arg name="gui" default="true" />
+  <arg name="image_transport" default="raw" />
 
   <node name="static_virtual_camera"
         pkg="jsk_recognition_utils" type="static_virtual_camera.py" />
@@ -13,6 +14,7 @@
         args="load imagesift/ImageSift nodelet_manager">
     <remap from="image" to="static_virtual_camera/image_color" />
     <remap from="camera_info" to="static_virtual_camera/camera_info" />
+    <param name="image_transport" value="$(arg image_transport)" />
   </node>
 
   <group if="$(arg gui)">
@@ -23,6 +25,7 @@
     <node name="feature0d_to_image"
           pkg="posedetection_msgs" type="feature0d_to_image">
       <remap from="image" to="static_virtual_camera/image_color" />
+      <param name="image_transport" value="$(arg image_transport)" />
     </node>
     <node name="imagefeature0d_view"
           pkg="image_view" type="image_view">

--- a/imagesift/src/imagesift.cpp
+++ b/imagesift/src/imagesift.cpp
@@ -53,7 +53,12 @@ namespace imagesift
     void SiftNode::onInit()
     {
         DiagnosticNodelet::onInit();
+        // First positional argument is the transport type
+        std::string transport;
+        pnh_->param("image_transport", transport, std::string("raw"));
+        ROS_INFO_STREAM("Using transport \"" << transport << "\" for " << pnh_->getNamespace());
         _it.reset(new image_transport::ImageTransport(*nh_));
+        _hints = image_transport::TransportHints(transport, ros::TransportHints(), *pnh_);
 
         pnh_->param("use_mask", _useMask, false);
         
@@ -69,7 +74,7 @@ namespace imagesift
     void SiftNode::subscribe()
     {
         if (!_useMask) {
-            _subImage = _it->subscribe("image", 1, &SiftNode::imageCb, this);
+            _subImage = _it->subscribe(nh_->resolveName("image"), 1, &SiftNode::imageCb, this, _hints);
         }
         else {
             _subImageWithMask.subscribe(*nh_, "image", 1);


### PR DESCRIPTION
example launch file
```
<launch>
  <group ns="/head_camera/rgb/">
    <node name="image_siftnode" pkg="imagesift" type="imagesift"
          output="screen" >
      <remap from="image" to="image_rect_color" />
      <param name="image_transport" value="compressed" />
      <!-- <param name="image_transport" value="raw" /> -->
    </node>

    <node name="point_pose_extractor" pkg="jsk_perception"
          type="point_pose_extractor">
      <param name="child_frame_name" value="opencv_logo"/>
      <!-- <param name="template_filename" value="$(find jsk_perception)/sample/opencv-logo2.png"/> -->
      <param name="template_filename" value="/home/k-okada/Downloads/ubereats.png"/>
      <param name="object_width" value="0.15" />
      <param name="object_height" value="0.076" />
      <param name="reprojection_threshold" value="10.0" />  <!-- 3.0 -->
      <param name="distanceratio_threshold" value="0.60" /> <!-- 0.49 -->
      <param name="relative_pose" value="0 0 0 0 0 0 1" />    <!-- quaternion expression -->
      <!-- param name="relative_pose" value="0 0 0 0 0 0" / --> <!-- you can also use rpy expression. --> -->                    
      <param name="error_threshold" value="50.0" />
    </node>

    <node pkg="checkerboard_detector" type="objectdetection_tf_publisher.py"
          name="objectdetection_tf_publisher">
      <param name="use_simple_tf" value="true" />
    </node>
  </group>
</launch>

```

or run `d`

![rosgraph](https://user-images.githubusercontent.com/493276/105842837-2ae50380-601a-11eb-9a6a-9c5c78e65725.png)
![rosgraph2](https://user-images.githubusercontent.com/493276/105842840-2c163080-601a-11eb-9bef-1fb90ab9953d.png)


This example requres https://github.com/jsk-ros-pkg/jsk_recognition/pull/2569 and https://github.com/jsk-ros-pkg/jsk_common_msgs/pull/27

to show `rqt_graph`
```
rosmaster
rosparam set enable_statistics true
roslaunch --screen imagesift imagesift_sample.launch image_transport:=compressed
rqt_graph
```

I followed https://github.com/introlab/rtabmap_ros/blob/4b878e45b9674e78ee502d1d924ac1d3e28c94a9/src/nodelets/rgbd_sync.cpp#L115-L147 for message filter and transport hint