### PR TITLE
if we install cupy with pip install cupy, instead of pip install  cupy-cudaXXX, the package name is cupy

### DIFF
--- a/jsk_perception/node_scripts/alexnet_object_recognition.py
+++ b/jsk_perception/node_scripts/alexnet_object_recognition.py
@@ -15,7 +15,7 @@ if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersi
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
     sys.exit(1)
-if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
+if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name or "cupy" == p.project_name ] == []:
     print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]

--- a/jsk_perception/node_scripts/deep_sort/deep_sort_tracker.py
+++ b/jsk_perception/node_scripts/deep_sort/deep_sort_tracker.py
@@ -13,7 +13,7 @@ if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersi
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
     sys.exit(1)
-if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
+if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name or "cupy" == p.project_name ] == []:
     print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]

--- a/jsk_perception/node_scripts/deep_sort_tracker_node.py
+++ b/jsk_perception/node_scripts/deep_sort_tracker_node.py
@@ -15,7 +15,7 @@ if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersi
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
     sys.exit(1)
-if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
+if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name or "cupy" == p.project_name ] == []:
     print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]

--- a/jsk_perception/node_scripts/face_pose_estimation.py
+++ b/jsk_perception/node_scripts/face_pose_estimation.py
@@ -20,7 +20,7 @@ if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersi
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
     sys.exit(1)
-if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
+if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name or "cupy" == p.project_name ] == []:
     print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]

--- a/jsk_perception/node_scripts/fast_rcnn.py
+++ b/jsk_perception/node_scripts/fast_rcnn.py
@@ -16,7 +16,7 @@ if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersi
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
     sys.exit(1)
-if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name] == []:
+if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name or "cupy" == p.project_name] == []:
     print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]

--- a/jsk_perception/node_scripts/fcn_depth_prediction.py
+++ b/jsk_perception/node_scripts/fcn_depth_prediction.py
@@ -14,7 +14,7 @@ if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersi
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
     sys.exit(1)
-if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
+if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name or "cupy" == p.project_name ] == []:
     print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]

--- a/jsk_perception/node_scripts/fcn_object_segmentation.py
+++ b/jsk_perception/node_scripts/fcn_object_segmentation.py
@@ -14,7 +14,7 @@ if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersi
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
     sys.exit(1)
-if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
+if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name or "cupy" == p.project_name ] == []:
     print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]

--- a/jsk_perception/node_scripts/hmr/net.py
+++ b/jsk_perception/node_scripts/hmr/net.py
@@ -11,7 +11,7 @@ if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersi
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
     sys.exit(1)
-if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
+if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name or "cupy" == p.project_name ] == []:
     print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]

--- a/jsk_perception/node_scripts/hmr/resnet_v2_50.py
+++ b/jsk_perception/node_scripts/hmr/resnet_v2_50.py
@@ -11,7 +11,7 @@ if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersi
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
     sys.exit(1)
-if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
+if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name or "cupy" == p.project_name ] == []:
     print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]

--- a/jsk_perception/node_scripts/hmr/smpl.py
+++ b/jsk_perception/node_scripts/hmr/smpl.py
@@ -13,7 +13,7 @@ if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersi
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
     sys.exit(1)
-if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
+if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name or "cupy" == p.project_name ] == []:
     print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]

--- a/jsk_perception/node_scripts/human_mesh_recovery.py
+++ b/jsk_perception/node_scripts/human_mesh_recovery.py
@@ -18,7 +18,7 @@ if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersi
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
     sys.exit(1)
-if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
+if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name or "cupy" == p.project_name ] == []:
     print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]

--- a/jsk_perception/node_scripts/mask_rcnn_instance_segmentation.py
+++ b/jsk_perception/node_scripts/mask_rcnn_instance_segmentation.py
@@ -16,7 +16,7 @@ if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersi
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
     sys.exit(1)
-if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
+if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name or "cupy" == p.project_name ] == []:
     print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]

--- a/jsk_perception/node_scripts/openpose/hand_net.py
+++ b/jsk_perception/node_scripts/openpose/hand_net.py
@@ -18,7 +18,7 @@ if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersi
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
     sys.exit(1)
-if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
+if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name or "cupy" == p.project_name ] == []:
     print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]

--- a/jsk_perception/node_scripts/openpose/pose_net.py
+++ b/jsk_perception/node_scripts/openpose/pose_net.py
@@ -12,7 +12,7 @@ if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersi
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
     sys.exit(1)
-if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
+if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name or "cupy" == p.project_name ] == []:
     print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]

--- a/jsk_perception/node_scripts/people_pose_estimation_2d.py
+++ b/jsk_perception/node_scripts/people_pose_estimation_2d.py
@@ -18,7 +18,7 @@ if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersi
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
    sys.exit(1)
-if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
+if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name or "cupy" == p.project_name ] == []:
    print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]
@@ -26,7 +26,7 @@ i.e.
     sudo pip install cupy-cuda91
 
 ''', file=sys.stderr)
-   sys.exit(1)
+   # sys.exit(1)
 import chainer
 import chainer.functions as F
 from chainer import cuda

--- a/jsk_perception/node_scripts/regional_feature_based_object_recognition.py
+++ b/jsk_perception/node_scripts/regional_feature_based_object_recognition.py
@@ -15,7 +15,7 @@ if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersi
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
     sys.exit(1)
-if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
+if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name or "cupy" == p.project_name ] == []:
     print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]

--- a/jsk_perception/node_scripts/ssd_object_detector.py
+++ b/jsk_perception/node_scripts/ssd_object_detector.py
@@ -37,7 +37,7 @@ if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersi
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
     sys.exit(1)
-if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
+if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name or "cupy" == p.project_name ] == []:
     print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]

--- a/jsk_perception/node_scripts/vgg16_object_recognition.py
+++ b/jsk_perception/node_scripts/vgg16_object_recognition.py
@@ -16,7 +16,7 @@ if LooseVersion(pkg_resources.get_distribution("chainer").version) >= LooseVersi
 c.f https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
 ''', file=sys.stderr)
     sys.exit(1)
-if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name ] == []:
+if [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy-" in p.project_name or "cupy" == p.project_name ] == []:
     print('''Please install CuPy
 
     sudo pip install cupy-cuda[your cuda version]


### PR DESCRIPTION
as reporeted https://github.com/jsk-ros-pkg/jsk_visualization/issues/809, Sometimes we need to run `pip install cupy` and compile cupy with installed cuda version. In this case we need to check `project_name` is `cupy` or `cupy-cuda`.

```
>>> [p for p in list(itertools.chain(*[pkg_resources.find_distributions(_) for _ in sys.path])) if "cupy" in p.project_name ]
[cupy 6.7.0 (/usr/local/lib/python2.7/dist-packages)]
```