### PR TITLE
Enable 3d hand pose detection

### DIFF
--- a/doc/jsk_perception/nodes/hand_pose_estimation_2d.rst
+++ b/doc/jsk_perception/nodes/hand_pose_estimation_2d.rst
@@ -1,4 +1,4 @@
-hand_pose_estimation_2d.py
+oWANG-SRH-2019-07.hand_pose_estimation_2d.py
 ==========================
 
 
@@ -20,19 +20,33 @@ Subscribing Topic
 
   Input image.
 
+* ``~input/depth`` (``sensor_msgs/Image``)
 
+  Input depth image.
+
+* ``~input/info`` (``sensor_msgs/CameraInfo``)
+
+  Input camera info.
+
+  
 Publishing Topic
 ----------------
-
-* ``~output/pose`` (``jsk_recognition_msgs/HandPoseArray``)
-
-  Detected hand keypoints 2D positions and scores in image.
 
 * ``~output/vis`` (``sensor_msgs/Image``)
 
   Visualization image of detected hand poses.
 
+* ``~output/pose`` (``jsk_recognition_msgs/HandPoseArray``)
 
+  If ``with_depth`` is true, publish 3D joint position.
+
+  If ``with_depth`` is false, publish 2D joint position in image.
+
+* ``~output/pose2d`` (``jsk_recognition_msgs/HandPoseArray``)
+
+  If ``with_depth`` is true, publish 2D joint position.
+
+  
 Parameters
 ----------
 
@@ -60,7 +74,27 @@ Parameters
 
   Trained `SRHandNet model file <https://www.yangangwang.com/papers/WANG-SRH-2019-07.html>`_.
 
+* ``~with_depth`` (Bool, Default: ``False``)
 
+  If true, subscribe ``~input/depth`` and ``~input/info``.
+
+* ``~sync_camera_info`` (Bool, Default: ``False``)
+
+  Synchronize ``~input/info`` if enabled, otherwise the last received camera info message is used.
+
+* ``~approximate_sync`` (Bool, Default: ``True``)
+
+  Use approximate synchronization policy.
+
+* ``~queue_size`` (Int, Default: ``10``)
+
+  Queue size for synchronization.
+
+* ``~slop`` (Float, Default: ``0.1``)
+
+  Slop for approximate sync.
+
+  
 Example
 -------
 

--- a/doc/jsk_perception/nodes/hand_pose_estimation_2d.rst
+++ b/doc/jsk_perception/nodes/hand_pose_estimation_2d.rst
@@ -98,9 +98,18 @@ Parameters
 Example
 -------
 
+For 2d hand pose detection.
+
 .. code-block:: bash
 
    roslaunch jsk_perception sample_hand_pose_estimation_2d.launch gpu:=0
+
+
+For 3d hand pose detection.
+
+.. code-block:: bash
+
+   roslaunch jsk_perception sample_hand_pose_estimation_3d.launch gpu:=0
 
 
 Reference

--- a/doc/jsk_perception/nodes/hand_pose_estimation_2d.rst
+++ b/doc/jsk_perception/nodes/hand_pose_estimation_2d.rst
@@ -1,4 +1,4 @@
-oWANG-SRH-2019-07.hand_pose_estimation_2d.py
+hand_pose_estimation_2d.py
 ==========================
 
 

--- a/doc/jsk_perception/nodes/hand_pose_estimation_2d.rst
+++ b/doc/jsk_perception/nodes/hand_pose_estimation_2d.rst
@@ -42,7 +42,7 @@ Publishing Topic
 
   If ``with_depth`` is false, publish 2D joint position in image.
 
-* ``~output/pose2d`` (``jsk_recognition_msgs/HandPoseArray``)
+* ``~output/pose_2d`` (``jsk_recognition_msgs/HandPoseArray``)
 
   If ``with_depth`` is true, publish 2D joint position.
 

--- a/jsk_perception/launch/hand_pose_estimation_2d.launch
+++ b/jsk_perception/launch/hand_pose_estimation_2d.launch
@@ -2,15 +2,21 @@
 
   <arg name="gui" default="true" />
   <arg name="gpu" default="-1" />
-  <arg name="INPUT_IMAGE" default="/usb_cam/image_raw" />
+  <arg name="INPUT_IMAGE" default="/kinect_head/rgb/image_rect_color" />
+  <arg name="INPUT_DEPTH_IMAGE" default="/kinect_head/depth_registered/hw_registered/image_rect" />
+  <arg name="INPUT_CAMERA_INFO" default="/kinect_head/rgb/camera_info" />
+  <arg name="with_depth" default="false" />
 
   <node name="hand_pose_estimation_2d"
         pkg="jsk_perception" type="hand_pose_estimation_2d.py"
         output="screen">
     <remap from="~input" to="$(arg INPUT_IMAGE)" />
+    <remap from="~input/depth" to="$(arg INPUT_DEPTH_IMAGE)" />
+    <remap from="~input/info" to="$(arg INPUT_CAMERA_INFO)" />
     <rosparam subst_value="true">
       gpu: $(arg gpu)
       model_file: $(find jsk_perception)/trained_data/SRHandNet.pts
+      with_depth: $(arg with_depth)
     </rosparam>
   </node>
 

--- a/jsk_perception/sample/config/hand_pose_estimation.rviz
+++ b/jsk_perception/sample/config/hand_pose_estimation.rviz
@@ -1,0 +1,175 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /HumanSkeletonArray1
+        - /PointCloud21
+        - /Image1
+      Splitter Ratio: 0.5
+    Tree Height: 527
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: PointCloud2
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: jsk_rviz_plugin/HumanSkeletonArray
+      Enabled: true
+      Name: HumanSkeletonArray
+      Topic: /hand_pose_estimation_2d/skeleton
+      Unreliable: false
+      Value: true
+      alpha: 1
+      color: 25; 255; 0
+      coloring: Flat color
+      line width: 0.009999999776482582
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 1.4774729013442993
+        Min Value: -0.10255253314971924
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Min Color: 0; 0; 0
+      Name: PointCloud2
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic: /kinect_head/depth_registered/points
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Class: rviz/Image
+      Enabled: true
+      Image Topic: /hand_pose_estimation_2d/output/vis
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Image
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: base_link
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 2.0610032081604004
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0.2626475691795349
+        Y: 0.7206520438194275
+        Z: 1.0827417373657227
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.25539907813072205
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 2.8853952884674072
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1296
+  Hide Left Dock: false
+  Hide Right Dock: false
+  Image:
+    collapsed: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000021100000472fc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d0000029a000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d00610067006501000002dd000001d20000001600fffffffb0000000a0049006d00610067006501000003310000017e0000000000000000000000010000010f00000472fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d00000472000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007460000003efc0100000002fb0000000800540069006d0065010000000000000746000002eb00fffffffb0000000800540069006d006501000000000000045000000000000000000000041a0000047200000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1862
+  X: 67
+  Y: 27

--- a/jsk_perception/sample/include/play_rosbag_hand.xml
+++ b/jsk_perception/sample/include/play_rosbag_hand.xml
@@ -4,7 +4,30 @@
 
   <node name="rosbag_play"
         pkg="rosbag" type="play"
-        args="$(find jsk_perception)/sample/data/hand_pose_estimation_2d.bag --clock --loop">
+        args="$(find jsk_perception)/sample/data/2022-04-07-18-36-43_hand_pose_estimation_2d.bag --clock --loop">
   </node>
+
+  <group ns="/kinect_head/rgb">
+    <node name="republish"
+          pkg="image_transport" type="republish"
+          args="compressed raw">
+      <remap from="in" to="image_raw" />
+      <remap from="out" to="image_raw" />
+    </node>
+  </group>
+  <group ns="/kinect_head/depth_registered">
+    <node name="republish"
+          pkg="image_transport" type="republish"
+          args="compressedDepth raw">
+      <remap from="in" to="image_raw" />
+      <remap from="out" to="image_raw" />
+    </node>
+  </group>
+
+  <include file="$(find openni2_launch)/launch/openni2.launch">
+    <arg name="load_driver" value="false"/>
+    <arg name="depth_registration" value="true"/>
+    <arg name="camera" value="kinect_head"/>
+  </include>
 
 </launch>

--- a/jsk_perception/sample/sample_hand_pose_estimation_2d.launch
+++ b/jsk_perception/sample/sample_hand_pose_estimation_2d.launch
@@ -3,10 +3,16 @@
   <arg name="gui" default="true" />
   <arg name="gpu" default="-1" />
   <arg name="use_usb_cam" default="false" />
-  <arg name="INPUT_IMAGE" default="/usb_cam/image_raw" />
+  <arg name="with_depth" default="false" if="$(arg use_usb_cam)"  />
+  <arg name="with_depth" default="true" unless="$(arg use_usb_cam)"  />
+  <arg name="INPUT_IMAGE" default="/usb_cam/image_raw" if="$(arg use_usb_cam)" />
+  <arg name="INPUT_IMAGE" default="/kinect_head/rgb/image_rect_color" unless="$(arg use_usb_cam)" />
+  <arg name="INPUT_DEPTH_IMAGE" default="/kinect_head/depth_registered/hw_registered/image_rect" />
+  <arg name="INPUT_CAMERA_INFO" default="/kinect_head/rgb/camera_info" />
 
-  <node name="usb_cam" pkg="usb_cam" type="usb_cam_node" 
-        if="$(arg use_usb_cam)" />
+  <node name="usb_cam" pkg="usb_cam" type="usb_cam_node"
+        if="$(arg use_usb_cam)" >
+  </node>
 
   <include file="$(find jsk_perception)/sample/include/play_rosbag_hand.xml"
            unless="$(arg use_usb_cam)" />
@@ -15,6 +21,9 @@
     <arg name="gui" value="$(arg gui)" />
     <arg name="gpu" value="$(arg gpu)" />
     <arg name="INPUT_IMAGE" value="$(arg INPUT_IMAGE)" />
+    <arg name="INPUT_DEPTH_IMAGE" value="$(arg INPUT_DEPTH_IMAGE)" />
+    <arg name="INPUT_CAMERA_INFO" value="$(arg INPUT_CAMERA_INFO)" />
+    <arg name="with_depth" value="$(arg with_depth)" />
   </include>
 
 </launch>

--- a/jsk_perception/sample/sample_hand_pose_estimation_3d.launch
+++ b/jsk_perception/sample/sample_hand_pose_estimation_3d.launch
@@ -2,27 +2,27 @@
 
   <arg name="gui" default="true" />
   <arg name="gpu" default="-1" />
-  <arg name="use_usb_cam" default="false" />
-  <arg name="with_depth" default="false"  />
-  <arg name="INPUT_IMAGE" default="/usb_cam/image_raw" if="$(arg use_usb_cam)" />
-  <arg name="INPUT_IMAGE" default="/kinect_head/rgb/image_rect_color" unless="$(arg use_usb_cam)" />
+  <arg name="with_depth" default="true" />
+  <arg name="INPUT_IMAGE" default="/kinect_head/rgb/image_rect_color" />
   <arg name="INPUT_DEPTH_IMAGE" default="/kinect_head/depth_registered/hw_registered/image_rect" />
   <arg name="INPUT_CAMERA_INFO" default="/kinect_head/rgb/camera_info" />
 
-  <node name="usb_cam" pkg="usb_cam" type="usb_cam_node"
-        if="$(arg use_usb_cam)" >
-  </node>
-
-  <include file="$(find jsk_perception)/sample/include/play_rosbag_hand.xml"
-           unless="$(arg use_usb_cam)" />
+  <include file="$(find jsk_perception)/sample/include/play_rosbag_hand.xml" />
 
   <include file="$(find jsk_perception)/launch/hand_pose_estimation_2d.launch">
-    <arg name="gui" value="$(arg gui)" />
+    <arg name="gui" value="false" />
     <arg name="gpu" value="$(arg gpu)" />
     <arg name="INPUT_IMAGE" value="$(arg INPUT_IMAGE)" />
     <arg name="INPUT_DEPTH_IMAGE" value="$(arg INPUT_DEPTH_IMAGE)" />
     <arg name="INPUT_CAMERA_INFO" value="$(arg INPUT_CAMERA_INFO)" />
     <arg name="with_depth" value="$(arg with_depth)" />
   </include>
+
+  <group if="$(arg gui)" >
+    <node name="rviz"
+          pkg="rviz" type="rviz"
+          args="-d $(find jsk_perception)/sample/config/hand_pose_estimation.rviz">
+    </node>
+  </group>
 
 </launch>

--- a/jsk_perception/scripts/install_sample_data.py
+++ b/jsk_perception/scripts/install_sample_data.py
@@ -112,9 +112,9 @@ def main():
 
     download_data(
         pkg_name=PKG,
-        path='sample/data/hand_pose_estimation_2d.bag',
-        url='https://drive.google.com/uc?id=1yJ2IYNmSO-0n0pE_Rs6FCgDQ8EKiCndr',
-        md5='362df96e8eaacaa82faa05ecebcd2166',
+        path='sample/data/2022-04-07-18-36-43_hand_pose_estimation_2d.bag',
+        url='https://drive.google.com/uc?id=1cyXdDPrdOiee9xOE8fW-3TWDCbCuwLBP',
+        md5='5ab7a29cba0f499b684e767458795be1',
         extract=False,
     )
 


### PR DESCRIPTION
Updated hand pose estimation to get hand pose in 3d．
Since the previous rosbag data doesn't include depth image, I replaced it with new one compatible．

`roslaunch jsk_perception sample_hand_pose_estimation_2d.launch GPU:=-1 with_depth:=true`

Cc: @iory 