### PR TITLE
[jsk_recognition_utils] use try to import chainer depend modules

### DIFF
--- a/jsk_recognition_utils/package.xml
+++ b/jsk_recognition_utils/package.xml
@@ -42,8 +42,10 @@
   <exec_depend>pcl_msgs</exec_depend>
   <exec_depend>pcl_ros</exec_depend>
   <exec_depend version_lt="7.0.0">python-chainer-pip</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-chainercv-pip</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-skimage</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-skimage</exec_depend>
+  <exec_depend>python-fcn-pip</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>tf2_ros</exec_depend>

--- a/jsk_recognition_utils/python/jsk_recognition_utils/__init__.py
+++ b/jsk_recognition_utils/python/jsk_recognition_utils/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
 
+import sys
+
 from jsk_recognition_utils import color
 from jsk_recognition_utils import conversations
 from jsk_recognition_utils import feature
@@ -7,15 +9,57 @@ from jsk_recognition_utils import mask
 from jsk_recognition_utils import visualize
 from jsk_recognition_utils import geometry
 
+
 try:
-    from jsk_recognition_utils import chainermodels  # NOQA
-    from jsk_recognition_utils import datasets  # NOQA
+    import chainer  # NOQA
+    _chainer_available = True
 except ImportError:
-    import sys
-    print(
-        'Please install chainer<7.0.0 to import '
-        'jsk_recognition_utils.chainermodels and datasets',
-        file=sys.stderr)
+    _chainer_available = False
+
+try:
+    import chainercv  # NOQA
+    _chainercv_available = True
+except ImportError:
+    _chainercv_available = False
+
+try:
+    import fcn  # NOQA
+    _fcn_available = True
+except ImportError:
+    _fcn_available = False
+
+if _chainer_available and _chainercv_available and _fcn_available:
+    from jsk_recognition_utils import chainermodels  # NOQA
+else:
+    _depends = []
+    if not _chainer_available:
+        _depends.append('chainer\\<7.0.0')
+    if not _chainercv_available:
+        _depends.append('chainercv')
+    if not _fcn_available:
+        _depends.append('fcn')
+    print('''
+Please install {0}
+to import jsk_recognition_utils.chainermodels.
+
+    sudo pip install {1}
+'''.format(', '.join(_depends), ' '.join(_depends)), file=sys.stderr)
+
+if _chainer_available and _chainercv_available:
+    from jsk_recognition_utils import datasets  # NOQA
+else:
+    _depends = []
+    if not _chainer_available:
+        _depends.append('chainer\\<7.0.0')
+    if not _chainercv_available:
+        _depends.append('chainercv')
+    print('''
+Please install {0}
+to import jsk_recognition_utils.datasets.
+
+    sudo pip install {1}
+'''.format(', '.join(_depends), ' '.join(_depends)), file=sys.stderr)
+
 
 bounding_box_msg_to_aabb = conversations.bounding_box_msg_to_aabb
 rects_msg_to_ndarray = conversations.rects_msg_to_ndarray

--- a/jsk_recognition_utils/python/jsk_recognition_utils/__init__.py
+++ b/jsk_recognition_utils/python/jsk_recognition_utils/__init__.py
@@ -1,12 +1,15 @@
-from jsk_recognition_utils import chainermodels
 from jsk_recognition_utils import color
 from jsk_recognition_utils import conversations
-from jsk_recognition_utils import datasets
 from jsk_recognition_utils import feature
 from jsk_recognition_utils import mask
 from jsk_recognition_utils import visualize
 from jsk_recognition_utils import geometry
 
+try:
+    from jsk_recognition_utils import chainermodels  # NOQA
+    from jsk_recognition_utils import datasets  # NOQA
+except ImportError:
+    print('Please install chainer<7.0.0 to import chainermodels')
 
 bounding_box_msg_to_aabb = conversations.bounding_box_msg_to_aabb
 rects_msg_to_ndarray = conversations.rects_msg_to_ndarray

--- a/jsk_recognition_utils/python/jsk_recognition_utils/__init__.py
+++ b/jsk_recognition_utils/python/jsk_recognition_utils/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from jsk_recognition_utils import color
 from jsk_recognition_utils import conversations
 from jsk_recognition_utils import feature
@@ -9,7 +11,11 @@ try:
     from jsk_recognition_utils import chainermodels  # NOQA
     from jsk_recognition_utils import datasets  # NOQA
 except ImportError:
-    print('Please install chainer<7.0.0 to import chainermodels')
+    import sys
+    print(
+        'Please install chainer<7.0.0 to import '
+        'jsk_recognition_utils.chainermodels and datasets',
+        file=sys.stderr)
 
 bounding_box_msg_to_aabb = conversations.bounding_box_msg_to_aabb
 rects_msg_to_ndarray = conversations.rects_msg_to_ndarray


### PR DESCRIPTION
use `try` to import `chainer` depending modules.
this PR solves https://github.com/jsk-ros-pkg/jsk_visualization/issues/800

cc. @Naoki-Hiraoka 