### PR TITLE
[WIP] [jsk_perception] add max_interval_duration for apply_mask_image

### DIFF
--- a/jsk_perception/include/jsk_perception/apply_mask_image.h
+++ b/jsk_perception/include/jsk_perception/apply_mask_image.h
@@ -75,6 +75,7 @@ namespace jsk_perception
     bool mask_black_to_transparent_;
     bool use_rectified_image_;
     int queue_size_;
+    double max_interval_duration_;
     int cval_;
     boost::shared_ptr<message_filters::Synchronizer<SyncPolicy> > sync_;
     boost::shared_ptr<message_filters::Synchronizer<ApproximateSyncPolicy> > async_;

--- a/jsk_perception/include/jsk_perception/apply_mask_image.h
+++ b/jsk_perception/include/jsk_perception/apply_mask_image.h
@@ -75,7 +75,7 @@ namespace jsk_perception
     bool mask_black_to_transparent_;
     bool use_rectified_image_;
     int queue_size_;
-    int max_interval_duration_;
+    double max_interval_duration_;
     int cval_;
     boost::shared_ptr<message_filters::Synchronizer<SyncPolicy> > sync_;
     boost::shared_ptr<message_filters::Synchronizer<ApproximateSyncPolicy> > async_;

--- a/jsk_perception/include/jsk_perception/apply_mask_image.h
+++ b/jsk_perception/include/jsk_perception/apply_mask_image.h
@@ -75,7 +75,7 @@ namespace jsk_perception
     bool mask_black_to_transparent_;
     bool use_rectified_image_;
     int queue_size_;
-    double max_interval_duration_;
+    int max_interval_duration_;
     int cval_;
     boost::shared_ptr<message_filters::Synchronizer<SyncPolicy> > sync_;
     boost::shared_ptr<message_filters::Synchronizer<ApproximateSyncPolicy> > async_;

--- a/jsk_perception/src/apply_mask_image.cpp
+++ b/jsk_perception/src/apply_mask_image.cpp
@@ -76,7 +76,7 @@ namespace jsk_perception
       async_->registerCallback(boost::bind(&ApplyMaskImage::apply, this, _1, _2));
     }
     else {
-      sync_ = boost::make_shared<message_filters::Synchronizer<SyncPolicy> >(queue_size_), (max_interval_duration_);
+      sync_ = boost::make_shared<message_filters::Synchronizer<SyncPolicy> >(queue_size_);
       sync_->connectInput(sub_image_, sub_mask_);
       sync_->registerCallback(boost::bind(&ApplyMaskImage::apply, this, _1, _2));
     }

--- a/jsk_perception/src/apply_mask_image.cpp
+++ b/jsk_perception/src/apply_mask_image.cpp
@@ -53,7 +53,7 @@ namespace jsk_perception
     pnh_->param("mask_black_to_transparent", mask_black_to_transparent_, false);
     pnh_->param("use_rectified_image", use_rectified_image_, true);
     pnh_->param("queue_size", queue_size_, 100);
-    pnh_->param("max_interval_duration", max_interval_duration_, 0.1);
+    pnh_->param("max_interval_duration", max_interval_duration_, ros::DURATION_MAX);
     pnh_->param("cval", cval_, 0);
     pub_image_ = advertise<sensor_msgs::Image>(
       *pnh_, "output", 1);

--- a/jsk_perception/src/apply_mask_image.cpp
+++ b/jsk_perception/src/apply_mask_image.cpp
@@ -53,7 +53,7 @@ namespace jsk_perception
     pnh_->param("mask_black_to_transparent", mask_black_to_transparent_, false);
     pnh_->param("use_rectified_image", use_rectified_image_, true);
     pnh_->param("queue_size", queue_size_, 100);
-    pnh_->param("max_interval_duration", max_interval_duration_, ros::DURATION_MAX.sec);
+    pnh_->param("max_interval_duration", max_interval_duration_, ros::DURATION_MAX.toSec());
     pnh_->param("cval", cval_, 0);
     pub_image_ = advertise<sensor_msgs::Image>(
       *pnh_, "output", 1);

--- a/jsk_perception/src/apply_mask_image.cpp
+++ b/jsk_perception/src/apply_mask_image.cpp
@@ -53,6 +53,7 @@ namespace jsk_perception
     pnh_->param("mask_black_to_transparent", mask_black_to_transparent_, false);
     pnh_->param("use_rectified_image", use_rectified_image_, true);
     pnh_->param("queue_size", queue_size_, 100);
+    pnh_->param("max_interval_duration", max_interval_duration_, 0.1);
     pnh_->param("cval", cval_, 0);
     pub_image_ = advertise<sensor_msgs::Image>(
       *pnh_, "output", 1);
@@ -70,12 +71,12 @@ namespace jsk_perception
     sub_info_ = pnh_->subscribe("input/camera_info", 1,
                                 &ApplyMaskImage::infoCallback, this);
     if (approximate_sync_) {
-      async_ = boost::make_shared<message_filters::Synchronizer<ApproximateSyncPolicy> >(queue_size_);
+      async_ = boost::make_shared<message_filters::Synchronizer<ApproximateSyncPolicy> >(queue_size_), (max_interval_duration_);
       async_->connectInput(sub_image_, sub_mask_);
       async_->registerCallback(boost::bind(&ApplyMaskImage::apply, this, _1, _2));
     }
     else {
-      sync_ = boost::make_shared<message_filters::Synchronizer<SyncPolicy> >(queue_size_);
+      sync_ = boost::make_shared<message_filters::Synchronizer<SyncPolicy> >(queue_size_), (max_interval_duration_);
       sync_->connectInput(sub_image_, sub_mask_);
       sync_->registerCallback(boost::bind(&ApplyMaskImage::apply, this, _1, _2));
     }

--- a/jsk_perception/src/apply_mask_image.cpp
+++ b/jsk_perception/src/apply_mask_image.cpp
@@ -54,7 +54,7 @@ namespace jsk_perception
     pnh_->param("mask_black_to_transparent", mask_black_to_transparent_, false);
     pnh_->param("use_rectified_image", use_rectified_image_, true);
     pnh_->param("queue_size", queue_size_, 100);
-    pnh_->param("max_interval_duration", max_interval_duration_, ros::DURATION_MAX.toSec());
+    pnh_->param("max_interval_duration", max_interval_duration_, ros::DURATION_MAX.sec);
     pnh_->param("cval", cval_, 0);
     pub_image_ = advertise<sensor_msgs::Image>(
       *pnh_, "output", 1);

--- a/jsk_perception/src/apply_mask_image.cpp
+++ b/jsk_perception/src/apply_mask_image.cpp
@@ -33,6 +33,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
+#include "ros/duration.h"
 #include "jsk_perception/apply_mask_image.h"
 #include <boost/assign.hpp>
 #include <jsk_topic_tools/log_utils.h>
@@ -53,7 +54,7 @@ namespace jsk_perception
     pnh_->param("mask_black_to_transparent", mask_black_to_transparent_, false);
     pnh_->param("use_rectified_image", use_rectified_image_, true);
     pnh_->param("queue_size", queue_size_, 100);
-    pnh_->param("max_interval_duration", max_interval_duration_, ros::DURATION_MAX);
+    pnh_->param("max_interval_duration", max_interval_duration_, ros::DURATION_MAX.toSec());
     pnh_->param("cval", cval_, 0);
     pub_image_ = advertise<sensor_msgs::Image>(
       *pnh_, "output", 1);

--- a/jsk_perception/src/apply_mask_image.cpp
+++ b/jsk_perception/src/apply_mask_image.cpp
@@ -33,7 +33,6 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#include "ros/duration.h"
 #include "jsk_perception/apply_mask_image.h"
 #include <boost/assign.hpp>
 #include <jsk_topic_tools/log_utils.h>


### PR DESCRIPTION
Add a parameter `max_interval_duration` that defines the delay (in seconds) with which messages can be synchronized in message_filters.
`max_interval_duration` is same as `slop` in python message_fileters. 