### PR TITLE
fix doc build and typo in aws_auto_checkin_app doc

### DIFF
--- a/doc/jsk_perception/nodes/aws_auto_checkin_app.rst
+++ b/doc/jsk_perception/nodes/aws_auto_checkin_app.rst
@@ -1,5 +1,5 @@
-aws_auto_cehckin_app.py
-=========================
+aws_auto_checkin_app.py
+=======================
 
 What is this?
 -------------
@@ -21,12 +21,13 @@ Subscribing Topic
 * ``~face_roi`` (``opencv_apps/FaceArrayStamped``)
 
   Rectangles on the face of input image. Use ROI value.
-  ```
+
+.. code-block::
+
         msg.faces[].face.x      : X coordinates of the center of the face image in the ~image input
         msg.faces[].face.y      : Y coordinates of the center of the face image in the ~image input
         msg.faces[].face.width  : Width of the face image
         msg.faces[].face.height : Height of the face iamge
-  ```
 
 Publishing Topic
 ----------------
@@ -48,7 +49,9 @@ Parameters
   can find how to generate this file on
   https://aws.amazon.com/jp/builders-flash/202004/auto-checkin-app/.
   In addition to that, you need to add "UserName" and "UserPassword"
-  ```
+
+.. code-block:: json
+
   {
     "Region": "%%REGION%%",
     "ApiEndpoint" : "%%REST_API_ID%%.execute-api.%%REGION%%.amazonaws.com/prod/rekognize_face",
@@ -64,7 +67,6 @@ Parameters
     "UserName": "%%YOUR_USER_NAME%%",
     "UserPassword": "%%YOUR_PASSWORD%%"
   }
-  ```
 
 Sample
 ------

--- a/doc/jsk_perception/nodes/aws_auto_checkin_app.rst
+++ b/doc/jsk_perception/nodes/aws_auto_checkin_app.rst
@@ -77,9 +77,9 @@ Sample
 
 
 For JSK user, Download `env.json` file from
-[Gdrive](https://drive.google.com/file/d/1WUrRxPtT0ZuRx-IqjGwDBqeR5vZVTkB1/view?usp=sharing)
+`Gdrive <https://drive.google.com/file/d/1WUrRxPtT0ZuRx-IqjGwDBqeR5vZVTkB1/view?usp=sharing>`_
 and put this under `/tmp` directory to run sample code.
 
-To add new people to face database, add face image file to [Amazon
-S3](https://console.aws.amazon.com/s3),
+To add new people to face database, add face image file to
+`Amazon S3 <https://console.aws.amazon.com/s3>`_,
 `auto-check-in-gapp-register...` buckets

--- a/doc/jsk_perception/nodes/aws_detect_faces.rst
+++ b/doc/jsk_perception/nodes/aws_detect_faces.rst
@@ -114,5 +114,5 @@ Example
      use_window (default "true"): set false if you do not want to display window
 
 For JSK user, Download `aws.json` file from
-[Gdrive](https://drive.google.com/file/d/1g9DopJACY0rphGUiU9YGVMdzAPLRsuIk/view?usp=sharing)
+`Gdrive <https://drive.google.com/file/d/1g9DopJACY0rphGUiU9YGVMdzAPLRsuIk/view?usp=sharing>`_
 and put this under `/tmp` directory to run sample code.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,3 +5,4 @@ sphinx-markdown-tables==0.0.9
 sphinx_rtd_theme==0.4.3
 sphinx-autobuild==0.5.0
 livereload==2.4.0
+Jinja2==3.0.3


### PR DESCRIPTION
now `aws_auto_checkin_app` doc is messed up because of mixed syntax of md and rst.
I fixed the typo.
this PR also fix doc build.

current: https://jsk-docs.readthedocs.io/projects/jsk-recognition/en/latest/jsk_perception/nodes/aws_auto_checkin_app.html
this PR: https://knorth55-jsk-recognition.readthedocs.io/en/aws-auto-checkin-doc/jsk_perception/nodes/aws_auto_checkin_app.html
