### PR TITLE
[jsk_pcl_ros/octomap_server_contact_nodelet.cpp] fix memory leak of colors pointer

### DIFF
--- a/jsk_pcl_ros/src/octomap_server_contact_nodelet.cpp
+++ b/jsk_pcl_ros/src/octomap_server_contact_nodelet.cpp
@@ -302,6 +302,14 @@ namespace jsk_pcl_ros
 
     if (m_compressMap)
       m_octree->prune();
+
+#ifdef COLOR_OCTOMAP_SERVER
+    if (colors)
+      {
+        delete[] colors;
+        colors = NULL;
+      }
+#endif
   }
 
   void OctomapServerContact::insertContactSensor(const jsk_recognition_msgs::ContactSensorArray::ConstPtr& msg) {


### PR DESCRIPTION
https://github.com/OctoMap/octomap_mapping/pull/40 と同じmemory leakがありました。

このmemory leakはCOLOR_OCTOMAP_SERVERオプションが定義されているときのみ発生しますが、デフォルトでは定義されていないため、普通に使っている限りはこのPR無しでもmemory leakは発生しません。