### PR TITLE
[jsk_perception] Poke in dual_fisheye_to_panorama for DiagnosticNodelet

### DIFF
--- a/jsk_perception/src/dual_fisheye_to_panorama.cpp
+++ b/jsk_perception/src/dual_fisheye_to_panorama.cpp
@@ -128,6 +128,9 @@ namespace jsk_perception
                                                    pano).toImageMsg());
     msg_panorama_info_.header = image_msg->header;
     pub_panorama_info_.publish(msg_panorama_info_);
+
+    // Poke DiagnosticNodelet
+    vital_checker_->poke();
   }
 }
 


### PR DESCRIPTION
I add `vital_checker_->poke()` in dual_fisheye_to_panorama for DiagnosticNodelet.

Without this code, the following error is always outputted.
```
DualFisheyeToPanorama not running for 1.000000 sec
```

Thank you very much for your help @iory