### PR TITLE
Add brightness arg to camera launchs

### DIFF
--- a/jsk_perception/launch/libuvc_camera.launch
+++ b/jsk_perception/launch/libuvc_camera.launch
@@ -6,6 +6,7 @@
   <arg name="width" />
   <arg name="video_mode" />
   <arg name="frame_rate" />
+  <arg name="brightness" />
   <arg name="gui" default="false" />
 
   <group ns="$(arg camera_name)">
@@ -16,6 +17,7 @@
       <param name="width" value="$(arg width)" />
       <param name="video_mode" value="$(arg video_mode)" />
       <param name="frame_rate" value="$(arg frame_rate)" />
+      <param name="brightness" value="$(arg brightness)" />
       <param name="time_method" value="start" />
       <param name="auto_exposure" value="1" />
       <param name="auto_white_balance" value="true" />

--- a/jsk_perception/launch/usb_cam.launch
+++ b/jsk_perception/launch/usb_cam.launch
@@ -5,6 +5,7 @@
   <arg name="width" />
   <arg name="video_mode" />
   <arg name="frame_rate" />
+  <arg name="brightness" />
   <arg name="gui" default="false" />
 
   <node pkg="usb_cam" type="usb_cam_node" name="$(arg camera_name)">
@@ -14,6 +15,7 @@
       image_width: $(arg width)
       pixel_format: $(arg video_mode)
       framerate: $(arg frame_rate)
+      brightness: $(arg brightness)
     </rosparam>
   </node>
 

--- a/jsk_perception/sample/sample_elp_usb_4k.launch
+++ b/jsk_perception/sample/sample_elp_usb_4k.launch
@@ -6,6 +6,7 @@
   <arg name="height" default="2160" />
   <arg name="video_mode" default="mjpeg" />
   <arg name="frame_rate" default="30" />
+  <arg name="brightness" default="0" />
   <arg name="gui" default="true" />
 
   <include file="$(find jsk_perception)/launch/libuvc_camera.launch">
@@ -16,6 +17,7 @@
     <arg name="width" value="$(arg width)" />
     <arg name="video_mode" value="$(arg video_mode)" />
     <arg name="frame_rate" value="$(arg frame_rate)" />
+    <arg name="brightness" value="$(arg brightness)" />
     <arg name="gui" value="$(arg gui)" />
   </include>
 </launch>

--- a/jsk_perception/sample/sample_insta360_air.launch
+++ b/jsk_perception/sample/sample_insta360_air.launch
@@ -10,6 +10,7 @@
   <arg name="height" default="1504" />
   <arg name="video_mode" default="mjpeg" />
   <arg name="frame_rate" default="30" />
+  <arg name="brightness" default="0" />
   <arg name="create_panorama" default="true" />
   <arg name="refine_align" default="false" />
   <arg name="save_unwarped" default="false" />
@@ -27,6 +28,7 @@
       <arg name="width" value="$(arg width)" />
       <arg name="video_mode" value="$(arg video_mode)" />
       <arg name="frame_rate" value="$(arg frame_rate)" />
+      <arg name="brightness" value="$(arg brightness)" /> <!-- -32768 ~ 32767 -->
       <arg name="gui" value="$(arg gui)" />
     </include>
     <!-- For kinetic or older -->
@@ -37,6 +39,7 @@
       <arg name="width" value="$(arg width)" />
       <arg name="video_mode" value="$(arg video_mode)" />
       <arg name="frame_rate" value="$(arg frame_rate)" />
+      <arg name="brightness" value="$(arg brightness)" /> <!-- 0 ~ 255 -->
       <arg name="gui" value="$(arg gui)" />
     </include>
   </group>

--- a/jsk_perception/sample/sample_insta360_air.launch
+++ b/jsk_perception/sample/sample_insta360_air.launch
@@ -10,7 +10,7 @@
   <arg name="height" default="1504" />
   <arg name="video_mode" default="mjpeg" />
   <arg name="frame_rate" default="30" />
-  <arg name="brightness" default="0" />
+  <arg name="brightness" default="128" />
   <arg name="create_panorama" default="true" />
   <arg name="refine_align" default="false" />
   <arg name="save_unwarped" default="false" />


### PR DESCRIPTION
I add `brightness` arg to camera launchs.
With the default settings, the insta360 image is very dark.
For isnta360, brightness:=128 works well with both usb_cam and libuvc_camera.

The same condition as now:
```
roslaunch jsk_perception sample_insta360_air.launch brightness:=0
```
![brightness_0](https://user-images.githubusercontent.com/19769486/108061398-9a8b6300-709b-11eb-9a52-cb4f263026f0.jpg)

Increase bightness:
```
roslaunch jsk_perception sample_insta360_air.launch brightness:=128
```
![brightness_128](https://user-images.githubusercontent.com/19769486/108061412-9fe8ad80-709b-11eb-8f53-ab0ea03ab7af.jpg)
