### PR TITLE
[jsk_perception] Use logdebug when height for label is not specified

### DIFF
--- a/jsk_perception/node_scripts/rect_array_in_panorama_to_bounding_box_array.py
+++ b/jsk_perception/node_scripts/rect_array_in_panorama_to_bounding_box_array.py
@@ -80,7 +80,14 @@ class RectArrayInPanoramaToBoundingBoxArray(object):
                 rospy.wait_for_message( '~input_rects', RectArray, 3)
                 break
             except (rospy.ROSException, rospy.ROSInterruptException) as e:
-                rospy.logwarn('subscribing topic seems not to be pulished. waiting... Error: {}'.format(e))
+                # For melodic or newer
+                # https://wiki.ros.org/rospy/Overview/Logging#Logging_Once
+                try:
+                    rospy.logwarn_throttle_identical(
+                        600, 'subscribing topic seems not to be pulished. waiting... Error: {}'.format(e))
+                # For kinetic or older (logwarn_throttle_identical is not defined)
+                except AttributeError:
+                    rospy.logwarn('subscribing topic seems not to be pulished. waiting... Error: {}'.format(e))
             rate.sleep()
 
         # Subscriber

--- a/jsk_perception/node_scripts/rect_array_in_panorama_to_bounding_box_array.py
+++ b/jsk_perception/node_scripts/rect_array_in_panorama_to_bounding_box_array.py
@@ -124,7 +124,14 @@ class RectArrayInPanoramaToBoundingBoxArray(object):
                         msg_rects.rects):
 
             if label_name not in self._dimensions_labels:
-                rospy.logdebug('height for label "{}" (id:{}) is not specified'.format(label_name,label_id))
+                # For melodic or newer
+                # https://wiki.ros.org/rospy/Overview/Logging#Logging_Periodically
+                try:
+                    rospy.logwarn_throttle_identical(
+                        600, 'height for label "{}" (id:{}) is not specified'.format(label_name,label_id))
+                # For kinetic or older (logwarn_throttle_identical is not defined)
+                except AttributeError:
+                    rospy.logwarn('height for label "{}" (id:{}) is not specified'.format(label_name,label_id))
                 continue
 
             (theta_a, phi_a) = transformPanoramaPoint(

--- a/jsk_perception/node_scripts/rect_array_in_panorama_to_bounding_box_array.py
+++ b/jsk_perception/node_scripts/rect_array_in_panorama_to_bounding_box_array.py
@@ -81,7 +81,7 @@ class RectArrayInPanoramaToBoundingBoxArray(object):
                 break
             except (rospy.ROSException, rospy.ROSInterruptException) as e:
                 # For melodic or newer
-                # https://wiki.ros.org/rospy/Overview/Logging#Logging_Once
+                # https://wiki.ros.org/rospy/Overview/Logging#Logging_Periodically
                 try:
                     rospy.logwarn_throttle_identical(
                         600, 'subscribing topic seems not to be pulished. waiting... Error: {}'.format(e))

--- a/jsk_perception/node_scripts/rect_array_in_panorama_to_bounding_box_array.py
+++ b/jsk_perception/node_scripts/rect_array_in_panorama_to_bounding_box_array.py
@@ -124,7 +124,7 @@ class RectArrayInPanoramaToBoundingBoxArray(object):
                         msg_rects.rects):
 
             if label_name not in self._dimensions_labels:
-                rospy.logwarn('height for label "{}" (id:{}) is not specified'.format(label_name,label_id))
+                rospy.logdebug('height for label "{}" (id:{}) is not specified'.format(label_name,label_id))
                 continue
 
             (theta_a, phi_a) = transformPanoramaPoint(


### PR DESCRIPTION
`rect_array_in_panorama_to_bounding_box_array.py` works fine even if label height is not specified.
However, even in that case, warning continue to be outputted to terminal.

Based on the issue https://github.com/jsk-ros-pkg/jsk_robot/issues/1518, I use `rospy.logdebug` when height for label is not specified.

PR for fetch branch
https://github.com/sktometometo/jsk_recognition/pull/7