### PR TITLE
fix typo in github workflow branch name

### DIFF
--- a/.github/workflows/indigo.yml
+++ b/.github/workflows/indigo.yml
@@ -3,7 +3,7 @@
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/kinetic.yml
+++ b/.github/workflows/kinetic.yml
@@ -3,7 +3,7 @@
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/melodic-base.yml
+++ b/.github/workflows/melodic-base.yml
@@ -3,7 +3,7 @@
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/melodic.yml
+++ b/.github/workflows/melodic.yml
@@ -3,7 +3,7 @@
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/noetic-full-test.yml
+++ b/.github/workflows/noetic-full-test.yml
@@ -3,7 +3,7 @@
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 jobs:
   noetic:

--- a/.github/workflows/noetic.yml
+++ b/.github/workflows/noetic.yml
@@ -3,7 +3,7 @@
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
I fix branch name from `main` -> `master` in github workflow branch name