### PR TITLE
[jsk_perception] do not exit if cupy is not installed

### DIFF
--- a/jsk_perception/node_scripts/alexnet_object_recognition.py
+++ b/jsk_perception/node_scripts/alexnet_object_recognition.py
@@ -7,23 +7,23 @@ from __future__ import print_function
 import itertools, pkg_resources, sys
 from distutils.version import LooseVersion
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
-   sys.exit(1)
+    sys.exit(1)
 if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   sys.exit(1)
+    # sys.exit(1)
 import chainer.serializers as S
 from jsk_recognition_msgs.msg import ClassificationResult
 from jsk_recognition_utils.chainermodels import AlexNet

--- a/jsk_perception/node_scripts/deep_sort/deep_sort_tracker.py
+++ b/jsk_perception/node_scripts/deep_sort/deep_sort_tracker.py
@@ -5,23 +5,23 @@ import numpy as np
 import itertools, pkg_resources, sys
 from distutils.version import LooseVersion
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
-   sys.exit(1)
+    sys.exit(1)
 if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   sys.exit(1)
+    # sys.exit(1)
 import chainer
 
 from jsk_recognition_utils.chainermodels.deep_sort_net\

--- a/jsk_perception/node_scripts/deep_sort_tracker_node.py
+++ b/jsk_perception/node_scripts/deep_sort_tracker_node.py
@@ -7,23 +7,23 @@ import rospy
 import itertools, pkg_resources, sys
 from distutils.version import LooseVersion
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
-   sys.exit(1)
+    sys.exit(1)
 if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   sys.exit(1)
+    # sys.exit(1)
 import chainer
 from sensor_msgs.msg import Image
 from cv_bridge import CvBridge

--- a/jsk_perception/node_scripts/face_pose_estimation.py
+++ b/jsk_perception/node_scripts/face_pose_estimation.py
@@ -12,23 +12,23 @@ import traceback
 import itertools, pkg_resources, sys
 from distutils.version import LooseVersion
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
-   sys.exit(1)
+    sys.exit(1)
 if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   sys.exit(1)
+    # sys.exit(1)
 import chainer
 from chainer.dataset import download
 from chainer.serializers import load_npz

--- a/jsk_perception/node_scripts/fast_rcnn.py
+++ b/jsk_perception/node_scripts/fast_rcnn.py
@@ -5,26 +5,26 @@ from __future__ import print_function
 import os.path as osp
 import sys
 
-import itertools, pkg_resources, sys
+import itertools, pkg_resources
 from distutils.version import LooseVersion
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
-   sys.exit(1)
-if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    sys.exit(1)
+if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name] == []:
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   sys.exit(1)
+    # sys.exit(1)
 import chainer
 from chainer import cuda
 import chainer.serializers as S

--- a/jsk_perception/node_scripts/fcn_depth_prediction.py
+++ b/jsk_perception/node_scripts/fcn_depth_prediction.py
@@ -6,23 +6,23 @@ from distutils.version import LooseVersion
 
 import itertools, pkg_resources, sys
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
-   sys.exit(1)
+    sys.exit(1)
 if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   sys.exit(1)
+    # sys.exit(1)
 import chainer
 from chainer import cuda
 import chainer.functions as F

--- a/jsk_perception/node_scripts/fcn_object_segmentation.py
+++ b/jsk_perception/node_scripts/fcn_object_segmentation.py
@@ -6,23 +6,23 @@ from distutils.version import LooseVersion
 
 import itertools, pkg_resources, sys
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
-   sys.exit(1)
+    sys.exit(1)
 if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   sys.exit(1)
+    # sys.exit(1)
 import chainer
 from chainer import cuda
 import chainer.serializers as S

--- a/jsk_perception/node_scripts/hmr/net.py
+++ b/jsk_perception/node_scripts/hmr/net.py
@@ -3,23 +3,23 @@ from __future__ import print_function
 import itertools, pkg_resources, sys
 from distutils.version import LooseVersion
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
-   sys.exit(1)
+    sys.exit(1)
 if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   sys.exit(1)
+    # sys.exit(1)
 import chainer
 import chainer.functions as F
 import chainer.links as L

--- a/jsk_perception/node_scripts/hmr/resnet_v2_50.py
+++ b/jsk_perception/node_scripts/hmr/resnet_v2_50.py
@@ -3,23 +3,23 @@ from __future__ import print_function
 import itertools, pkg_resources, sys
 from distutils.version import LooseVersion
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
-   sys.exit(1)
+    sys.exit(1)
 if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   sys.exit(1)
+    # sys.exit(1)
 import chainer
 import chainer.functions as F
 from chainer import initializers

--- a/jsk_perception/node_scripts/hmr/smpl.py
+++ b/jsk_perception/node_scripts/hmr/smpl.py
@@ -5,23 +5,23 @@ from __future__ import print_function
 import itertools, pkg_resources, sys
 from distutils.version import LooseVersion
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
-   sys.exit(1)
+    sys.exit(1)
 if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   sys.exit(1)
+    # sys.exit(1)
 from chainer import Parameter
 from chainer import Variable
 import chainer

--- a/jsk_perception/node_scripts/human_mesh_recovery.py
+++ b/jsk_perception/node_scripts/human_mesh_recovery.py
@@ -10,23 +10,23 @@ from __future__ import print_function
 import itertools, pkg_resources, sys
 from distutils.version import LooseVersion
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
-   sys.exit(1)
+    sys.exit(1)
 if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   sys.exit(1)
+    # sys.exit(1)
 import chainer
 import chainer.functions as F
 from chainer import Variable

--- a/jsk_perception/node_scripts/mask_rcnn_instance_segmentation.py
+++ b/jsk_perception/node_scripts/mask_rcnn_instance_segmentation.py
@@ -8,23 +8,23 @@ import yaml
 import itertools, pkg_resources
 from distutils.version import LooseVersion
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
-   sys.exit(1)
+    sys.exit(1)
 if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   sys.exit(1)
+    # sys.exit(1)
 import chainer
 import numpy as np
 

--- a/jsk_perception/node_scripts/openpose/hand_net.py
+++ b/jsk_perception/node_scripts/openpose/hand_net.py
@@ -10,23 +10,23 @@ import os
 import itertools, pkg_resources, sys
 from distutils.version import LooseVersion
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
-   sys.exit(1)
+    sys.exit(1)
 if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   sys.exit(1)
+    # sys.exit(1)
 import chainer
 import chainer.functions as F
 import chainer.links as L

--- a/jsk_perception/node_scripts/openpose/pose_net.py
+++ b/jsk_perception/node_scripts/openpose/pose_net.py
@@ -4,23 +4,23 @@ import os
 import itertools, pkg_resources, sys
 from distutils.version import LooseVersion
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
-   sys.exit(1)
+    sys.exit(1)
 if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   sys.exit(1)
+    sys.exit(1)
 import chainer
 import chainer.functions as F
 import chainer.links as L

--- a/jsk_perception/node_scripts/people_pose_estimation_2d.py
+++ b/jsk_perception/node_scripts/people_pose_estimation_2d.py
@@ -11,7 +11,7 @@ import itertools, pkg_resources, sys
 from distutils.version import LooseVersion
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
    sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+   print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 

--- a/jsk_perception/node_scripts/regional_feature_based_object_recognition.py
+++ b/jsk_perception/node_scripts/regional_feature_based_object_recognition.py
@@ -7,23 +7,23 @@ import os.path as osp
 import itertools, pkg_resources, sys
 from distutils.version import LooseVersion
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
-   sys.exit(1)
+    sys.exit(1)
 if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   sys.exit(1)
+    # sys.exit(1)
 import chainer
 from chainer import cuda
 import numpy as np

--- a/jsk_perception/node_scripts/ssd_object_detector.py
+++ b/jsk_perception/node_scripts/ssd_object_detector.py
@@ -27,23 +27,22 @@ from pcl_msgs.msg import PointIndices
 import itertools, pkg_resources, sys
 from distutils.version import LooseVersion
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
-   sys.exit(1)
+    sys.exit(1)
 if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   #sys.exit(1)
 import chainer
 from chainercv.links import SSD300
 from chainercv.links import SSD512

--- a/jsk_perception/node_scripts/vgg16_object_recognition.py
+++ b/jsk_perception/node_scripts/vgg16_object_recognition.py
@@ -8,23 +8,23 @@ from __future__ import print_function
 import itertools, pkg_resources, sys
 from distutils.version import LooseVersion
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
-   sys.exit(1)
+    sys.exit(1)
 if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   sys.exit(1)
+    # sys.exit(1)
 import chainer
 from chainer import cuda
 import chainer.serializers as S

--- a/jsk_perception/scripts/create_db_for_feature_based_object_recognition.py
+++ b/jsk_perception/scripts/create_db_for_feature_based_object_recognition.py
@@ -9,23 +9,23 @@ import os.path as osp
 import itertools, pkg_resources, sys
 from distutils.version import LooseVersion
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
-   sys.exit(1)
+    sys.exit(1)
 if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   sys.exit(1)
+    # sys.exit(1)
 import chainer
 from chainer import cuda
 import numpy as np

--- a/jsk_perception/scripts/install_trained_data.py
+++ b/jsk_perception/scripts/install_trained_data.py
@@ -9,19 +9,19 @@ import os.path as osp
 import itertools, pkg_resources, sys
 from distutils.version import LooseVersion
 try:
-    chainer_version = pkg_resources.get_distribution(chainer).version
+    chainer_version = pkg_resources.get_distribution('chainer').version
 except:
     chainer_version = None
 if chainer_version and LooseVersion(chainer_version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
 if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.

--- a/jsk_perception/scripts/ssd_train_dataset.py
+++ b/jsk_perception/scripts/ssd_train_dataset.py
@@ -16,23 +16,23 @@ import yaml
 import itertools, pkg_resources
 from distutils.version import LooseVersion
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
-   sys.exit(1)
+    sys.exit(1)
 if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   sys.exit(1)
+    # sys.exit(1)
 import chainer
 from chainer import serializers
 from chainer import training

--- a/jsk_perception/scripts/train_fcn.py
+++ b/jsk_perception/scripts/train_fcn.py
@@ -12,23 +12,23 @@ os.environ['MPLBACKEND'] = 'Agg'  # NOQA
 import itertools, pkg_resources, sys
 from distutils.version import LooseVersion
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
-   sys.exit(1)
+    sys.exit(1)
 if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   sys.exit(1)
+    # sys.exit(1)
 import chainer
 from chainer import cuda
 from chainer.datasets import TransformDataset

--- a/jsk_perception/scripts/train_fcn_depth_prediction.py
+++ b/jsk_perception/scripts/train_fcn_depth_prediction.py
@@ -9,6 +9,25 @@ import datetime
 import os
 import os.path as osp
 
+import itertools, pkg_resources, sys
+from distutils.version import LooseVersion
+if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
+
+    sudo pip install chainer==6.7.0
+
+c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
+''', file=sys.stderr)
+    sys.exit(1)
+if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name] == []:
+    print('''Please install CuPy
+
+    sudo pip install cupy-cuda[your cuda version]
+i.e.
+    sudo pip install cupy-cuda91
+
+''', file=sys.stderr)
 import chainer
 from chainer import cuda
 from chainer.datasets import TransformDataset

--- a/jsk_perception/scripts/train_mask_rcnn.py
+++ b/jsk_perception/scripts/train_mask_rcnn.py
@@ -14,23 +14,23 @@ os.environ['MPLBACKEND'] = 'Agg'  # NOQA
 import itertools, pkg_resources, sys
 from distutils.version import LooseVersion
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
-   sys.exit(1)
+    sys.exit(1)
 if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   sys.exit(1)
+    # sys.exit(1)
 import chainer
 from chainer import cuda
 from chainer.datasets import TransformDataset

--- a/jsk_perception/scripts/train_ssd.py
+++ b/jsk_perception/scripts/train_ssd.py
@@ -11,23 +11,23 @@ import os.path as osp
 import itertools, pkg_resources, sys
 from distutils.version import LooseVersion
 if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersion('7.0.0') and \
-   sys.version_info.major == 2:
-   print('''Please install chainer <= 7.0.0:
+        sys.version_info.major == 2:
+    print('''Please install chainer < 7.0.0:
 
     sudo pip install chainer==6.7.0
 
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
-   sys.exit(1)
+    sys.exit(1)
 if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
-   print('''Please install CuPy
+    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
 i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   sys.exit(1)
+    # sys.exit(1)
 import chainer
 from chainer.datasets import TransformDataset
 from chainer.optimizer_hooks import WeightDecay


### PR DESCRIPTION
- do not `sys.exit(1)` when `cupy` is not installed.
  - most nodes can be run by CPU.
- fix indent from 3 spaces to 4 spaces