### PR TITLE
[jsk_perception] Add libuvc_camera to dependency for sample_insta360_air.launch

### DIFF
--- a/jsk_perception/package.xml
+++ b/jsk_perception/package.xml
@@ -32,6 +32,7 @@
   <build_depend>jsk_recognition_utils</build_depend>
   <build_depend>jsk_topic_tools</build_depend>
   <build_depend>libcmt</build_depend>
+  <build_depend>libuvc_camera</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>mk</build_depend>
   <build_depend>nodelet</build_depend>
@@ -67,6 +68,7 @@
   <exec_depend>jsk_rqt_plugins</exec_depend>
   <exec_depend>jsk_topic_tools</exec_depend>
   <exec_depend>libcmt</exec_depend>
+  <exec_depend>libuvc_camera</exec_depend>
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>mk</exec_depend>
   <exec_depend>ml_classifiers</exec_depend>


### PR DESCRIPTION
`sample_insta360_air.launch` use `libuvc_camera` but no dependency is written in `package.xml`.
So, we have to execute `sudo apt install ros-melodic-libuvc-camera` manually without this pull request.

Please let me know if there is any reason why `libuvc_camera` is not listed in the dependencies.

cc:@708yamaguchi
