### PR TITLE
Add python-numpy due to ros/rosdistro#31580

### DIFF
--- a/.github/workflows/indigo.yml
+++ b/.github/workflows/indigo.yml
@@ -24,6 +24,7 @@ jobs:
         uses: jsk-ros-pkg/jsk_travis@master
         with:
           USE_JENKINS: true
+          EXTRA_DEB : "python-numpy"
           ROS_DISTRO : indigo
           ROS_PARALLEL_JOBS : "-j8"
           ROS_PARALLEL_TEST_JOBS : "-j4"

--- a/.github/workflows/kinetic.yml
+++ b/.github/workflows/kinetic.yml
@@ -24,7 +24,6 @@ jobs:
         uses: jsk-ros-pkg/jsk_travis@master
         with:
           USE_JENKINS: true
-          EXTRA_DEB : "python-numpy"
           ROS_DISTRO : kinetic
           ROS_PARALLEL_JOBS : "-j8"
           ROS_PARALLEL_TEST_JOBS : "-j4"

--- a/.github/workflows/kinetic.yml
+++ b/.github/workflows/kinetic.yml
@@ -24,6 +24,7 @@ jobs:
         uses: jsk-ros-pkg/jsk_travis@master
         with:
           USE_JENKINS: true
+          EXTRA_DEB : "python-numpy"
           ROS_DISTRO : kinetic
           ROS_PARALLEL_JOBS : "-j8"
           ROS_PARALLEL_TEST_JOBS : "-j4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
     - NOT_TEST_INSTALL=true
     - USE_JENKINS=true
     - USE_DEB=true
+    - EXTRA_DEB="python-numpy" # add python-numpy due to https://github.com/ros/rosdistro/pull/31552
     - ROSDEP_ADDITIONAL_OPTIONS='-n -r -v --ignore-src' # run rosdep without -q
   matrix:
     - CHECK_PYTHON3_COMPILE=true


### PR DESCRIPTION
This is in response to https://github.com/ros/rosdistro removing all EOL keys related to python-numpy in https://github.com/ros/rosdistro/pull/31552.
I used https://github.com/jsk-ros-pkg/jsk_3rdparty/pull/306/commits/fcdd7ce9b720124e97c419e388a4f81ae85f13ec as a reference for writing.
