### PR TITLE
[jsk_perception/virtual_camera_mono] Use DiagnosticNodelet to start subscribing topics when camera_info is subscribed

### DIFF
--- a/doc/jsk_perception/nodes/virtual_camera_mono.md
+++ b/doc/jsk_perception/nodes/virtual_camera_mono.md
@@ -1,4 +1,4 @@
-# virtual_camera_mono
+# VirtualCameraMono
 
 ![](images/virtual_camera_mono.png)
 

--- a/jsk_perception/CMakeLists.txt
+++ b/jsk_perception/CMakeLists.txt
@@ -305,6 +305,8 @@ if(robot_self_filter_FOUND)
   jsk_add_nodelet(src/robot_to_mask_image.cpp "jsk_perception/RobotToMaskImage" "robot_to_mask_image")
 endif()
 
+jsk_add_nodelet(src/virtual_camera_mono.cpp "jsk_perception/VirtualCameraMono" "virtual_camera_mono")
+
 # compiling jsk_perception library for nodelet
 if(TARGET JSK_NODELET_${PROJECT_NAME}_dual_fisheye_to_panorama)
   add_library(${PROJECT_NAME} SHARED ${jsk_perception_nodelet_sources}
@@ -345,7 +347,6 @@ target_link_libraries(oriented_gradient ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 jsk_add_node(src/camshiftdemo.cpp camshiftdemo)
 jsk_add_node(src/linemod.cpp linemod)
-jsk_add_node(src/virtual_camera_mono.cpp virtual_camera_mono)
 jsk_add_node(src/point_pose_extractor.cpp point_pose_extractor)
 jsk_add_node(src/white_balance_converter.cpp white_balance_converter)
 jsk_add_node(src/rectangle_detector.cpp rectangle_detector)

--- a/jsk_perception/include/jsk_perception/virtual_camera_mono.h
+++ b/jsk_perception/include/jsk_perception/virtual_camera_mono.h
@@ -2,8 +2,9 @@
 #define JSK_PERCEPTION_VIRTUAL_CAMERA_MONO_H_
 
 #include <jsk_topic_tools/diagnostic_nodelet.h>
-#include <dynamic_reconfigure/server.h>
 #include <jsk_perception/VirtualCameraMonoConfig.h>
+
+#include <dynamic_reconfigure/server.h>
 #include <image_transport/image_transport.h>
 #include <image_geometry/pinhole_camera_model.h>
 #include <tf/transform_listener.h>
@@ -23,7 +24,6 @@ namespace jsk_perception
   {
   public:
     typedef VirtualCameraMonoConfig Config;
-    typedef boost::shared_ptr<VirtualCameraMono> Ptr;
     VirtualCameraMono() : DiagnosticNodelet("VirtualCameraMono") {}
 
   protected:
@@ -50,7 +50,6 @@ namespace jsk_perception
     ros::Subscriber sub_trans_, sub_poly_;
     
     boost::shared_ptr<dynamic_reconfigure::Server<Config> > srv_;
-    boost::mutex mutex_;
     boost::shared_ptr<image_transport::ImageTransport> it_;
     tf::TransformListener tf_listener_;
     image_geometry::PinholeCameraModel cam_model_;
@@ -59,7 +58,6 @@ namespace jsk_perception
     tf::StampedTransform trans_; // transform to virtual camera
     geometry_msgs::PolygonStamped poly_; // target polygon to transform image
     int interpolation_method_;
-
     
   private:
     

--- a/jsk_perception/include/jsk_perception/virtual_camera_mono.h
+++ b/jsk_perception/include/jsk_perception/virtual_camera_mono.h
@@ -27,9 +27,7 @@ namespace jsk_perception
     VirtualCameraMono() : DiagnosticNodelet("VirtualCameraMono") {}
 
   protected:
-    ////////////////////////////////////////////////////////
-    // methods
-    ////////////////////////////////////////////////////////
+
     virtual void onInit();
     virtual void configCb (Config &config, uint32_t level);    
     virtual void subscribe();
@@ -42,9 +40,6 @@ namespace jsk_perception
 		      tf::StampedTransform& trans, geometry_msgs::PolygonStamped& poly,
                                                    image_geometry::PinholeCameraModel& cam_model_);
 
-    ////////////////////////////////////////////////////////
-    // parameters
-    ////////////////////////////////////////////////////////
     image_transport::CameraSubscriber sub_;
     image_transport::CameraPublisher pub_;
     ros::Subscriber sub_trans_, sub_poly_;

--- a/jsk_perception/include/jsk_perception/virtual_camera_mono.h
+++ b/jsk_perception/include/jsk_perception/virtual_camera_mono.h
@@ -1,0 +1,69 @@
+#ifndef JSK_PERCEPTION_VIRTUAL_CAMERA_MONO_H_
+#define JSK_PERCEPTION_VIRTUAL_CAMERA_MONO_H_
+
+#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <dynamic_reconfigure/server.h>
+#include <jsk_perception/VirtualCameraMonoConfig.h>
+#include <image_transport/image_transport.h>
+#include <image_geometry/pinhole_camera_model.h>
+#include <tf/transform_listener.h>
+#include <tf/transform_broadcaster.h>
+#include <boost/assign.hpp>
+#include <boost/thread.hpp>
+#include <geometry_msgs/PolygonStamped.h>
+#if ( CV_MAJOR_VERSION >= 4)
+#else
+#include <opencv/cv.hpp>
+#include <opencv/highgui.h>
+#endif
+
+namespace jsk_perception
+{
+  class VirtualCameraMono: public jsk_topic_tools::DiagnosticNodelet
+  {
+  public:
+    typedef VirtualCameraMonoConfig Config;
+    typedef boost::shared_ptr<VirtualCameraMono> Ptr;
+    VirtualCameraMono() : DiagnosticNodelet("VirtualCameraMono") {}
+
+  protected:
+    ////////////////////////////////////////////////////////
+    // methods
+    ////////////////////////////////////////////////////////
+    virtual void onInit();
+    virtual void configCb (Config &config, uint32_t level);    
+    virtual void subscribe();
+    virtual void unsubscribe();
+    virtual void imageCb (const sensor_msgs::ImageConstPtr& image_msg,
+                          const sensor_msgs::CameraInfoConstPtr& info_msg);
+    virtual void polyCb (const geometry_msgs::PolygonStampedConstPtr& poly);
+    virtual void transCb (const geometry_msgs::TransformStampedConstPtr& tf);
+    virtual bool TransformImage(cv::Mat src, cv::Mat dest,
+		      tf::StampedTransform& trans, geometry_msgs::PolygonStamped& poly,
+                                                   image_geometry::PinholeCameraModel& cam_model_);
+
+    ////////////////////////////////////////////////////////
+    // parameters
+    ////////////////////////////////////////////////////////
+    image_transport::CameraSubscriber sub_;
+    image_transport::CameraPublisher pub_;
+    ros::Subscriber sub_trans_, sub_poly_;
+    
+    boost::shared_ptr<dynamic_reconfigure::Server<Config> > srv_;
+    boost::mutex mutex_;
+    boost::shared_ptr<image_transport::ImageTransport> it_;
+    tf::TransformListener tf_listener_;
+    image_geometry::PinholeCameraModel cam_model_;
+    tf::TransformBroadcaster tf_broadcaster_;
+
+    tf::StampedTransform trans_; // transform to virtual camera
+    geometry_msgs::PolygonStamped poly_; // target polygon to transform image
+    int interpolation_method_;
+
+    
+  private:
+    
+  };
+}
+
+#endif

--- a/jsk_perception/plugins/nodelet/libjsk_perception.xml
+++ b/jsk_perception/plugins/nodelet/libjsk_perception.xml
@@ -286,4 +286,8 @@
          type="jsk_perception::DrawRects"
          base_class_type="nodelet::Nodelet">
   </class>
+  <class name="jsk_perception/VirtualCameraMono"
+         type="jsk_perception::VirtualCameraMono"
+         base_class_type="nodelet::Nodelet">
+  </class>
 </library>

--- a/jsk_perception/src/virtual_camera_mono.cpp
+++ b/jsk_perception/src/virtual_camera_mono.cpp
@@ -1,70 +1,35 @@
-#include <ros/ros.h>
-#include <dynamic_reconfigure/server.h>
 #include <jsk_topic_tools/log_utils.h>
 #include <jsk_topic_tools/rosparam_utils.h>
-#include <image_transport/image_transport.h>
-#include <image_geometry/pinhole_camera_model.h>
-#include <tf/transform_listener.h>
-#include <tf/transform_broadcaster.h>
 #include <cv_bridge/cv_bridge.h>
-#if ( CV_MAJOR_VERSION >= 4)
-#else
-#include <opencv/cv.hpp>
-#include <opencv/highgui.h>
-#endif
-
 #include <string>
 #include <vector>
-#include <boost/assign.hpp>
-#include <boost/thread.hpp>
-
 #include <geometry_msgs/Polygon.h>
-#include <geometry_msgs/PolygonStamped.h>
 
-#include <jsk_perception/VirtualCameraMonoConfig.h>
-
-
-class VirtualCameraMono
+#include "jsk_perception/virtual_camera_mono.h"
+namespace jsk_perception
 {
-  ros::NodeHandle nh_,private_nh_;
-  boost::shared_ptr<dynamic_reconfigure::Server<jsk_perception::VirtualCameraMonoConfig> > srv_;
-  image_transport::ImageTransport it_,it_priv_;
-  image_transport::CameraSubscriber sub_;
-  image_transport::CameraPublisher pub_;
-  int subscriber_count_;
-  tf::TransformListener tf_listener_;
-  image_geometry::PinholeCameraModel cam_model_;
-  tf::TransformBroadcaster tf_broadcaster_;
-  ros::Subscriber sub_trans_, sub_poly_;
-
-  tf::StampedTransform trans_; // transform to virtual camera
-  geometry_msgs::PolygonStamped poly_; // target polygon to transform image
-  int interpolation_method_;
-
-public:
-  VirtualCameraMono() : private_nh_("~"), it_(nh_), it_priv_(private_nh_), subscriber_count_(0)
+  void VirtualCameraMono::onInit()
   {
-    image_transport::SubscriberStatusCallback connect_cb = boost::bind(&VirtualCameraMono::connectCb, this, _1);
-    image_transport::SubscriberStatusCallback disconnect_cb = boost::bind(&VirtualCameraMono::disconnectCb, this, _1);
-    pub_ = it_priv_.advertiseCamera("image", 1, connect_cb, disconnect_cb);
+    DiagnosticNodelet::onInit();
+    pnh_->param("frame_id", trans_.frame_id_, std::string("/elevator_inside_panel"));
+    pnh_->param("child_frame_id", trans_.child_frame_id_, std::string("/virtual_camera_frame"));
+    ROS_INFO("VirutalCmaeraMono(%s) frame_id: %s, chid_frame_id: %s", ros::this_node::getName().c_str(), trans_.frame_id_.c_str(), trans_.child_frame_id_.c_str());
+
+    pub_ = advertiseCamera(*pnh_, "image", 1, false);
 
     dynamic_reconfigure::Server<jsk_perception::VirtualCameraMonoConfig>::CallbackType f =
       boost::bind(&VirtualCameraMono::configCb, this, _1, _2);
-    srv_ = boost::make_shared<dynamic_reconfigure::Server<jsk_perception::VirtualCameraMonoConfig> >(private_nh_);
+    srv_ = boost::make_shared<dynamic_reconfigure::Server<jsk_perception::VirtualCameraMonoConfig> >(*pnh_);
     srv_->setCallback(f);
 
-    private_nh_.param("frame_id", trans_.frame_id_, std::string("/elevator_inside_panel"));
-    private_nh_.param("child_frame_id", trans_.child_frame_id_, std::string("/virtual_camera_frame"));
-    ROS_INFO("VirutalCmaeraMono(%s) frame_id: %s, chid_frame_id: %s", ros::this_node::getName().c_str(), trans_.frame_id_.c_str(), trans_.child_frame_id_.c_str());
-
     std::vector<double> initial_pos, initial_rot;
-    if (jsk_topic_tools::readVectorParameter(private_nh_, "initial_pos", initial_pos)) {
+    if (jsk_topic_tools::readVectorParameter(*pnh_, "initial_pos", initial_pos)) {
       trans_.setOrigin(tf::Vector3(initial_pos[0], initial_pos[1], initial_pos[2]));
     }
     else {
       trans_.setOrigin(tf::Vector3(0.7, 0, 0));
     }
-    if (jsk_topic_tools::readVectorParameter(private_nh_, "initial_rot", initial_rot)) {
+    if (jsk_topic_tools::readVectorParameter(*pnh_, "initial_rot", initial_rot)) {
       trans_.setRotation(tf::Quaternion(initial_rot[0], initial_rot[1], initial_rot[2], initial_rot[3]));
     }
     else {
@@ -81,12 +46,13 @@ public:
     pt.x=0, pt.y=1, pt.z=-1; poly_.polygon.points.push_back(pt);
 
     // parameter subscriber
-    sub_trans_ = nh_.subscribe<geometry_msgs::TransformStamped>("view_point", 1, &VirtualCameraMono::transCb, this);
-    sub_poly_ = nh_.subscribe<geometry_msgs::PolygonStamped>("target_polygon", 1, &VirtualCameraMono::polyCb, this);
+    sub_trans_ = nh_->subscribe<geometry_msgs::TransformStamped>("view_point", 1, &VirtualCameraMono::transCb, this);
+    sub_poly_ = nh_->subscribe<geometry_msgs::PolygonStamped>("target_polygon", 1, &VirtualCameraMono::polyCb, this);
 
+    onInitPostProcess();
   }
 
-  void configCb(const jsk_perception::VirtualCameraMonoConfig &config, uint32_t level)
+  void VirtualCameraMono::configCb(Config &config, uint32_t level)
   {
     boost::mutex::scoped_lock(mutex_);
     switch (config.interpolation_method) {
@@ -111,39 +77,23 @@ public:
     }
   }
 
-  void connectCb(const image_transport::SingleSubscriberPublisher&)
-  {
-    if (subscriber_count_ == 0){
-      subscribe();
-    }
-    subscriber_count_++;
-    ROS_DEBUG("connected new node. current subscriber: %d", subscriber_count_);
-  }
-
-  void disconnectCb(const image_transport::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-    ROS_DEBUG("disconnected node. current subscriber: %d", subscriber_count_);
-  }
-
-  void subscribe()
+  void VirtualCameraMono::subscribe()
   {
     ROS_INFO("Subscribing to image topic");
-    sub_ = it_.subscribeCamera("image", 1, &VirtualCameraMono::imageCb, this);
+    it_.reset(new image_transport::ImageTransport(*pnh_));
+    sub_ = it_->subscribeCamera("image", 1, &VirtualCameraMono::imageCb, this);
     ros::V_string names = boost::assign::list_of("image");
     jsk_topic_tools::warnNoRemap(names);
   }
 
-  void unsubscribe()
+  void VirtualCameraMono::unsubscribe()
   {
     ROS_INFO("Unsubscibing from image topic");
+    // sub_.unsubscribe();
     sub_.shutdown();
   }
 
-  void imageCb(const sensor_msgs::ImageConstPtr& image_msg,
+  void VirtualCameraMono::imageCb(const sensor_msgs::ImageConstPtr& image_msg,
                const sensor_msgs::CameraInfoConstPtr& info_msg)
   {
     cv_bridge::CvImagePtr cv_ptr;
@@ -179,10 +129,10 @@ public:
   }
 
   // subscribe target polygon
-  void polyCb(const geometry_msgs::PolygonStampedConstPtr& poly) { poly_ = *poly; }
+  void VirtualCameraMono::polyCb(const geometry_msgs::PolygonStampedConstPtr& poly) { poly_ = *poly; }
 
   // subscribe virtual camera pose
-  void transCb(const geometry_msgs::TransformStampedConstPtr& tf)
+  void VirtualCameraMono::transCb(const geometry_msgs::TransformStampedConstPtr& tf)
   {
     trans_.frame_id_ = tf->header.frame_id;
     trans_.child_frame_id_ = tf->child_frame_id;
@@ -194,7 +144,7 @@ public:
   }
 
   // poly is plane only
-  bool TransformImage(cv::Mat src, cv::Mat dest,
+  bool VirtualCameraMono::TransformImage(cv::Mat src, cv::Mat dest,
 		      tf::StampedTransform& trans, geometry_msgs::PolygonStamped& poly,
 		      image_geometry::PinholeCameraModel& cam_model_)
   {
@@ -238,14 +188,7 @@ public:
     }
     return true;
   }
-};
-
-int main(int argc, char **argv)
-{
-  ros::init(argc, argv, "virtual_camera_mono");
-
-  VirtualCameraMono vcam;
-
-  ros::spin();
 }
 
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS (jsk_perception::VirtualCameraMono, nodelet::Nodelet);

--- a/jsk_perception/src/virtual_camera_mono.cpp
+++ b/jsk_perception/src/virtual_camera_mono.cpp
@@ -10,7 +10,7 @@ namespace jsk_perception
   void VirtualCameraMono::onInit()
   {
     DiagnosticNodelet::onInit();
-    pub_ = advertiseCamera(*pnh_, "image", 1, false);
+    pub_ = advertiseCamera(*pnh_, "image", 1);
 
     dynamic_reconfigure::Server<jsk_perception::VirtualCameraMonoConfig>::CallbackType f =
       boost::bind(&VirtualCameraMono::configCb, this, _1, _2);

--- a/jsk_perception/src/virtual_camera_mono.cpp
+++ b/jsk_perception/src/virtual_camera_mono.cpp
@@ -1,11 +1,9 @@
 #include "jsk_perception/virtual_camera_mono.h"
 
-#include <jsk_topic_tools/log_utils.h>
 #include <jsk_topic_tools/rosparam_utils.h>
 #include <cv_bridge/cv_bridge.h>
 #include <string>
 #include <vector>
-#include <geometry_msgs/Polygon.h>
 
 namespace jsk_perception
 {

--- a/jsk_perception/src/virtual_camera_mono.cpp
+++ b/jsk_perception/src/virtual_camera_mono.cpp
@@ -1,3 +1,5 @@
+#include "jsk_perception/virtual_camera_mono.h"
+
 #include <jsk_topic_tools/log_utils.h>
 #include <jsk_topic_tools/rosparam_utils.h>
 #include <cv_bridge/cv_bridge.h>
@@ -5,22 +7,21 @@
 #include <vector>
 #include <geometry_msgs/Polygon.h>
 
-#include "jsk_perception/virtual_camera_mono.h"
 namespace jsk_perception
 {
   void VirtualCameraMono::onInit()
   {
     DiagnosticNodelet::onInit();
-    pnh_->param("frame_id", trans_.frame_id_, std::string("/elevator_inside_panel"));
-    pnh_->param("child_frame_id", trans_.child_frame_id_, std::string("/virtual_camera_frame"));
-    ROS_INFO("VirutalCmaeraMono(%s) frame_id: %s, chid_frame_id: %s", ros::this_node::getName().c_str(), trans_.frame_id_.c_str(), trans_.child_frame_id_.c_str());
-
     pub_ = advertiseCamera(*pnh_, "image", 1, false);
 
     dynamic_reconfigure::Server<jsk_perception::VirtualCameraMonoConfig>::CallbackType f =
       boost::bind(&VirtualCameraMono::configCb, this, _1, _2);
     srv_ = boost::make_shared<dynamic_reconfigure::Server<jsk_perception::VirtualCameraMonoConfig> >(*pnh_);
     srv_->setCallback(f);
+
+    pnh_->param("frame_id", trans_.frame_id_, std::string("/elevator_inside_panel"));
+    pnh_->param("child_frame_id", trans_.child_frame_id_, std::string("/virtual_camera_frame"));
+    ROS_INFO("VirutalCmaeraMono(%s) frame_id: %s, chid_frame_id: %s", ros::this_node::getName().c_str(), trans_.frame_id_.c_str(), trans_.child_frame_id_.c_str());
 
     std::vector<double> initial_pos, initial_rot;
     if (jsk_topic_tools::readVectorParameter(*pnh_, "initial_pos", initial_pos)) {
@@ -80,7 +81,7 @@ namespace jsk_perception
   void VirtualCameraMono::subscribe()
   {
     ROS_INFO("Subscribing to image topic");
-    it_.reset(new image_transport::ImageTransport(*pnh_));
+    it_.reset(new image_transport::ImageTransport(*nh_));
     sub_ = it_->subscribeCamera("image", 1, &VirtualCameraMono::imageCb, this);
     ros::V_string names = boost::assign::list_of("image");
     jsk_topic_tools::warnNoRemap(names);
@@ -89,7 +90,6 @@ namespace jsk_perception
   void VirtualCameraMono::unsubscribe()
   {
     ROS_INFO("Unsubscibing from image topic");
-    // sub_.unsubscribe();
     sub_.shutdown();
   }
 

--- a/jsk_perception/src/virtual_camera_mono.cpp
+++ b/jsk_perception/src/virtual_camera_mono.cpp
@@ -94,6 +94,7 @@ namespace jsk_perception
   void VirtualCameraMono::imageCb(const sensor_msgs::ImageConstPtr& image_msg,
                const sensor_msgs::CameraInfoConstPtr& info_msg)
   {
+    vital_checker_->poke();
     cv_bridge::CvImagePtr cv_ptr;
     cv::Mat image;
     try {


### PR DESCRIPTION
Currently this node starts subscribing input topics if output image is subscribed.
~~I added `info_connect_cb` and `info_disconnect_cb` to set them to advertiseCamera defined in image_transport.~~ 

This node is useful to project robot model from overhead onto the ground. I only subscribe virtual_camera_info.
https://github.com/nakane11/teach_spot/blob/f7bdb84058f14dff8dbbe1799ff6e05dbb447b1c/launch/dynamic_footprint.launch#L11-L22

Please refer to https://github.com/jsk-ros-pkg/jsk_common/issues/1198
Another solution is to use [advertiseCamera](https://github.com/jsk-ros-pkg/jsk_common/blob/30cdff0624b253d58af2b00ccdf0277cf27d9ec1/jsk_topic_tools/include/jsk_topic_tools/connection_based_nodelet.h#L314-L341) in ConnectionBasedNodelet (DiagnosticNodelet inherits it), ~~but I don't think we should do that for backward compatibility.~~ 
Deprecated advertiseCamera passes `info_connect_cb` and `info_disconnect_cb` to original advertiseCamera of image_transport.
cc: @iory 