### PR TITLE
[jsk_pcl_ros] fix bug of lookuptransform in heightmapconverter

### DIFF
--- a/doc/jsk_pcl_ros/nodes/heightmap_converter.md
+++ b/doc/jsk_pcl_ros/nodes/heightmap_converter.md
@@ -55,6 +55,10 @@ Convert a pointcloud(`sensor_msgs/PointCloud2`) into heightmap representation (`
 
   These parameters can be changed by `dynamic_reconfigure`.
 
+* `~duration_transform_timeout` (Double default: `1.0`)
+
+  duration of timeout for transform looking up of tf frames
+
 * `~initial_probability` (Double, default: `1.0`)
 
   Initial value to be set to Channel1 of heightmap image

--- a/jsk_pcl_ros/include/jsk_pcl_ros/heightmap_converter.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/heightmap_converter.h
@@ -82,6 +82,7 @@ namespace jsk_pcl_ros
     ros::Publisher pub_config_;
     ros::Subscriber sub_;
     boost::shared_ptr<dynamic_reconfigure::Server<Config> > srv_;
+    double duration_transform_timeout_;
     double min_x_;
     double max_x_;
     double min_y_;

--- a/jsk_pcl_ros/src/heightmap_converter_nodelet.cpp
+++ b/jsk_pcl_ros/src/heightmap_converter_nodelet.cpp
@@ -88,6 +88,8 @@ namespace jsk_pcl_ros
       /* convert points */
       tf::StampedTransform ros_fixed_to_center;
       try {
+	tf_->waitForTransform(fixed_frame_id_, center_frame_id_,
+			     msg->header.stamp, ros::Duration(1.0));
         tf_->lookupTransform(fixed_frame_id_, center_frame_id_,
                              msg->header.stamp, ros_fixed_to_center);
       }
@@ -103,6 +105,8 @@ namespace jsk_pcl_ros
 
       tf::StampedTransform ros_msg_to_fixed;
       try {
+	tf_->waitForTransform(msg->header.frame_id, fixed_frame_id_,
+			     msg->header.stamp, ros::Duration(1.0));
         tf_->lookupTransform(msg->header.frame_id, fixed_frame_id_,
                              msg->header.stamp, ros_msg_to_fixed);
       }

--- a/jsk_pcl_ros/src/heightmap_converter_nodelet.cpp
+++ b/jsk_pcl_ros/src/heightmap_converter_nodelet.cpp
@@ -61,6 +61,7 @@ namespace jsk_pcl_ros
     pnh_->param("use_projected_center", use_projected_center_, false);
 
     pnh_->param("max_queue_size", max_queue_size_, 10);
+    pnh_->param("duration_transform_timeout", duration_transform_timeout_, 1.0);
     pub_ = advertise<sensor_msgs::Image>(*pnh_, "output", 1);
 
     tf_ = TfListenerSingleton::getInstance();
@@ -88,8 +89,8 @@ namespace jsk_pcl_ros
       /* convert points */
       tf::StampedTransform ros_fixed_to_center;
       try {
-	tf_->waitForTransform(fixed_frame_id_, center_frame_id_,
-			     msg->header.stamp, ros::Duration(1.0));
+        tf_->waitForTransform(fixed_frame_id_, center_frame_id_,
+                              msg->header.stamp, ros::Duration(duration_transform_timeout_));
         tf_->lookupTransform(fixed_frame_id_, center_frame_id_,
                              msg->header.stamp, ros_fixed_to_center);
       }
@@ -105,8 +106,8 @@ namespace jsk_pcl_ros
 
       tf::StampedTransform ros_msg_to_fixed;
       try {
-	tf_->waitForTransform(msg->header.frame_id, fixed_frame_id_,
-			     msg->header.stamp, ros::Duration(1.0));
+        tf_->waitForTransform(msg->header.frame_id, fixed_frame_id_,
+                              msg->header.stamp, ros::Duration(duration_transform_timeout_));
         tf_->lookupTransform(msg->header.frame_id, fixed_frame_id_,
                              msg->header.stamp, ros_msg_to_fixed);
       }


### PR DESCRIPTION
To supress 'tf lookup would require extrapolation into the future' warning of heightmap conveter, added waitfortransform() before lookupTransform()