### PR TITLE
enable to publish comprssed image if required

### DIFF
--- a/jsk_perception/node_scripts/image_publisher.py
+++ b/jsk_perception/node_scripts/image_publisher.py
@@ -32,7 +32,7 @@ class ImagePublisher(object):
         dynamic_reconfigure.server.Server(
             ImagePublisherConfig, self._cb_dyn_reconfig)
         self.pub = rospy.Publisher('~output', Image, queue_size=1)
-        self.pub_compressed = rospy.Publisher('~output/compressed', CompressedImage, queue_size=1)
+        self.pub_compressed = rospy.Publisher('{}/compressed'.format(rospy.resolve_name('~output')), CompressedImage, queue_size=1)
         self.publish_info = rospy.get_param('~publish_info', True)
         if self.publish_info:
             self.pub_info = rospy.Publisher(


### PR DESCRIPTION
Changes:

7bab20b9 (Kei Okada, 39 seconds ago)
   enable to change output image/{compressed,camera_info} when remapped
   ~output:=tmp

1b19390a (Kei Okada, 2 minutes ago)
   enable to publish comprssed image if required

6e8f2a81 (Kei Okada, 56 minutes ago)
   do not error ```     if (len(img.shape) == 2 and AttributeError: 'NoneType'
   object has no attribute 'shape' ``` when file is not found