### PR TITLE
[jsk_perception] Fix NoRegionError in aws_detect_faces.py

### DIFF
--- a/doc/jsk_perception/nodes/aws_detect_faces.rst
+++ b/doc/jsk_perception/nodes/aws_detect_faces.rst
@@ -29,7 +29,8 @@ Publishing Topic
 
   Pose of the face as determined by its pitch, roll, and yaw. The pose is published in Quaternion, to reconstruct Roll, Pitch, Yaw, use following codes.
 
-  ```
+.. code-block:: bash
+
   import math
   import rospy
   from geometry_msgs.msg import PoseArray
@@ -45,11 +46,11 @@ Publishing Topic
       rospy.init_node('pose_example')
       rospy.Subscriber('/aws_detect_faces/poses', PoseArray, cb)
       rospy.spin()
-  ```
+
 
 * ``~attributes`` (``jsk_recognition_msgs/ClassificationResult``)
 
-   Attributes of the face, such as emotions, presence of beard, sunglasses, and so on, with confidence.
+  Attributes of the face, such as emotions, presence of beard, sunglasses, and so on, with confidence.
 
 * ``~landmarks`` (``jsk_recognition_msgs/PeoplePoseArray``)
 
@@ -69,13 +70,15 @@ Parameters
   see `Set up an AWS account and create an IAM user
   <https://docs.aws.amazon.com/rekognition/latest/dg/setting-up.html>`_
   for how to obtain keys.
-  ```
+
+.. code-block:: json
+
   {
       "aws_access_key_id" : "####################",
       "aws_secret_access_key" : "********************"
   }
 
-  ```
+  
 
 * ``~attributes`` (Bool, Default: ``ALL``)
 

--- a/doc/jsk_perception/nodes/aws_detect_faces.rst
+++ b/doc/jsk_perception/nodes/aws_detect_faces.rst
@@ -74,6 +74,7 @@ Parameters
 .. code-block:: json
 
   {
+      "region" : "xxxxxxxxxxxxxxxxxxxx",
       "aws_access_key_id" : "####################",
       "aws_secret_access_key" : "********************"
   }

--- a/jsk_perception/node_scripts/aws_detect_faces.py
+++ b/jsk_perception/node_scripts/aws_detect_faces.py
@@ -30,6 +30,7 @@ import cv_bridge
 
 import json
 
+import sys
 
 COLORS = [
     (100, 100, 100),
@@ -68,7 +69,7 @@ class DetectFaces(ConnectionBasedTransport):
                 aws_credentials = json.load(f)
         except IOError:
             rospy.logerr('Cannot open "{}".\n Please put region/aws_access_key_id/aws_secret_access_key to aws.json.'.format(aws_credentials_path))
-            raise
+            sys.exit(1)
 
         try:
             aws_access_key_id = aws_credentials['aws_access_key_id']

--- a/jsk_perception/node_scripts/aws_detect_faces.py
+++ b/jsk_perception/node_scripts/aws_detect_faces.py
@@ -73,6 +73,7 @@ class DetectFaces(ConnectionBasedTransport):
         try:
             aws_access_key_id = aws_credentials['aws_access_key_id']
             aws_secret_access_key = aws_credentials['aws_secret_access_key']
+            region_name = aws_credentials['region']
         except KeyError:
             print('Invalid config file')
             raise
@@ -80,7 +81,8 @@ class DetectFaces(ConnectionBasedTransport):
         self.rekognition = boto3.client(
             'rekognition',
             aws_access_key_id=aws_access_key_id,
-            aws_secret_access_key=aws_secret_access_key)
+            aws_secret_access_key=aws_secret_access_key,
+            region_name=region_name)
 
         self.bridge = cv_bridge.CvBridge()
 

--- a/jsk_perception/node_scripts/aws_detect_faces.py
+++ b/jsk_perception/node_scripts/aws_detect_faces.py
@@ -67,7 +67,7 @@ class DetectFaces(ConnectionBasedTransport):
             with open(aws_credentials_path) as f:
                 aws_credentials = json.load(f)
         except IOError:
-            rospy.logerr('Cannot open "{}".\n Pulease put region/aws_access_key_id/aws_secret_access_key to aws.json.'.format(aws_credentials_path))
+            rospy.logerr('Cannot open "{}".\n Please put region/aws_access_key_id/aws_secret_access_key to aws.json.'.format(aws_credentials_path))
             raise
 
         try:

--- a/jsk_perception/package.xml
+++ b/jsk_perception/package.xml
@@ -77,6 +77,8 @@
   <exec_depend>openni2_launch</exec_depend>
   <exec_depend>pcl_ros</exec_depend>
   <exec_depend>posedetection_msgs</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-boto3</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-boto3</exec_depend>
   <!-- install chainer {{ -->
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-h5py</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-h5py</exec_depend>


### PR DESCRIPTION
In this PR

- Add `region_name` argument for boto3.client because of the following NoRegionError. We have to set `region_name` in boto3.client.

<details>
<summary>error log </summary>

```
$ roslaunch jsk_perception sample_aws_detect_faces.launch 
... logging to /home/tsukamoto/.ros/log/80e1b0c0-b3f8-11ec-ae1b-d05099843c5d/roslaunch-tsukamoto-desktop-26099.log
Checking log directory for disk usage. This may take a while.
Press Ctrl-C to interrupt
WARNING: disk usage in log directory [/home/tsukamoto/.ros/log] is over 1GB.
It's recommended that you use the 'rosclean' command.

started roslaunch server http://tsukamoto-desktop:37241/

SUMMARY
========

CLEAR PARAMETERS
 * /aws_detect_faces/

PARAMETERS
 * /aws_detect_faces/always_subscribe: True
 * /aws_detect_faces/attributes: ALL
 * /aws_detect_faces/aws_credentials_path: /tmp/aws.json
 * /aws_detect_faces/use_window: True
 * /camera/camera_nodelet_manager/num_worker_threads: 4
 * /camera/depth_rectify_depth/interpolation: 0
 * /camera/depth_registered_rectify_depth/interpolation: 0
 * /rosdistro: melodic
 * /rosversion: 1.14.13
 * /use_sim_time: True

NODES
  /
    aws_detect_faces (jsk_perception/aws_detect_faces.py)
    camera_base_link (tf2_ros/static_transform_publisher)
    camera_base_link1 (tf2_ros/static_transform_publisher)
    camera_base_link2 (tf2_ros/static_transform_publisher)
    camera_base_link3 (tf2_ros/static_transform_publisher)
    rosbag_play (rosbag/play)
  /camera/
    camera_nodelet_manager (nodelet/nodelet)
    depth_metric (nodelet/nodelet)
    depth_metric_rect (nodelet/nodelet)
    depth_points (nodelet/nodelet)
    depth_rectify_depth (nodelet/nodelet)
    depth_registered_hw_metric_rect (nodelet/nodelet)
    depth_registered_metric (nodelet/nodelet)
    depth_registered_rectify_depth (nodelet/nodelet)
    points_xyzrgb_hw_registered (nodelet/nodelet)
    rgb_rectify_color (nodelet/nodelet)
  /camera/depth_registered/
    republish (image_transport/republish)
  /camera/rgb/
    republish (image_transport/republish)

ROS_MASTER_URI=http://localhost:11311

process[rosbag_play-1]: started with pid [26126]
process[camera/rgb/republish-2]: started with pid [26127]
process[camera/depth_registered/republish-3]: started with pid [26133]
process[camera/camera_nodelet_manager-4]: started with pid [26141]
process[camera/rgb_rectify_color-5]: started with pid [26152]
process[camera/depth_rectify_depth-6]: started with pid [26153]
process[camera/depth_metric_rect-7]: started with pid [26160]
process[camera/depth_metric-8]: started with pid [26163]
process[camera/depth_points-9]: started with pid [26169]
process[camera/depth_registered_rectify_depth-10]: started with pid [26175]
process[camera/points_xyzrgb_hw_registered-11]: started with pid [26181]
process[camera/depth_registered_hw_metric_rect-12]: started with pid [26186]
process[camera/depth_registered_metric-13]: started with pid [26195]
process[camera_base_link-14]: started with pid [26203]
[ INFO] [1649136627.450753261] [/camera/camera_nodelet_manager]: [Initializing nodelet with 4 worker threads.]
process[camera_base_link1-15]: started with pid [26216]
process[camera_base_link2-16]: started with pid [26222]
process[camera_base_link3-17]: started with pid [26227]
process[aws_detect_faces-18]: started with pid [26285]
[INFO] [1649136629.768790, 0.000000] [/aws_detect_faces]: [ROS node initialized as /aws_detect_faces]
[INFO] [1649136629.775112, 0.000000] [/aws_detect_faces]: [Loading AWS credentials from /tmp/aws.json]
/home/tsukamoto/.local/lib/python2.7/site-packages/boto3/compat.py:86: PythonDeprecationWarning: Boto3 will no longer support Python 2.7 starting July 15, 2021. To continue receiving service updates, bug fixes, and security updates please upgrade to Python 3.6 or later. More information can be found here: https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/
  warnings.warn(warning, PythonDeprecationWarning)
Traceback (most recent call last):
  File "/home/tsukamoto/ros/jsk_recognition_ws/src/jsk_recognition/jsk_perception/node_scripts/aws_detect_faces.py", line 359, in <module>
    detect_faces = DetectFaces()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/jsk_topic_tools/transport.py", line 26, in __call__
    obj = type.__call__(cls, *args, **kwargs)
  File "/home/tsukamoto/ros/jsk_recognition_ws/src/jsk_recognition/jsk_perception/node_scripts/aws_detect_faces.py", line 83, in __init__
    aws_secret_access_key=aws_secret_access_key)
  File "/home/tsukamoto/.local/lib/python2.7/site-packages/boto3/__init__.py", line 93, in client
    return _get_default_session().client(*args, **kwargs)
  File "/home/tsukamoto/.local/lib/python2.7/site-packages/boto3/session.py", line 263, in client
    aws_session_token=aws_session_token, config=config)
  File "/home/tsukamoto/.local/lib/python2.7/site-packages/botocore/session.py", line 851, in create_client
    client_config=config, api_version=api_version)
  File "/home/tsukamoto/.local/lib/python2.7/site-packages/botocore/client.py", line 88, in create_client
    verify, credentials, scoped_config, client_config, endpoint_bridge)
  File "/home/tsukamoto/.local/lib/python2.7/site-packages/botocore/client.py", line 357, in _get_client_args
    verify, credentials, scoped_config, client_config, endpoint_bridge)
  File "/home/tsukamoto/.local/lib/python2.7/site-packages/botocore/args.py", line 73, in get_client_args
    endpoint_url, is_secure, scoped_config)
  File "/home/tsukamoto/.local/lib/python2.7/site-packages/botocore/args.py", line 154, in compute_client_args
    s3_config=s3_config,
  File "/home/tsukamoto/.local/lib/python2.7/site-packages/botocore/args.py", line 220, in _compute_endpoint_config
    return self._resolve_endpoint(**resolve_endpoint_kwargs)
  File "/home/tsukamoto/.local/lib/python2.7/site-packages/botocore/args.py", line 303, in _resolve_endpoint
    service_name, region_name, endpoint_url, is_secure)
  File "/home/tsukamoto/.local/lib/python2.7/site-packages/botocore/client.py", line 431, in resolve
    service_name, region_name)
  File "/home/tsukamoto/.local/lib/python2.7/site-packages/botocore/regions.py", line 134, in construct_endpoint
    partition, service_name, region_name)
  File "/home/tsukamoto/.local/lib/python2.7/site-packages/botocore/regions.py", line 148, in _endpoint_for_partition
    raise NoRegionError()
botocore.exceptions.NoRegionError: You must specify a region.
[aws_detect_faces-18] process has died [pid 26285, exit code 1, cmd /home/tsukamoto/ros/jsk_recognition_ws/src/jsk_recognition/jsk_perception/node_scripts/aws_detect_faces.py image:=/camera/rgb/image_raw __name:=aws_detect_faces __log:=/home/tsukamoto/.ros/log/80e1b0c0-b3f8-11ec-ae1b-d05099843c5d/aws_detect_faces-18.log].
log file: /home/tsukamoto/.ros/log/80e1b0c0-b3f8-11ec-ae1b-d05099843c5d/aws_detect_faces-18*.log

```

</details>

- Add dependency on python-boto3 or python3-boto3 for `aws_detect_face` and `aws_auto_checkin`

- (fix typo)