### PR TITLE
[jsk_perception] Exclude depth z=0

### DIFF
--- a/jsk_perception/node_scripts/hand_pose_estimation_2d.py
+++ b/jsk_perception/node_scripts/hand_pose_estimation_2d.py
@@ -276,7 +276,7 @@ class HandPoseEstimation2D(ConnectionBasedTransport):
                     z = float(depth_img[int(v)][int(u)])
                 else:
                     continue
-                if np.isnan(z):
+                if np.isnan(z) or z <= 0:
                     continue
                 x = (u - camera_model.cx()) * z / camera_model.fx()
                 y = (v - camera_model.cy()) * z / camera_model.fy()

--- a/jsk_perception/node_scripts/people_pose_estimation_2d.py
+++ b/jsk_perception/node_scripts/people_pose_estimation_2d.py
@@ -304,7 +304,7 @@ class PeoplePoseEstimation2D(ConnectionBasedTransport):
                     z = float(depth_img[int(joint_pos['y'])][int(joint_pos['x'])])
                 else:
                     continue
-                if np.isnan(z):
+                if np.isnan(z) or z <= 0:
                     continue
                 x = (joint_pos['x'] - cx) * z / fx
                 y = (joint_pos['y'] - cy) * z / fy


### PR DESCRIPTION
When depth image contains 0 value, 0 is also assigned to x and y position. `np.isnan(z)` cannot deal with it.
I checked this with `/kinect_head/depth_registered/hw_registered/image_rect_raw`.

By visualizing HumanSkeletonArray, we can see this problem.