### PR TITLE
Use DiagnosticNodelet instead of ConnectionBasedNodelet.

### DIFF
--- a/imagesift/include/imagesift/imagesift.h
+++ b/imagesift/include/imagesift/imagesift.h
@@ -37,7 +37,18 @@
 #ifndef IMAGESIFT_SIFT_NODE_H_
 #define IMAGESIFT_SIFT_NODE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <ros/node_handle.h>
 #include <sensor_msgs/Image.h>
 #include <posedetection_msgs/ImageFeature0D.h>
@@ -57,14 +68,14 @@
 
 namespace imagesift
 {
-  class SiftNode: public jsk_topic_tools::DiagnosticNodelet
+  class SiftNode: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<
       sensor_msgs::Image,
       sensor_msgs::Image > SyncPolicy;
     ros::WallTime lasttime;
-    SiftNode(): DiagnosticNodelet("SiftNode") {}
+    SiftNode(){}
     virtual ~SiftNode();
   protected:
     bool _bInfoInitialized;

--- a/imagesift/src/imagesift.cpp
+++ b/imagesift/src/imagesift.cpp
@@ -52,7 +52,7 @@ namespace imagesift
 {
     void SiftNode::onInit()
     {
-        DiagnosticNodelet::onInit();
+        jsk_topic_tools::NODELET::onInit();
         // First positional argument is the transport type
         std::string transport;
         pnh_->param("image_transport", transport, std::string("raw"));
@@ -228,7 +228,9 @@ namespace imagesift
             return;
         }
         detect(_sift_msg.features,*msg_ptr, mask_ptr);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
         vital_checker_->poke();
+#endif
         _pubFeatures.publish(_sift_msg.features);
 
         if(!_bInfoInitialized) {

--- a/jsk_pcl_ros/include/jsk_pcl_ros/add_color_from_image.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/add_color_from_image.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_ADD_COLOR_FROM_IMAGE_H_
 #define JSK_PCL_ROS_ADD_COLOR_FROM_IMAGE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
@@ -50,7 +61,7 @@
 
 namespace jsk_pcl_ros
 {
-  class AddColorFromImage: public jsk_topic_tools::DiagnosticNodelet
+  class AddColorFromImage: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ApproximateTime<
@@ -58,7 +69,7 @@ namespace jsk_pcl_ros
     sensor_msgs::Image,
     sensor_msgs::CameraInfo
     > SyncPolicy;
-    AddColorFromImage(): DiagnosticNodelet("AddColorFromImage") { }
+    AddColorFromImage(){ }
     virtual ~AddColorFromImage();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/add_color_from_image_to_organized.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/add_color_from_image_to_organized.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_ADD_COLOR_FROM_IMAGE_TO_ORGANIZED_H_
 #define JSK_PCL_ROS_ADD_COLOR_FROM_IMAGE_TO_ORGANIZED_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
@@ -50,13 +61,13 @@
 
 namespace jsk_pcl_ros
 {
-  class AddColorFromImageToOrganized: public jsk_topic_tools::DiagnosticNodelet
+  class AddColorFromImageToOrganized: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ApproximateTime<
       sensor_msgs::PointCloud2,
       sensor_msgs::Image > SyncPolicy;
-    AddColorFromImageToOrganized(): DiagnosticNodelet("AddColorFromImageToOrganized") { }
+    AddColorFromImageToOrganized(){ }
     virtual ~AddColorFromImageToOrganized();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/attention_clipper.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/attention_clipper.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_ATTENTION_CLIPPER_H_
 #define JSK_PCL_ROS_ATTENTION_CLIPPER_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/CameraInfo.h>
 #include "jsk_recognition_utils/pcl_conversion_util.h"
 #include "jsk_recognition_utils/geo_util.h"
@@ -50,10 +61,10 @@
 
 namespace jsk_pcl_ros
 {
-  class AttentionClipper: public jsk_topic_tools::DiagnosticNodelet
+  class AttentionClipper: public jsk_topic_tools::NODELET
   {
   public:
-    AttentionClipper(): DiagnosticNodelet("AttentionClipper") { }
+    AttentionClipper(){ }
 
   protected:
     ////////////////////////////////////////////////////////

--- a/jsk_pcl_ros/include/jsk_pcl_ros/bilateral_filter.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/bilateral_filter.h
@@ -38,7 +38,18 @@
 #define JSK_PCL_ROS_BILATERAL_FILTER_H_
 
 #include <pcl_ros/publisher.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include "jsk_recognition_utils/pcl_conversion_util.h"
 #include <jsk_pcl_ros/BilateralFilterConfig.h>
 #include <dynamic_reconfigure/server.h>
@@ -74,13 +85,13 @@ namespace jsk_pcl_ros
   }
 
   
-  class BilateralFilter: public jsk_topic_tools::DiagnosticNodelet
+  class BilateralFilter: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<BilateralFilter> Ptr;
     typedef pcl::PointXYZRGB PointT;
     typedef BilateralFilterConfig Config;
-    BilateralFilter() : DiagnosticNodelet("BilateralFilter") {}
+    BilateralFilter(){}
   protected:
     ////////////////////////////////////////////////////////
     // methods

--- a/jsk_pcl_ros/include/jsk_pcl_ros/border_estimator.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/border_estimator.h
@@ -49,20 +49,31 @@
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/synchronizer.h>
 
-#include "jsk_topic_tools/diagnostic_nodelet.h"
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 #include <jsk_pcl_ros/BorderEstimatorConfig.h>
 #include <dynamic_reconfigure/server.h>
 
 namespace jsk_pcl_ros
 {
-  class BorderEstimator: public jsk_topic_tools::DiagnosticNodelet
+  class BorderEstimator: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ApproximateTime<
     sensor_msgs::PointCloud2, sensor_msgs::CameraInfo> SyncPolicy;
     typedef BorderEstimatorConfig Config;
-    BorderEstimator(): DiagnosticNodelet("BorderEstimator") {}
+    BorderEstimator(){}
     virtual ~BorderEstimator();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/bounding_box_filter.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/bounding_box_filter.h
@@ -48,11 +48,22 @@
 #include <jsk_recognition_msgs/ClusterPointIndices.h>
 #include <jsk_recognition_msgs/ModelCoefficientsArray.h>
 #include <jsk_pcl_ros/BoundingBoxFilterConfig.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros
 {
-  class BoundingBoxFilter: public jsk_topic_tools::DiagnosticNodelet
+  class BoundingBoxFilter: public jsk_topic_tools::NODELET
   {
   public:
     typedef jsk_pcl_ros::BoundingBoxFilterConfig Config;
@@ -62,7 +73,7 @@ namespace jsk_pcl_ros
       jsk_recognition_msgs::ClusterPointIndices
       > SyncPolicy;
 
-    BoundingBoxFilter() : DiagnosticNodelet("BoundingBoxFilter") {}
+    BoundingBoxFilter(){}
     virtual ~BoundingBoxFilter();
 
   protected:
@@ -76,8 +87,10 @@ namespace jsk_pcl_ros
       const jsk_recognition_msgs::BoundingBoxArray::ConstPtr& box_array_msg,
       const jsk_recognition_msgs::ClusterPointIndices::ConstPtr& indices_msg);
     virtual void configCallback(Config &config, uint32_t level);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     virtual void updateDiagnostic(
       diagnostic_updater::DiagnosticStatusWrapper &stat);
+#endif
     virtual void subscribe();
     virtual void unsubscribe();
     void filterBoundingBoxes(

--- a/jsk_pcl_ros/include/jsk_pcl_ros/boundingbox_occlusion_rejector.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/boundingbox_occlusion_rejector.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_BOUNDING_BOX_OCCLUSION_REJECTOR_H_
 #define JSK_PCL_ROS_BOUNDING_BOX_OCCLUSION_REJECTOR_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_recognition_msgs/BoundingBoxArray.h>
 #include <sensor_msgs/CameraInfo.h>
 
@@ -47,11 +58,11 @@
 
 namespace jsk_pcl_ros
 {
-  class BoundingBoxOcclusionRejector: public jsk_topic_tools::DiagnosticNodelet
+  class BoundingBoxOcclusionRejector: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<BoundingBoxOcclusionRejector> Ptr;
-    BoundingBoxOcclusionRejector(): DiagnosticNodelet("BoundingBoxOcclusionRejector"){}
+    BoundingBoxOcclusionRejector(){}
 
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/capture_stereo_synchronizer.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/capture_stereo_synchronizer.h
@@ -43,7 +43,18 @@
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/synchronizer.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/CameraInfo.h>
@@ -54,7 +65,7 @@
 
 namespace jsk_pcl_ros
 {
-  class CaptureStereoSynchronizer: public jsk_topic_tools::DiagnosticNodelet
+  class CaptureStereoSynchronizer: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<CaptureStereoSynchronizer> Ptr;
@@ -67,7 +78,7 @@ namespace jsk_pcl_ros
       sensor_msgs::CameraInfo,    // right camera info
       stereo_msgs::DisparityImage // stereo disparity
       > SyncPolicy;
-    CaptureStereoSynchronizer(): DiagnosticNodelet("CaptureStereoSynchronizer") { }
+    CaptureStereoSynchronizer(){ }
     virtual ~CaptureStereoSynchronizer();
   protected:
     ////////////////////////////////////////////////////////

--- a/jsk_pcl_ros/include/jsk_pcl_ros/cluster_point_indices_decomposer.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/cluster_point_indices_decomposer.h
@@ -60,15 +60,26 @@
 #include <diagnostic_updater/publisher.h>
 #include "jsk_recognition_utils/pcl_util.h"
 #include <jsk_topic_tools/vital_checker.h>
-#include "jsk_topic_tools/diagnostic_nodelet.h"
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include "jsk_pcl_ros/ClusterPointIndicesDecomposerConfig.h"
 
 namespace jsk_pcl_ros
 {
-  class ClusterPointIndicesDecomposer: public jsk_topic_tools::DiagnosticNodelet
+  class ClusterPointIndicesDecomposer: public jsk_topic_tools::NODELET
   {
   public:
-    ClusterPointIndicesDecomposer(): DiagnosticNodelet("ClusterPointIndicesDecomposer") { }
+    ClusterPointIndicesDecomposer(){ }
     virtual ~ClusterPointIndicesDecomposer();
     typedef jsk_pcl_ros::ClusterPointIndicesDecomposerConfig Config;
     typedef message_filters::sync_policies::ExactTime<
@@ -139,8 +150,10 @@ namespace jsk_pcl_ros
                                  const jsk_recognition_msgs::ModelCoefficientsArrayConstPtr& coefficients);
 
     virtual void configCallback (Config &config, uint32_t level);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     virtual void updateDiagnostic(
       diagnostic_updater::DiagnosticStatusWrapper &stat);
+#endif
     virtual void allocatePublishers(size_t num);
     virtual void publishNegativeIndices(
       const sensor_msgs::PointCloud2ConstPtr &input,

--- a/jsk_pcl_ros/include/jsk_pcl_ros/collision_detector.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/collision_detector.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_COLLISION_DETECTOR_H_
 #define JSK_PCL_ROS_COLLISION_DETECTOR_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/PointCloud2.h>
 #include <jsk_recognition_msgs/CheckCollision.h>
 
@@ -51,11 +62,11 @@
 
 namespace jsk_pcl_ros
 {
-  class CollisionDetector: public jsk_topic_tools::DiagnosticNodelet
+  class CollisionDetector: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<CollisionDetector> Ptr;
-    CollisionDetector(): DiagnosticNodelet("CollisionDetector") {}
+    CollisionDetector(){}
 
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/color_based_region_growing_segmentation.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/color_based_region_growing_segmentation.h
@@ -47,14 +47,25 @@
 
 #include <dynamic_reconfigure/server.h>
 #include "jsk_pcl_ros/ColorBasedRegionGrowingSegmentationConfig.h"
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 namespace jsk_pcl_ros
 {
   class ColorBasedRegionGrowingSegmentation:
-    public jsk_topic_tools::DiagnosticNodelet
+    public jsk_topic_tools::NODELET
   {
   public:
-    ColorBasedRegionGrowingSegmentation(): DiagnosticNodelet("ColorBasedRegionGrowingSegmentation") {}
+    ColorBasedRegionGrowingSegmentation(){}
   protected:
     ros::Publisher pub_;
     ros::Subscriber sub_;

--- a/jsk_pcl_ros/include/jsk_pcl_ros/color_filter.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/color_filter.h
@@ -47,7 +47,18 @@
 #include <dynamic_reconfigure/server.h>
 
 #include "jsk_recognition_utils/pcl_conversion_util.h"
-#include "jsk_topic_tools/diagnostic_nodelet.h"
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros
 {
@@ -55,7 +66,7 @@ namespace jsk_pcl_ros
   class HSIColorFilter;
 
   template <class PackedComparison, typename Config>
-  class ColorFilter: public jsk_topic_tools::DiagnosticNodelet
+  class ColorFilter: public jsk_topic_tools::NODELET
   {
     friend class RGBColorFilter;
     friend class HSIColorFilter;
@@ -65,7 +76,7 @@ namespace jsk_pcl_ros
     typedef typename pcl::ConditionBase<pcl::PointXYZRGB>::Ptr ConditionPtr;
     typedef typename pcl::ComparisonBase<pcl::PointXYZRGB>::Ptr ComparisonPtr;
     typedef PackedComparison Comparison;
-    ColorFilter(): DiagnosticNodelet("ColorFilter") {}
+    ColorFilter(){}
     ~ColorFilter() {
       // message_filters::Synchronizer needs to be called reset
       // before message_filters::Subscriber is freed.

--- a/jsk_pcl_ros/include/jsk_pcl_ros/color_histogram.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/color_histogram.h
@@ -41,7 +41,18 @@
 #define JSK_PCL_ROS_COLOR_HISTOGRAM_H__
 
 #include <dynamic_reconfigure/server.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_recognition_msgs/ColorHistogram.h>
 #include <jsk_recognition_msgs/ColorHistogramArray.h>
 #include <jsk_recognition_msgs/ClusterPointIndices.h>
@@ -57,14 +68,14 @@
 
 namespace jsk_pcl_ros
 {
-  class ColorHistogram : public jsk_topic_tools::DiagnosticNodelet
+  class ColorHistogram : public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<sensor_msgs::PointCloud2,
                                                       jsk_recognition_msgs::ClusterPointIndices> SyncPolicy;
     typedef ColorHistogramConfig Config;
 
-    ColorHistogram() : DiagnosticNodelet("ColorHistogram") {}
+    ColorHistogram(){}
     virtual ~ColorHistogram();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/color_histogram_classifier.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/color_histogram_classifier.h
@@ -41,7 +41,18 @@
 #define JSK_PCL_ROS_COLOR_HISTOGRAM_CLASSIFIER_H__
 
 #include <dynamic_reconfigure/server.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_recognition_msgs/ClusterPointIndices.h>
 #include <jsk_recognition_msgs/ColorHistogram.h>
 #include <jsk_recognition_msgs/ColorHistogramArray.h>
@@ -54,12 +65,12 @@
 
 namespace jsk_pcl_ros
 {
-  class ColorHistogramClassifier : public jsk_topic_tools::DiagnosticNodelet
+  class ColorHistogramClassifier : public jsk_topic_tools::NODELET
   {
   public:
     typedef ColorHistogramClassifierConfig Config;
 
-    ColorHistogramClassifier() : DiagnosticNodelet("ColorHistogramClassifier"){}
+    ColorHistogramClassifier(){}
   protected:
     virtual void onInit();
     virtual void configCallback(Config & config, uint32_t level);

--- a/jsk_pcl_ros/include/jsk_pcl_ros/color_histogram_filter.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/color_histogram_filter.h
@@ -41,7 +41,18 @@
 #define JSK_PCL_ROS_COLOR_HISTOGRAM_FILTER_H__
 
 #include <dynamic_reconfigure/server.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_recognition_msgs/ClusterPointIndices.h>
 #include <jsk_recognition_msgs/ColorHistogram.h>
 #include <jsk_recognition_msgs/ColorHistogramArray.h>
@@ -54,14 +65,14 @@
 
 namespace jsk_pcl_ros
 {
-  class ColorHistogramFilter : public jsk_topic_tools::DiagnosticNodelet
+  class ColorHistogramFilter : public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<jsk_recognition_msgs::ColorHistogramArray,
                                                       jsk_recognition_msgs::ClusterPointIndices> SyncPolicy;
     typedef ColorHistogramFilterConfig Config;
 
-    ColorHistogramFilter() : DiagnosticNodelet("ColorHistogramFilter"){}
+    ColorHistogramFilter(){}
     virtual ~ColorHistogramFilter();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/color_histogram_matcher.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/color_histogram_matcher.h
@@ -50,11 +50,22 @@
 #include <dynamic_reconfigure/server.h>
 #include <jsk_pcl_ros/ColorHistogramMatcherConfig.h>
 
-#include "jsk_topic_tools/diagnostic_nodelet.h"
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros
 {
-  class ColorHistogramMatcher : public jsk_topic_tools::DiagnosticNodelet
+  class ColorHistogramMatcher : public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime< sensor_msgs::PointCloud2,
@@ -66,7 +77,7 @@ namespace jsk_pcl_ros
       USE_VALUE,
       USE_HUE_AND_SATURATION
     };
-    ColorHistogramMatcher(): DiagnosticNodelet("ColorHistogramMatcher") {}
+    ColorHistogramMatcher(){}
     virtual ~ColorHistogramMatcher();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/colorize_random_points_RF.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/colorize_random_points_RF.h
@@ -54,13 +54,24 @@
 #include <ml_classifiers/ClassDataPoint.h>
 #include <math.h>
 #include <stdlib.h>
-#include "jsk_topic_tools/diagnostic_nodelet.h"
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 namespace jsk_pcl_ros
 {
-  class ColorizeMapRandomForest: public jsk_topic_tools::DiagnosticNodelet
+  class ColorizeMapRandomForest: public jsk_topic_tools::NODELET
   {
   public:
-    ColorizeMapRandomForest() : DiagnosticNodelet("ColorizeMapRandomForest") {}
+    ColorizeMapRandomForest(){}
   protected:
     ros::Subscriber sub_input_;
     ros::Publisher pub_;

--- a/jsk_pcl_ros/include/jsk_pcl_ros/container_occupancy_detector.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/container_occupancy_detector.h
@@ -54,14 +54,25 @@
 #include "jsk_recognition_utils/geo_util.h"
 #include <jsk_recognition_msgs/BoundingBoxArray.h>
 #include <jsk_recognition_msgs/ClusterPointIndices.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/PointCloud2.h>
 
 #include <pcl/filters/crop_box.h>
 
 namespace jsk_pcl_ros{
 
-      class ContainerOccupancyDetector: public jsk_topic_tools::DiagnosticNodelet{
+      class ContainerOccupancyDetector: public jsk_topic_tools::NODELET{
             public:
                   typedef message_filters::sync_policies::ExactTime<
                   jsk_recognition_msgs::BoundingBoxArray,
@@ -73,7 +84,7 @@ namespace jsk_pcl_ros{
                   sensor_msgs::PointCloud2,
                   jsk_recognition_msgs::ClusterPointIndices
                   > ApproximateSyncPolicy;
-                  ContainerOccupancyDetector() : DiagnosticNodelet("ContainerOccupancyDetector") {}
+                  ContainerOccupancyDetector(){}
                   virtual ~ContainerOccupancyDetector();
 
             protected:
@@ -85,8 +96,10 @@ namespace jsk_pcl_ros{
                         const jsk_recognition_msgs::BoundingBoxArray::ConstPtr& boxes_msg,
                         const sensor_msgs::PointCloud2::ConstPtr& points_msg,
                         const jsk_recognition_msgs::ClusterPointIndices::ConstPtr& point_indices_msg);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
                   virtual void updateDiagnostic(
                         diagnostic_updater::DiagnosticStatusWrapper &stat);
+#endif
                   virtual void subscribe();
                   virtual void unsubscribe();
                   virtual bool pointsTransform(

--- a/jsk_pcl_ros/include/jsk_pcl_ros/convex_connected_voxels.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/convex_connected_voxels.h
@@ -40,7 +40,18 @@
 #include <jsk_pcl_ros/region_adjacency_graph.h>
 #include <jsk_recognition_msgs/ClusterPointIndices.h>
 #include <jsk_recognition_utils/pcl_conversion_util.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 // ROS header directives
 #include <ros/ros.h>
@@ -79,10 +90,10 @@
 
 namespace jsk_pcl_ros
 {
-   class ConvexConnectedVoxels: public jsk_topic_tools::DiagnosticNodelet
+   class ConvexConnectedVoxels: public jsk_topic_tools::NODELET
    {
     public:
-      ConvexConnectedVoxels() : DiagnosticNodelet("ConvexConnectedVoxels") {}
+      ConvexConnectedVoxels(){}
       typedef pcl::PointXYZRGB PointT;
 
     protected:

--- a/jsk_pcl_ros/include/jsk_pcl_ros/depth_calibration.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/depth_calibration.h
@@ -37,7 +37,18 @@
 #define JSK_PCL_ROS_DEPTH_CALIBRATION_H_
 
 #include "pcl_ros/pcl_nodelet.h"
-#include "jsk_topic_tools/diagnostic_nodelet.h"
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include "jsk_recognition_msgs/SetDepthCalibrationParameter.h"
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
@@ -51,7 +62,7 @@ namespace jsk_pcl_ros
   // calibration:
   // z' = C_2(u, v) z^2 + C_1(u, v) z + C_0(u, v)
   // C_i(u, v) = au + bv + c
-  class DepthCalibration: public jsk_topic_tools::DiagnosticNodelet
+  class DepthCalibration: public jsk_topic_tools::NODELET
   {
   public:
     typedef pcl::PointXYZRGB PointT;
@@ -59,7 +70,7 @@ namespace jsk_pcl_ros
         sensor_msgs::Image,
         sensor_msgs::CameraInfo> SyncPolicy;
 
-    DepthCalibration(): DiagnosticNodelet("DepthCalibration") { }
+    DepthCalibration(){ }
     virtual ~DepthCalibration();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/depth_image_creator.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/depth_image_creator.h
@@ -60,12 +60,23 @@
 #include <std_srvs/Empty.h>
 #include <boost/thread/mutex.hpp>
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include "jsk_pcl_ros/tf_listener_singleton.h"
 
 namespace jsk_pcl_ros
 {
-  class DepthImageCreator : public jsk_topic_tools::DiagnosticNodelet
+  class DepthImageCreator : public jsk_topic_tools::NODELET
   {
   protected:
     message_filters::Subscriber<sensor_msgs::CameraInfo> sub_info_;
@@ -119,7 +130,7 @@ namespace jsk_pcl_ros
     void subscribe();
     void unsubscribe();
   public:
-    DepthImageCreator(): DiagnosticNodelet("DepthImageCreator") {}
+    DepthImageCreator(){}
     virtual ~DepthImageCreator();
   };
 }

--- a/jsk_pcl_ros/include/jsk_pcl_ros/edge_depth_refinement.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/edge_depth_refinement.h
@@ -53,11 +53,22 @@
 #include <dynamic_reconfigure/server.h>
 #include <boost/tuple/tuple.hpp>
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros
 {
-  class EdgeDepthRefinement: public jsk_topic_tools::DiagnosticNodelet
+  class EdgeDepthRefinement: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<
@@ -65,7 +76,7 @@ namespace jsk_pcl_ros
     jsk_recognition_msgs::ClusterPointIndices > SyncPolicy;
     typedef pcl::PointXYZRGB PointT;
     typedef jsk_pcl_ros::EdgeDepthRefinementConfig Config;
-    EdgeDepthRefinement(): DiagnosticNodelet("EdgeDepthRefinement") {}
+    EdgeDepthRefinement(){}
     virtual ~EdgeDepthRefinement();
   protected:
     ////////////////////////////////////////////////////////

--- a/jsk_pcl_ros/include/jsk_pcl_ros/edgebased_cube_finder.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/edgebased_cube_finder.h
@@ -60,7 +60,18 @@
 #include <jsk_pcl_ros/EdgebasedCubeFinderConfig.h>
 #include <dynamic_reconfigure/server.h>
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros
 {
@@ -154,10 +165,10 @@ namespace jsk_pcl_ros
   private:
   };
   
-  class EdgebasedCubeFinder: public jsk_topic_tools::DiagnosticNodelet
+  class EdgebasedCubeFinder: public jsk_topic_tools::NODELET
   {
   public:
-    EdgebasedCubeFinder(): DiagnosticNodelet("EdgebasedCubeFinder") {}
+    EdgebasedCubeFinder(){}
     typedef message_filters::sync_policies::ExactTime<
     sensor_msgs::PointCloud2,
     jsk_recognition_msgs::ParallelEdgeArray > SyncPolicy;

--- a/jsk_pcl_ros/include/jsk_pcl_ros/environment_plane_modeling.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/environment_plane_modeling.h
@@ -64,7 +64,18 @@
 #include "jsk_recognition_utils/pcl_util.h"
 #include <jsk_recognition_msgs/SimpleOccupancyGridArray.h>
 #include <jsk_recognition_msgs/BoundingBoxArray.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include "jsk_recognition_utils/geo_util.h"
 #include "jsk_pcl_ros/tf_listener_singleton.h"
 
@@ -77,7 +88,7 @@ namespace jsk_pcl_ros
    * @brief
    * Nodelet implementation of jsk_pcl/EnvironmentPlaneModeling
    */
-  class EnvironmentPlaneModeling: public jsk_topic_tools::DiagnosticNodelet
+  class EnvironmentPlaneModeling: public jsk_topic_tools::NODELET
   {
   public:
     typedef EnvironmentPlaneModelingConfig Config;
@@ -88,7 +99,7 @@ namespace jsk_pcl_ros
       jsk_recognition_msgs::PolygonArray,
       jsk_recognition_msgs::ModelCoefficientsArray,
       jsk_recognition_msgs::ClusterPointIndices > SyncPolicy;
-    EnvironmentPlaneModeling(): DiagnosticNodelet("EnvironmentPlaneModeling") {}
+    EnvironmentPlaneModeling(){}
     virtual ~EnvironmentPlaneModeling();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/euclidean_cluster_extraction_nodelet.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/euclidean_cluster_extraction_nodelet.h
@@ -64,11 +64,22 @@
 #include "jsk_recognition_utils/pcl_conversion_util.h"
 #include <jsk_topic_tools/time_accumulator.h>
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros
 {
-  class EuclideanClustering : public jsk_topic_tools::DiagnosticNodelet
+  class EuclideanClustering : public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<
@@ -83,7 +94,7 @@ namespace jsk_pcl_ros
     typedef std::vector<Eigen::Vector4f,
                         Eigen::aligned_allocator<Eigen::Vector4f> >
     Vector4fVector;
-    EuclideanClustering() : DiagnosticNodelet("EuclideanClustering") {}
+    EuclideanClustering(){}
     virtual ~EuclideanClustering();
   protected:
     boost::shared_ptr <dynamic_reconfigure::Server<Config> > srv_;
@@ -132,7 +143,9 @@ namespace jsk_pcl_ros
                                           std::vector<pcl::PointIndices> &clustered_indices);
     bool serviceCallback(jsk_recognition_msgs::EuclideanSegment::Request &req,
                          jsk_recognition_msgs::EuclideanSegment::Response &res);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     virtual void updateDiagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat);
+#endif
     virtual std::vector<pcl::PointIndices> pivotClusterIndices(
       std::vector<int>& pivot_table,
       std::vector<pcl::PointIndices>& cluster_indices);

--- a/jsk_pcl_ros/include/jsk_pcl_ros/extract_cuboid_particles_top_n.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/extract_cuboid_particles_top_n.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_EXTRACT_CUBOID_PARTICLES_TOP_N_BASE_H_
 #define JSK_PCL_ROS_EXTRACT_CUBOID_PARTICLES_TOP_N_BASE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include "jsk_pcl_ros/plane_supported_cuboid_estimator.h"
 #include <dynamic_reconfigure/server.h>
 #include <jsk_pcl_ros/ExtractParticlesTopNBaseConfig.h>
@@ -57,12 +68,12 @@ namespace jsk_pcl_ros
   }
 
   
-  class ExtractCuboidParticlesTopN: public jsk_topic_tools::DiagnosticNodelet
+  class ExtractCuboidParticlesTopN: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<ExtractCuboidParticlesTopN> Ptr;
     typedef ExtractParticlesTopNBaseConfig Config;
-    ExtractCuboidParticlesTopN(): DiagnosticNodelet("ExtractCuboidParticlesTopN") {}
+    ExtractCuboidParticlesTopN(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/extract_indices.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/extract_indices.h
@@ -36,7 +36,18 @@
 #ifndef JSK_PCL_ROS_EXTRACT_INDICES_H_
 #define JSK_PCL_ROS_EXTRACT_INDICES_H_
 
-#include "jsk_topic_tools/diagnostic_nodelet.h"
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include "jsk_recognition_utils/pcl_conversion_util.h"
 
 #include <sensor_msgs/PointCloud2.h>
@@ -47,7 +58,7 @@
 
 namespace jsk_pcl_ros
 {
-  class ExtractIndices: public jsk_topic_tools::DiagnosticNodelet
+  class ExtractIndices: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<
@@ -57,7 +68,7 @@ namespace jsk_pcl_ros
       PCLIndicesMsg,
       sensor_msgs::PointCloud2 > ApproximateSyncPolicy;
 
-    ExtractIndices(): DiagnosticNodelet("ExtractIndices") {}
+    ExtractIndices(){}
     virtual ~ExtractIndices();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/feature_registration.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/feature_registration.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_FEATURE_REGISTRATION_H_
 #define JSK_PCL_ROS_FEATURE_REGISTRATION_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
@@ -58,14 +69,14 @@ namespace jsk_pcl_ros
    * @brief
    * Nodelet implementation of jsk_pcl/FeatureRegistration
    */
-  class FeatureRegistration: public jsk_topic_tools::DiagnosticNodelet
+  class FeatureRegistration: public jsk_topic_tools::NODELET
   {
   public:
     typedef FeatureRegistrationConfig Config;
     typedef message_filters::sync_policies::ApproximateTime<
     sensor_msgs::PointCloud2,
     sensor_msgs::PointCloud2> SyncPolicy;
-    FeatureRegistration(): DiagnosticNodelet("FeatureRegistration") {};
+    FeatureRegistration(){};
     virtual ~FeatureRegistration();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/find_object_on_plane.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/find_object_on_plane.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_FIND_OBJECT_ON_PLANE_H_
 #define JSK_PCL_ROS_FIND_OBJECT_ON_PLANE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <message_filters/subscriber.h>
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/exact_time.h>
@@ -51,7 +62,7 @@
 
 namespace jsk_pcl_ros
 {
-  class FindObjectOnPlane: public jsk_topic_tools::DiagnosticNodelet
+  class FindObjectOnPlane: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ApproximateTime<
@@ -59,7 +70,7 @@ namespace jsk_pcl_ros
     sensor_msgs::CameraInfo,
     pcl_msgs::ModelCoefficients > SyncPolicy;
 
-    FindObjectOnPlane(): DiagnosticNodelet("FindObjectOnPlane") {}
+    FindObjectOnPlane(){}
     virtual ~FindObjectOnPlane();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/fisheye_sphere_publisher.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/fisheye_sphere_publisher.h
@@ -50,16 +50,27 @@
 #include <pcl/filters/extract_indices.h>
 
 #include <jsk_pcl_ros/FisheyeSphereConfig.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <dynamic_reconfigure/server.h>
 
 namespace jsk_pcl_ros
 {
-  class FisheyeSpherePublisher: public jsk_topic_tools::DiagnosticNodelet
+  class FisheyeSpherePublisher: public jsk_topic_tools::NODELET
   {
   public:
     typedef FisheyeSphereConfig Config;
-    FisheyeSpherePublisher(): DiagnosticNodelet("FisheyeSpherePublisher") {}
+    FisheyeSpherePublisher(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/fuse_images.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/fuse_images.h
@@ -37,7 +37,18 @@
 
 #include <vector>
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <message_filters/pass_through.h>
 #include <message_filters/subscriber.h>
 #include <message_filters/synchronizer.h>
@@ -48,11 +59,11 @@
 
 namespace jsk_pcl_ros
 {
-  class FuseImages: public jsk_topic_tools::DiagnosticNodelet
+  class FuseImages: public jsk_topic_tools::NODELET
   {
   public:
     FuseImages(const std::string& name, const std::string& encoding):
-      DiagnosticNodelet(name), encoding_(encoding) {}
+      encoding_(encoding) {}
     virtual ~FuseImages();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/geometric_consistency_grouping.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/geometric_consistency_grouping.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_GEOMETRIC_CONSISTENCY_GROUPING_H_
 #define JSK_PCL_ROS_GEOMETRIC_CONSISTENCY_GROUPING_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
@@ -58,15 +69,14 @@ namespace jsk_pcl_ros
    * @brief
    * Nodelet implementation of jsk_pcl/GeometricConsistencyGrouping 
    */
-  class GeometricConsistencyGrouping: public jsk_topic_tools::DiagnosticNodelet
+  class GeometricConsistencyGrouping: public jsk_topic_tools::NODELET
   {
   public:
     typedef GeometricConsistencyGroupingConfig Config;
     typedef message_filters::sync_policies::ExactTime<
       sensor_msgs::PointCloud2,
       sensor_msgs::PointCloud2> SyncPolicy;
-    GeometricConsistencyGrouping():
-      DiagnosticNodelet("GeometricConsistencyGrouping") {}
+    GeometricConsistencyGrouping(){}
     virtual ~GeometricConsistencyGrouping();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/grid_sampler.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/grid_sampler.h
@@ -42,15 +42,26 @@
 #include <sensor_msgs/PointCloud2.h>
 
 #include <jsk_pcl_ros/GridSamplerConfig.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros
 {
-  class GridSampler: public jsk_topic_tools::DiagnosticNodelet
+  class GridSampler: public jsk_topic_tools::NODELET
   {
   public:
     typedef jsk_pcl_ros::GridSamplerConfig Config;
-    GridSampler(): DiagnosticNodelet("GridSampler") {}
+    GridSampler(){}
   protected:
     virtual void onInit();
     virtual void sample(const sensor_msgs::PointCloud2::ConstPtr& msg);

--- a/jsk_pcl_ros/include/jsk_pcl_ros/handle_estimator.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/handle_estimator.h
@@ -51,11 +51,22 @@
 #include <boost/circular_buffer.hpp>
 #include <boost/tuple/tuple.hpp>
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros
 {
-  class HandleEstimator: public jsk_topic_tools::DiagnosticNodelet
+  class HandleEstimator: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime< sensor_msgs::PointCloud2,
@@ -67,7 +78,7 @@ namespace jsk_pcl_ros
       HANDLE_SMALL_ENOUGH_LIE_ON_PLANE_Y_LONGEST,
       HANDLE_SMALL_ENOUGH_LIE_ON_PLANE_X_LONGEST
     };
-    HandleEstimator(): DiagnosticNodelet("HandleEstimator") {}
+    HandleEstimator(){}
     virtual ~HandleEstimator();
 
   protected:

--- a/jsk_pcl_ros/include/jsk_pcl_ros/heightmap_converter.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/heightmap_converter.h
@@ -36,7 +36,18 @@
 #ifndef JSK_PCL_ROS_HEIGHTMAP_CONVERTER_H_
 #define JSK_PCL_ROS_HEIGHTMAP_CONVERTER_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 #include <sensor_msgs/PointCloud2.h>
 #include <jsk_pcl_ros/HeightmapConverterConfig.h>
@@ -51,12 +62,12 @@
 namespace jsk_pcl_ros
 {
 
-  class HeightmapConverter: public jsk_topic_tools::DiagnosticNodelet
+  class HeightmapConverter: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<HeightmapConverter> Ptr;
     typedef HeightmapConverterConfig Config;
-    HeightmapConverter(): DiagnosticNodelet("HeightmapConverter") {}
+    HeightmapConverter(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/heightmap_morphological_filtering.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/heightmap_morphological_filtering.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_HEIGHTMAP_MORPHOLOGICAL_FILTERLING_H_
 #define JSK_PCL_ROS_HEIGHTMAP_MORPHOLOGICAL_FILTERLING_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <cv_bridge/cv_bridge.h>
 #include <opencv2/opencv.hpp>
 #include <jsk_pcl_ros/HeightmapMorphologicalFilteringConfig.h>
@@ -51,7 +62,7 @@
 
 namespace jsk_pcl_ros
 {
-  class HeightmapMorphologicalFiltering: public jsk_topic_tools::DiagnosticNodelet
+  class HeightmapMorphologicalFiltering: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<HeightmapMorphologicalFiltering> Ptr;
@@ -62,7 +73,7 @@ namespace jsk_pcl_ros
         boost::accumulators::tag::variance,
         boost::accumulators::tag::count,
         boost::accumulators::tag::mean> >  Accumulator;
-    HeightmapMorphologicalFiltering(): DiagnosticNodelet("HeightmapMorphologicalFiltering") {}
+    HeightmapMorphologicalFiltering(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/heightmap_time_accumulation.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/heightmap_time_accumulation.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_HEIGHTMAP_TIME_ACCUMULATION_H_
 #define JSK_PCL_ROS_HEIGHTMAP_TIME_ACCUMULATION_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_recognition_msgs/HeightmapConfig.h>
 #include <jsk_pcl_ros/HeightmapTimeAccumulationConfig.h>
 #include <dynamic_reconfigure/server.h>
@@ -63,7 +74,7 @@ namespace jsk_pcl_ros
   typedef pcl::PointXYZI PointType;
 
   class HeightmapTimeAccumulation:
-    public jsk_topic_tools::DiagnosticNodelet
+    public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<HeightmapTimeAccumulation> Ptr;
@@ -74,7 +85,7 @@ namespace jsk_pcl_ros
         boost::accumulators::tag::variance,
         boost::accumulators::tag::count,
         boost::accumulators::tag::mean> >  Accumulator;
-    HeightmapTimeAccumulation(): DiagnosticNodelet("HeightmapTimeAccumulation") {}
+    HeightmapTimeAccumulation(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/heightmap_to_pointcloud.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/heightmap_to_pointcloud.h
@@ -38,7 +38,18 @@
 #define JSK_PCL_ROS_HEIGHTMAP_TO_POINTCLOUD_H_
 
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <dynamic_reconfigure/server.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <sensor_msgs/Image.h>
@@ -46,11 +57,11 @@
 
 namespace jsk_pcl_ros
 {
-  class HeightmapToPointCloud: public jsk_topic_tools::DiagnosticNodelet
+  class HeightmapToPointCloud: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<HeightmapToPointCloud> Ptr;
-    HeightmapToPointCloud(): DiagnosticNodelet("HeightmapToPointCloud") {}
+    HeightmapToPointCloud(){}
     
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/hinted_handle_estimator.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/hinted_handle_estimator.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_HINTED_HANDLE_ESTIMATOR_H_
 #define JSK_PCL_ROS_HINTED_HANDLE_ESTIMATOR_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_recognition_msgs/ClusterPointIndices.h>
 #include <jsk_recognition_msgs/SimpleHandle.h>
 #include <geometry_msgs/PointStamped.h>
@@ -127,10 +138,10 @@ visualization_msgs::MarkerArray make_handle_array(geometry_msgs::PoseStamped pos
 
 namespace jsk_pcl_ros
 {
-  class HintedHandleEstimator: public jsk_topic_tools::DiagnosticNodelet
+  class HintedHandleEstimator: public jsk_topic_tools::NODELET
   {
   public:
-    HintedHandleEstimator(): DiagnosticNodelet("HintedHandleEstimator") {}
+    HintedHandleEstimator(){}
     virtual ~HintedHandleEstimator();
     typedef message_filters::sync_policies::ApproximateTime<
       sensor_msgs::PointCloud2,

--- a/jsk_pcl_ros/include/jsk_pcl_ros/hinted_plane_detector.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/hinted_plane_detector.h
@@ -40,7 +40,18 @@
 #include <pcl/point_types.h>
 #include <pcl_ros/pcl_nodelet.h>
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/synchronizer.h>
@@ -53,14 +64,14 @@
 
 namespace jsk_pcl_ros {
   
-  class HintedPlaneDetector: public jsk_topic_tools::DiagnosticNodelet
+  class HintedPlaneDetector: public jsk_topic_tools::NODELET
   {
   public:
     typedef HintedPlaneDetectorConfig Config;
     typedef message_filters::sync_policies::ExactTime<
     sensor_msgs::PointCloud2,
     sensor_msgs::PointCloud2> SyncPolicy;
-    HintedPlaneDetector(): DiagnosticNodelet("HintedPlaneDetector") {}
+    HintedPlaneDetector(){}
     virtual ~HintedPlaneDetector();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/hinted_stick_finder.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/hinted_stick_finder.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_HINTED_STICK_FINDER_H_
 #define JSK_PCL_ROS_HINTED_STICK_FINDER_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/synchronizer.h>
@@ -56,7 +67,7 @@
 
 namespace jsk_pcl_ros
 {
-  class HintedStickFinder: public jsk_topic_tools::DiagnosticNodelet
+  class HintedStickFinder: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ApproximateTime<
@@ -64,7 +75,7 @@ namespace jsk_pcl_ros
     sensor_msgs::CameraInfo,       // camera info
     sensor_msgs::PointCloud2> ASyncPolicy;
     typedef HintedStickFinderConfig Config;
-    HintedStickFinder(): DiagnosticNodelet("HintedStickFinder") {}
+    HintedStickFinder(){}
     virtual ~HintedStickFinder();
   protected:
 

--- a/jsk_pcl_ros/include/jsk_pcl_ros/icp_registration.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/icp_registration.h
@@ -48,7 +48,18 @@
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/synchronizer.h>
 #include "jsk_pcl_ros/tf_listener_singleton.h"
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_recognition_msgs/PointsArray.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <jsk_recognition_utils/time_util.h>
@@ -56,7 +67,7 @@
 
 namespace jsk_pcl_ros
 {
-  class ICPRegistration: public jsk_topic_tools::DiagnosticNodelet
+  class ICPRegistration: public jsk_topic_tools::NODELET
   {
   public:
     typedef pcl::PointXYZRGBNormal PointT;
@@ -71,7 +82,7 @@ namespace jsk_pcl_ros
       sensor_msgs::PointCloud2,
       sensor_msgs::PointCloud2
       > ReferenceSyncPolicy;
-    ICPRegistration(): DiagnosticNodelet("ICPRegistration"), timer_(10), done_init_(false) { }
+    ICPRegistration(): timer_(10), done_init_(false) { }
     virtual ~ICPRegistration();
   protected:
     ////////////////////////////////////////////////////////

--- a/jsk_pcl_ros/include/jsk_pcl_ros/incremental_model_registration.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/incremental_model_registration.h
@@ -40,7 +40,18 @@
 #include <geometry_msgs/PoseStamped.h>
 #include <sensor_msgs/PointCloud.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/synchronizer.h>
@@ -73,10 +84,10 @@ namespace jsk_pcl_ros
     
   };
   
-  class IncrementalModelRegistration: public jsk_topic_tools::DiagnosticNodelet
+  class IncrementalModelRegistration: public jsk_topic_tools::NODELET
   {
   public:
-    IncrementalModelRegistration(): DiagnosticNodelet("IncrementalModelRegistration") {}
+    IncrementalModelRegistration(){}
     virtual ~IncrementalModelRegistration();
     typedef message_filters::sync_policies::ExactTime<
       sensor_msgs::PointCloud2,
@@ -89,8 +100,10 @@ namespace jsk_pcl_ros
     virtual void onInit();
     virtual void subscribe() {}
     virtual void unsubscribe() {}
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     virtual void updateDiagnostic(
       diagnostic_updater::DiagnosticStatusWrapper &stat) {}
+#endif
     virtual void newsampleCallback(
       const sensor_msgs::PointCloud2::ConstPtr& cloud_msg,
       const pcl_msgs::PointIndices::ConstPtr& indices_msg,

--- a/jsk_pcl_ros/include/jsk_pcl_ros/interactive_cuboid_likelihood.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/interactive_cuboid_likelihood.h
@@ -46,13 +46,13 @@
 
 namespace jsk_pcl_ros
 {
-  class InteractiveCuboidLikelihood: public jsk_topic_tools::DiagnosticNodelet
+  class InteractiveCuboidLikelihood: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<InteractiveCuboidLikelihood> Ptr;
     typedef InteractiveCuboidLikelihoodConfig Config;
     typedef pcl::tracking::ParticleCuboid Particle;
-    InteractiveCuboidLikelihood(): DiagnosticNodelet("InteractiveCuboidLikelihood") {}
+    InteractiveCuboidLikelihood(){}
     
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/intermittent_image_annotator.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/intermittent_image_annotator.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_INTERMITTENT_IMAGE_ANNOTATOR_H_
 #define JSK_PCL_ROS_INTERMITTENT_IMAGE_ANNOTATOR_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <std_srvs/Empty.h>
@@ -70,12 +81,11 @@ namespace jsk_pcl_ros
     
   };
   
-  class IntermittentImageAnnotator: public jsk_topic_tools::DiagnosticNodelet
+  class IntermittentImageAnnotator: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<IntermittentImageAnnotator> Ptr;
-    IntermittentImageAnnotator():
-      DiagnosticNodelet("IntermittentImageAnnotator") {}
+    IntermittentImageAnnotator(){}
 
   protected:
     ////////////////////////////////////////////////////////

--- a/jsk_pcl_ros/include/jsk_pcl_ros/joint_state_static_filter.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/joint_state_static_filter.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_JOINT_STATE_STATIC_FILTER_H_
 #define JSK_PCL_ROS_JOINT_STATE_STATIC_FILTER_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <boost/tuple/tuple.hpp>
 #include <float.h>
 #include <sensor_msgs/PointCloud2.h>
@@ -47,11 +58,11 @@
 namespace jsk_pcl_ros
 {
 
-  class JointStateStaticFilter: public jsk_topic_tools::DiagnosticNodelet
+  class JointStateStaticFilter: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::tuple<ros::Time, bool> StampedBool;
-    JointStateStaticFilter(): DiagnosticNodelet("JointStateStaticFilter"),
+    JointStateStaticFilter(): 
                               buf_(100),
                               eps_(0.00001) { }
   protected:

--- a/jsk_pcl_ros/include/jsk_pcl_ros/keypoints_publisher.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/keypoints_publisher.h
@@ -5,14 +5,25 @@
 #include <pcl/point_types.h>
 #include <pcl_ros/pcl_nodelet.h>
 #include <pcl/point_cloud.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros
 {
-  class KeypointsPublisher: public jsk_topic_tools::DiagnosticNodelet
+  class KeypointsPublisher: public jsk_topic_tools::NODELET
   {
   public:
-    KeypointsPublisher(): DiagnosticNodelet("KeypointsPublisher") {}
+    KeypointsPublisher(){}
     virtual void onInit();
   protected:
     virtual void inputCallback(const sensor_msgs::PointCloud2::ConstPtr& input);

--- a/jsk_pcl_ros/include/jsk_pcl_ros/kinfu.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/kinfu.h
@@ -49,7 +49,18 @@
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/exact_time.h>
 #include <message_filters/sync_policies/approximate_time.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_recognition_utils/pcl_conversion_util.h>
 #include <pcl_conversions/pcl_conversions.h>
 #include <std_srvs/Empty.h>
@@ -75,7 +86,7 @@ namespace pcl
 
 namespace jsk_pcl_ros
 {
-  class Kinfu: public jsk_topic_tools::DiagnosticNodelet
+  class Kinfu: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<

--- a/jsk_pcl_ros/include/jsk_pcl_ros/line_segment_collector.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/line_segment_collector.h
@@ -42,7 +42,18 @@
 #ifndef JSK_PCL_ROS_LINE_SEGMENT_COLLECTOR_H_
 #define JSK_PCL_ROS_LINE_SEGMENT_COLLECTOR_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_recognition_msgs/ClusterPointIndices.h>
 #include <jsk_recognition_msgs/ModelCoefficientsArray.h>
 #include <sensor_msgs/JointState.h>
@@ -103,10 +114,10 @@ namespace jsk_pcl_ros
   private:
   };
   
-  class LineSegmentCollector: public jsk_topic_tools::DiagnosticNodelet
+  class LineSegmentCollector: public jsk_topic_tools::NODELET
   {
   public:
-    LineSegmentCollector(): DiagnosticNodelet("LineSegmentCollector") { }
+    LineSegmentCollector(){ }
     virtual ~LineSegmentCollector();
     typedef message_filters::sync_policies::ExactTime<
       sensor_msgs::PointCloud2,

--- a/jsk_pcl_ros/include/jsk_pcl_ros/line_segment_detector.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/line_segment_detector.h
@@ -39,7 +39,18 @@
 
 #include <pcl/segmentation/sac_segmentation.h>
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/synchronizer.h>
@@ -87,10 +98,10 @@ namespace jsk_pcl_ros
     
   };
   
-  class LineSegmentDetector: public jsk_topic_tools::DiagnosticNodelet
+  class LineSegmentDetector: public jsk_topic_tools::NODELET
   {
   public:
-    LineSegmentDetector(): DiagnosticNodelet("LineSegmentDetector")
+    LineSegmentDetector()
     {
     }
     ~LineSegmentDetector() {

--- a/jsk_pcl_ros/include/jsk_pcl_ros/linemod.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/linemod.h
@@ -39,7 +39,18 @@
 
 #include "jsk_recognition_utils/pcl_conversion_util.h"
 #include <image_geometry/pinhole_camera_model.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <pcl/recognition/linemod/line_rgbd.h>
 #include <pcl/recognition/color_gradient_modality.h>
 #include <pcl/recognition/surface_normal_modality.h>
@@ -63,11 +74,11 @@
 
 namespace jsk_pcl_ros
 {
-  class LINEMODDetector: public jsk_topic_tools::DiagnosticNodelet
+  class LINEMODDetector: public jsk_topic_tools::NODELET
   {
   public:
     typedef LINEMODDetectorConfig Config;
-    LINEMODDetector(): DiagnosticNodelet("LINEMODDetector") {}
+    LINEMODDetector(){}
   protected:
     ////////////////////////////////////////////////////////
     // methods

--- a/jsk_pcl_ros/include/jsk_pcl_ros/mask_image_cluster_filter.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/mask_image_cluster_filter.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_MASK_IMAGE_CLUSTER_FILTER_H_
 #define JSK_PCL_ROS_MASK_IMAGE_CLUSTER_FILTER_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_recognition_msgs/ClusterPointIndices.h>
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/CameraInfo.h>
@@ -50,10 +61,10 @@
 
 namespace jsk_pcl_ros
 {
-  class MaskImageClusterFilter: public jsk_topic_tools::DiagnosticNodelet
+  class MaskImageClusterFilter: public jsk_topic_tools::NODELET
   {
   public:
-    MaskImageClusterFilter(): DiagnosticNodelet("MaskImageClusterFilter") {}
+    MaskImageClusterFilter(){}
     virtual ~MaskImageClusterFilter();
     typedef message_filters::sync_policies::ExactTime<
       sensor_msgs::PointCloud2,

--- a/jsk_pcl_ros/include/jsk_pcl_ros/mask_image_filter.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/mask_image_filter.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_MASK_IMAGE_FILTER_H_
 #define JSK_PCL_ROS_MASK_IMAGE_FILTER_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <sensor_msgs/PointCloud2.h>
@@ -45,10 +56,10 @@
 
 namespace jsk_pcl_ros
 {
-  class MaskImageFilter: public jsk_topic_tools::DiagnosticNodelet
+  class MaskImageFilter: public jsk_topic_tools::NODELET
   {
   public:
-    MaskImageFilter(): DiagnosticNodelet("MaskImageFilter") {}
+    MaskImageFilter(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/moving_least_square_smoothing.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/moving_least_square_smoothing.h
@@ -50,15 +50,26 @@
 #include <pcl/surface/mls.h>
 #include <dynamic_reconfigure/server.h>
 #include <pcl/filters/filter.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros
 {
-  class MovingLeastSquareSmoothing: public jsk_topic_tools::DiagnosticNodelet
+  class MovingLeastSquareSmoothing: public jsk_topic_tools::NODELET
   {
   public:
     typedef MovingLeastSquareSmoothingConfig Config;
-    MovingLeastSquareSmoothing(): DiagnosticNodelet("MovingLesatSquareSmoothing"){};
+    MovingLeastSquareSmoothing(){};
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/multi_plane_extraction.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/multi_plane_extraction.h
@@ -52,12 +52,23 @@
 #include "jsk_recognition_utils/pcl_util.h"
 #include "jsk_recognition_utils/pcl_conversion_util.h"
 #include <jsk_topic_tools/vital_checker.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include "jsk_pcl_ros/tf_listener_singleton.h"
 
 namespace jsk_pcl_ros
 {
-  class MultiPlaneExtraction: public jsk_topic_tools::DiagnosticNodelet
+  class MultiPlaneExtraction: public jsk_topic_tools::NODELET
   {
   public:
     
@@ -73,7 +84,7 @@ namespace jsk_pcl_ros
       jsk_recognition_msgs::PolygonArray> ASyncPolicy;
     typedef jsk_pcl_ros::MultiPlaneExtractionConfig Config;
 
-    MultiPlaneExtraction(): DiagnosticNodelet("MultiPlaneExtraction") { }
+    MultiPlaneExtraction(){ }
     virtual ~MultiPlaneExtraction();
   protected:
     ////////////////////////////////////////////////////////
@@ -92,9 +103,10 @@ namespace jsk_pcl_ros
                          const jsk_recognition_msgs::PolygonArray::ConstPtr& polygons);
     
     virtual void configCallback (Config &config, uint32_t level);
-
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     virtual void updateDiagnostic(
       diagnostic_updater::DiagnosticStatusWrapper &stat);
+#endif
 
     virtual void subscribe();
     virtual void unsubscribe();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/multi_plane_sac_segmentation.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/multi_plane_sac_segmentation.h
@@ -48,7 +48,18 @@
 #include <message_filters/synchronizer.h>
 
 #include <jsk_pcl_ros/MultiPlaneSACSegmentationConfig.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include "jsk_pcl_ros/tf_listener_singleton.h"
 
 
@@ -63,7 +74,7 @@
 
 namespace jsk_pcl_ros
 {
-  class MultiPlaneSACSegmentation: public jsk_topic_tools::DiagnosticNodelet
+  class MultiPlaneSACSegmentation: public jsk_topic_tools::NODELET
   {
   public:
     typedef pcl::PointXYZRGB PointT;
@@ -85,7 +96,7 @@ namespace jsk_pcl_ros
       > SyncNormalImuPolicy;
     typedef message_filters::Synchronizer<SyncNormalImuPolicy>
     NormalImuSynchronizer;
-    MultiPlaneSACSegmentation(): DiagnosticNodelet("MultiPlaneSACSegmentation") {}
+    MultiPlaneSACSegmentation(){}
     virtual ~MultiPlaneSACSegmentation();
   protected:
     ////////////////////////////////////////////////////////

--- a/jsk_pcl_ros/include/jsk_pcl_ros/normal_direction_filter.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/normal_direction_filter.h
@@ -39,7 +39,18 @@
 
 #include <pcl_ros/point_cloud.h>
 #include <sensor_msgs/PointCloud2.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include "jsk_pcl_ros/NormalDirectionFilterConfig.h"
 #include <dynamic_reconfigure/server.h>
 #include <message_filters/subscriber.h>
@@ -52,14 +63,14 @@
 
 namespace jsk_pcl_ros
 {
-  class NormalDirectionFilter: public jsk_topic_tools::DiagnosticNodelet
+  class NormalDirectionFilter: public jsk_topic_tools::NODELET
   {
   public:
     typedef NormalDirectionFilterConfig Config;
     typedef message_filters::sync_policies::ApproximateTime<
       sensor_msgs::PointCloud2,
       sensor_msgs::Imu> SyncPolicy;
-    NormalDirectionFilter(): DiagnosticNodelet("NormalDirectionFilter") {}
+    NormalDirectionFilter(){}
     virtual ~NormalDirectionFilter();
   protected:
     ////////////////////////////////////////////////////////

--- a/jsk_pcl_ros/include/jsk_pcl_ros/normal_estimation_integral_image.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/normal_estimation_integral_image.h
@@ -42,15 +42,26 @@
 #include <pcl_ros/pcl_nodelet.h>
 #include <dynamic_reconfigure/server.h>
 #include "jsk_pcl_ros/NormalEstimationIntegralImageConfig.h"
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros
 {
   class NormalEstimationIntegralImage:
-    public jsk_topic_tools::DiagnosticNodelet
+    public jsk_topic_tools::NODELET
   {
   public:
-    NormalEstimationIntegralImage(): DiagnosticNodelet("NormalEstimationIntegralImage") {}
+    NormalEstimationIntegralImage(){}
     typedef jsk_pcl_ros::NormalEstimationIntegralImageConfig Config;    
   protected:
     ros::Subscriber sub_input_;

--- a/jsk_pcl_ros/include/jsk_pcl_ros/normal_estimation_omp.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/normal_estimation_omp.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_NORMAL_ESTIMATION_OMP_H_
 #define JSK_PCL_ROS_NORMAL_ESTIMATION_OMP_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/PointCloud2.h>
 #include <pcl_ros/FeatureConfig.h>
 #include <dynamic_reconfigure/server.h>
@@ -47,12 +58,12 @@
 
 namespace jsk_pcl_ros
 {
-  class NormalEstimationOMP: public jsk_topic_tools::DiagnosticNodelet
+  class NormalEstimationOMP: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<NormalEstimationOMP> Ptr;
     typedef pcl_ros::FeatureConfig Config;
-    NormalEstimationOMP(): DiagnosticNodelet("NormalEstimationOMP"), timer_(10) {}
+    NormalEstimationOMP(): timer_(10) {}
     
   protected:
 

--- a/jsk_pcl_ros/include/jsk_pcl_ros/octomap_server_contact.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/octomap_server_contact.h
@@ -37,7 +37,18 @@
 #define OCTOMAP_SERVER_OCTOMAPSERVER_CONTACT_H_
 
 #include <ros/ros.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 #define NDEBUG
 #include <octomap_server/OctomapServer.h>
@@ -50,10 +61,10 @@ using octomap_server::OctomapServer;
 namespace jsk_pcl_ros
 {
   class OctomapServerContact : public OctomapServer,
-                               public jsk_topic_tools::DiagnosticNodelet
+                               public jsk_topic_tools::NODELET
   {
    public:
-    OctomapServerContact(): DiagnosticNodelet("OctomapServerContact") {}
+    OctomapServerContact(){}
     OctomapServerContact(const ros::NodeHandle &privateNh);
      virtual ~OctomapServerContact();
 

--- a/jsk_pcl_ros/include/jsk_pcl_ros/octree_change_publisher.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/octree_change_publisher.h
@@ -48,7 +48,18 @@
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
 #include <pcl/octree/octree.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros
 {
@@ -67,11 +78,11 @@ namespace jsk_pcl_ros
    ISSN={1050-4729}, 
    month={May},}
    */
-  class OctreeChangePublisher: public jsk_topic_tools::DiagnosticNodelet
+  class OctreeChangePublisher: public jsk_topic_tools::NODELET
   {
   public:
     typedef OctreeChangePublisherConfig Config;
-    OctreeChangePublisher(): DiagnosticNodelet("OctreeChangePublisher") {}
+    OctreeChangePublisher(){}
   protected:
     int counter_;
     int noise_filter_;

--- a/jsk_pcl_ros/include/jsk_pcl_ros/octree_voxel_grid.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/octree_voxel_grid.h
@@ -40,7 +40,18 @@
 #include <ros/ros.h>
 #include <ros/names.h>
 #include <dynamic_reconfigure/server.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/PointCloud2.h>
 #include <visualization_msgs/Marker.h>
 #include <visualization_msgs/MarkerArray.h>
@@ -53,11 +64,11 @@
 
 namespace jsk_pcl_ros
 {
-  class OctreeVoxelGrid : public jsk_topic_tools::DiagnosticNodelet
+  class OctreeVoxelGrid : public jsk_topic_tools::NODELET
   {
   public:
     typedef jsk_pcl_ros::OctreeVoxelGridConfig Config;
-    OctreeVoxelGrid(): DiagnosticNodelet("OctreeVoxelGrid") {}
+    OctreeVoxelGrid(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/organize_pointcloud.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/organize_pointcloud.h
@@ -47,14 +47,25 @@
 #include <pcl/filters/extract_indices.h>
 #include <pcl/range_image/range_image.h>
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros
 {
-  class OrganizePointCloud: public jsk_topic_tools::DiagnosticNodelet
+  class OrganizePointCloud: public jsk_topic_tools::NODELET
   {
   protected:
-    OrganizePointCloud(): DiagnosticNodelet("OrganizePointCloud") {}
+    OrganizePointCloud(){}
     double angular_resolution, angle_width, angle_height;
     int min_points;
     ros::Subscriber sub_;

--- a/jsk_pcl_ros/include/jsk_pcl_ros/organized_edge_detector.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/organized_edge_detector.h
@@ -42,16 +42,27 @@
 #include <jsk_pcl_ros/OrganizedEdgeDetectorConfig.h>
 #include <dynamic_reconfigure/server.h>
 #include <image_transport/image_transport.h>
-#include "jsk_topic_tools/diagnostic_nodelet.h"
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros
 {
-  class OrganizedEdgeDetector: public jsk_topic_tools::DiagnosticNodelet
+  class OrganizedEdgeDetector: public jsk_topic_tools::NODELET
   {
   public:
     typedef pcl::PointXYZRGB PointT;
     typedef jsk_pcl_ros::OrganizedEdgeDetectorConfig Config;
-    OrganizedEdgeDetector() : DiagnosticNodelet("OrganizedEdgeDetector") {}
+    OrganizedEdgeDetector(){}
   protected:
     ////////////////////////////////////////////////////////
     // methods

--- a/jsk_pcl_ros/include/jsk_pcl_ros/organized_multi_plane_segmentation.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/organized_multi_plane_segmentation.h
@@ -54,16 +54,27 @@
 
 #include <diagnostic_updater/diagnostic_updater.h>
 #include <diagnostic_updater/publisher.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_topic_tools/diagnostic_utils.h>
 
 namespace jsk_pcl_ros
 {
   class OrganizedMultiPlaneSegmentation:
-    public jsk_topic_tools::DiagnosticNodelet
+    public jsk_topic_tools::NODELET
   {
   public:
-    OrganizedMultiPlaneSegmentation(): DiagnosticNodelet("OrganizedMultiPlaneSegmentation") {}
+    OrganizedMultiPlaneSegmentation(){}
     typedef pcl::PointXYZRGBA PointT;
     typedef std::vector<pcl::PlanarRegion<PointT>,
                         Eigen::aligned_allocator<pcl::PlanarRegion<PointT> > >

--- a/jsk_pcl_ros/include/jsk_pcl_ros/organized_pass_through.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/organized_pass_through.h
@@ -38,19 +38,30 @@
 #define JSK_PCL_ROS_ORGANIZED_PASS_THROUGH_H_
 
 #include <pcl_ros/pcl_nodelet.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_topic_tools/counter.h>
 #include <dynamic_reconfigure/server.h>
 #include "jsk_pcl_ros/OrganizedPassThroughConfig.h"
 
 namespace jsk_pcl_ros
 {
-  class OrganizedPassThrough: public jsk_topic_tools::DiagnosticNodelet
+  class OrganizedPassThrough: public jsk_topic_tools::NODELET
   {
   public:
     typedef jsk_pcl_ros::OrganizedPassThroughConfig Config;
     typedef pcl::PointXYZRGB PointT;
-    OrganizedPassThrough(): DiagnosticNodelet("OrganizedPassThrough") {}
+    OrganizedPassThrough(){}
 
   protected:
     ////////////////////////////////////////////////////////
@@ -68,9 +79,10 @@ namespace jsk_pcl_ros
 
     virtual pcl::PointIndices::Ptr filterIndices(const pcl::PointCloud<PointT>::Ptr& pc);
     
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     virtual void updateDiagnostic(
       diagnostic_updater::DiagnosticStatusWrapper &stat);
-
+#endif
     bool isPointNaN(const PointT& p) {
       return (!pcl_isfinite(p.x) || !pcl_isfinite(p.y) || !pcl_isfinite(p.z));
     }

--- a/jsk_pcl_ros/include/jsk_pcl_ros/organized_statistical_outlier_removal.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/organized_statistical_outlier_removal.h
@@ -39,19 +39,30 @@
 
 #include <pcl/pcl_base.h>
 #include <pcl_ros/pcl_nodelet.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_topic_tools/counter.h>
 #include <dynamic_reconfigure/server.h>
 #include "jsk_pcl_ros/OrganizedStatisticalOutlierRemovalConfig.h"
 
 namespace jsk_pcl_ros
 {
-  class OrganizedStatisticalOutlierRemoval: public jsk_topic_tools::DiagnosticNodelet
+  class OrganizedStatisticalOutlierRemoval: public jsk_topic_tools::NODELET
   {
   public:
     typedef jsk_pcl_ros::OrganizedStatisticalOutlierRemovalConfig Config;
     typedef pcl::PointXYZRGB PointT;
-    OrganizedStatisticalOutlierRemoval() : DiagnosticNodelet("OrganizedStatisticalOutlierRemoval") {};
+    OrganizedStatisticalOutlierRemoval(){};
   protected:
     ////////////////////////////////////////////////////////
     // methods
@@ -66,8 +77,10 @@ namespace jsk_pcl_ros
 
     virtual void filter(const sensor_msgs::PointCloud2::ConstPtr& msg);
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     virtual void updateDiagnostic(
       diagnostic_updater::DiagnosticStatusWrapper &stat);
+#endif
 
     ////////////////////////////////////////////////////////
     // ROS variables

--- a/jsk_pcl_ros/include/jsk_pcl_ros/parallel_edge_finder.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/parallel_edge_finder.h
@@ -50,18 +50,29 @@
 #include <message_filters/synchronizer.h>
 #include "jsk_recognition_utils/geo_util.h"
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros
 {
-  class ParallelEdgeFinder: public jsk_topic_tools::DiagnosticNodelet
+  class ParallelEdgeFinder: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<
     jsk_recognition_msgs::ClusterPointIndices,
     jsk_recognition_msgs::ModelCoefficientsArray > SyncPolicy;
     typedef jsk_pcl_ros::ParallelEdgeFinderConfig Config;
-    ParallelEdgeFinder() : DiagnosticNodelet("ParallelEdgeFinder"){}
+    ParallelEdgeFinder(){}
     virtual ~ParallelEdgeFinder();
   protected:
     ////////////////////////////////////////////////////////

--- a/jsk_pcl_ros/include/jsk_pcl_ros/particle_filter_tracking.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/particle_filter_tracking.h
@@ -44,7 +44,18 @@
 #include <tf/transform_broadcaster.h>
 #include <tf_conversions/tf_eigen.h>
 #include <jsk_recognition_utils/pcl_conversion_util.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_recognition_utils/tf_listener_singleton.h>
 #include <boost/circular_buffer.hpp>
 // pcl
@@ -535,7 +546,7 @@ namespace pcl
 using namespace pcl::tracking;
 namespace jsk_pcl_ros
 {
-  class ParticleFilterTracking: public jsk_topic_tools::DiagnosticNodelet
+  class ParticleFilterTracking: public jsk_topic_tools::NODELET
   {
   public:
     typedef pcl::PointXYZRGB PointT;
@@ -548,7 +559,7 @@ namespace jsk_pcl_ros
       sensor_msgs::PointCloud2 > SyncChangePolicy;
     typedef ParticleFilterTracker<PointT, ParticleXYZRPY>::PointCloudStatePtr
     PointCloudStatePtr;
-    ParticleFilterTracking(): DiagnosticNodelet("ParticleFilterTracking"), timer_(10), distance_error_buffer_(100), angle_error_buffer_(100), no_move_buffer_(10) {}
+    ParticleFilterTracking(): timer_(10), distance_error_buffer_(100), angle_error_buffer_(100), no_move_buffer_(10) {}
     virtual ~ParticleFilterTracking();
   protected:
     pcl::PointCloud<PointT>::Ptr cloud_pass_;

--- a/jsk_pcl_ros/include/jsk_pcl_ros/people_detection.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/people_detection.h
@@ -36,7 +36,18 @@
 #ifndef JSK_PCL_ROS_PEOPLE_DETECTION_H_
 #define JSK_PCL_ROS_PEOPLE_DETECTION_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 #include <jsk_recognition_msgs/BoundingBoxArray.h>
 #include <jsk_recognition_msgs/ModelCoefficientsArray.h>
@@ -49,9 +60,9 @@
 #include <pcl/people/ground_based_people_detection_app.h>
 
 namespace jsk_pcl_ros {
-  class PeopleDetection : public jsk_topic_tools::DiagnosticNodelet {
+  class PeopleDetection : public jsk_topic_tools::NODELET {
    public:
-    PeopleDetection() : DiagnosticNodelet("PeopleDetection") {}
+    PeopleDetection(){}
 
     typedef jsk_pcl_ros::PeopleDetectionConfig Config;
 

--- a/jsk_pcl_ros/include/jsk_pcl_ros/plane_supported_cuboid_estimator.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/plane_supported_cuboid_estimator.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_PLANE_SUPPORTED_CUBOID_ESTIMATOR_H_
 #define JSK_PCL_ROS_PLANE_SUPPORTED_CUBOID_ESTIMATOR_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/synchronizer.h>
@@ -265,7 +276,7 @@ namespace jsk_pcl_ros
     }    
   }
   
-  class PlaneSupportedCuboidEstimator: public jsk_topic_tools::DiagnosticNodelet
+  class PlaneSupportedCuboidEstimator: public jsk_topic_tools::NODELET
   {
   public:
     typedef pcl::tracking::ParticleCuboid Particle;
@@ -276,7 +287,7 @@ namespace jsk_pcl_ros
       jsk_recognition_msgs::PolygonArray,
       jsk_recognition_msgs::ModelCoefficientsArray> PolygonSyncPolicy;
     
-    PlaneSupportedCuboidEstimator(): DiagnosticNodelet("PlaneSupportedCuboidEstimator") {}
+    PlaneSupportedCuboidEstimator(){}
     virtual ~PlaneSupportedCuboidEstimator();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/pointcloud_localization.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/pointcloud_localization.h
@@ -39,7 +39,18 @@
 #include <tf_conversions/tf_eigen.h>
 #include "jsk_pcl_ros/tf_listener_singleton.h"
 #include <tf/transform_broadcaster.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <std_srvs/Empty.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <geometry_msgs/PoseStamped.h>
@@ -49,12 +60,12 @@
 
 namespace jsk_pcl_ros
 {
-  class PointCloudLocalization: public jsk_topic_tools::DiagnosticNodelet
+  class PointCloudLocalization: public jsk_topic_tools::NODELET
   {
   public:
     PointCloudLocalization():
-      first_time_(true), localize_requested_(false),
-      DiagnosticNodelet("PointCloudLocalization") {}
+      first_time_(true), localize_requested_(false)
+      {}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/pointcloud_screenpoint.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/pointcloud_screenpoint.h
@@ -40,7 +40,18 @@
 #include <geometry_msgs/PolygonStamped.h>
 #include <jsk_pcl_ros/PointcloudScreenpointConfig.h>
 #include <jsk_recognition_msgs/TransformScreenpoint.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
 #include <message_filters/sync_policies/exact_time.h>
@@ -53,10 +64,10 @@ namespace mf = message_filters;
 
 namespace jsk_pcl_ros
 {
-  class PointcloudScreenpoint : public jsk_topic_tools::DiagnosticNodelet
+  class PointcloudScreenpoint : public jsk_topic_tools::NODELET
   {
    public:
-    PointcloudScreenpoint() : DiagnosticNodelet("PointcloudScreenpoint") {}
+    PointcloudScreenpoint(){}
     virtual ~PointcloudScreenpoint();
    protected:
     typedef PointcloudScreenpointConfig Config;

--- a/jsk_pcl_ros/include/jsk_pcl_ros/ppf_registration.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/ppf_registration.h
@@ -36,7 +36,18 @@
 #ifndef JSK_PCL_ROS_ADD_COLOR_FROM_IMAGE_H_
 #define JSK_PCL_ROS_ADD_COLOR_FROM_IMAGE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include "jsk_recognition_utils/pcl_util.h"
 #include "jsk_recognition_utils/geo_util.h"
 #include "jsk_recognition_utils/pcl_conversion_util.h"
@@ -58,7 +69,7 @@
 
 namespace jsk_pcl_ros
 {
-  class PPFRegistration: public jsk_topic_tools::DiagnosticNodelet
+  class PPFRegistration: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<
@@ -74,7 +85,7 @@ namespace jsk_pcl_ros
     sensor_msgs::PointCloud2,
     sensor_msgs::PointCloud2> CloudApproximateSyncPolicy;
     typedef jsk_pcl_ros::PPFRegistrationConfig Config;
-    PPFRegistration(): DiagnosticNodelet("PPFRegistration") {}
+    PPFRegistration(){}
     virtual ~PPFRegistration();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/primitive_shape_classifier.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/primitive_shape_classifier.h
@@ -42,7 +42,18 @@
 
 #include <boost/shared_ptr.hpp>
 #include <dynamic_reconfigure/server.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/synchronizer.h>
 #include <message_filters/subscriber.h>
@@ -59,7 +70,7 @@
 
 namespace jsk_pcl_ros
 {
-  class PrimitiveShapeClassifier : public jsk_topic_tools::DiagnosticNodelet
+  class PrimitiveShapeClassifier : public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<sensor_msgs::PointCloud2,
@@ -69,7 +80,7 @@ namespace jsk_pcl_ros
     typedef PrimitiveShapeClassifierConfig Config;
     typedef pcl::PointXYZRGBA PointT;
 
-    PrimitiveShapeClassifier() : DiagnosticNodelet("PrimitiveShapeClassifier") {}
+    PrimitiveShapeClassifier(){}
     virtual ~PrimitiveShapeClassifier();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/rearrange_bounding_box.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/rearrange_bounding_box.h
@@ -36,7 +36,18 @@
 #ifndef JSK_PCL_ROS_REARRANGE_BOUNDING_BOX_H
 #define JSK_PCL_ROS_REARRANGE_BOUNDING_BOX_H
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_recognition_msgs/BoundingBoxArray.h>
 
 #include <dynamic_reconfigure/server.h>
@@ -46,11 +57,11 @@
 
 namespace jsk_pcl_ros
 {
-  class RearrangeBoundingBox : public jsk_topic_tools::DiagnosticNodelet
+  class RearrangeBoundingBox : public jsk_topic_tools::NODELET
   {
   public:
     typedef jsk_pcl_ros::RearrangeBoundingBoxConfig Config;
-    RearrangeBoundingBox() : DiagnosticNodelet("RearrangeBoundingBox") {}
+    RearrangeBoundingBox(){}
 
   protected:
     ////////////////////////////////////////////////////////

--- a/jsk_pcl_ros/include/jsk_pcl_ros/region_growing_multiple_plane_segmentation.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/region_growing_multiple_plane_segmentation.h
@@ -43,7 +43,18 @@
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/sync_policies/approximate_time.h>
 #include <message_filters/synchronizer.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include "jsk_recognition_utils/geo_util.h"
 #include "jsk_recognition_msgs/PolygonArray.h"
 #include "jsk_recognition_msgs/ClusterPointIndices.h"
@@ -54,7 +65,7 @@
 namespace jsk_pcl_ros
 {
   class RegionGrowingMultiplePlaneSegmentation:
-    public jsk_topic_tools::DiagnosticNodelet
+    public jsk_topic_tools::NODELET
   {
   public:
     typedef pcl::PointXYZRGB PointT;
@@ -64,7 +75,7 @@ namespace jsk_pcl_ros
       sensor_msgs::PointCloud2,
       sensor_msgs::PointCloud2 > NormalSyncPolicy;
     RegionGrowingMultiplePlaneSegmentation()
-      : DiagnosticNodelet("RegionGrowingMultiplePlaneSegmentation"), 
+      : 
         timer_(10), 
         done_initialization_(false) {}
     virtual ~RegionGrowingMultiplePlaneSegmentation();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/region_growing_segmentation.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/region_growing_segmentation.h
@@ -47,14 +47,25 @@
 
 #include <dynamic_reconfigure/server.h>
 #include "jsk_pcl_ros/RegionGrowingSegmentationConfig.h"
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 namespace jsk_pcl_ros
 {
   class RegionGrowingSegmentation:
-    public jsk_topic_tools::DiagnosticNodelet
+    public jsk_topic_tools::NODELET
   {
   public:
-    RegionGrowingSegmentation() : DiagnosticNodelet("RegionGrowingSegmentation") {}
+    RegionGrowingSegmentation(){}
   protected:
     ros::Publisher pub_;
     ros::Subscriber sub_;

--- a/jsk_pcl_ros/include/jsk_pcl_ros/roi_clipper.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/roi_clipper.h
@@ -38,7 +38,18 @@
 #ifndef JSK_PCL_ROS_ROI_CLIPPER_H_
 #define JSK_PCL_ROS_ROI_CLIPPER_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/synchronizer.h>
@@ -48,13 +59,13 @@
 #include <pcl_conversions/pcl_conversions.h>
 namespace jsk_pcl_ros
 {
-  class ROIClipper: public jsk_topic_tools::DiagnosticNodelet
+  class ROIClipper: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<
     sensor_msgs::Image,
     sensor_msgs::CameraInfo > SyncPolicy;
-    ROIClipper(): DiagnosticNodelet("ROIClipper") {}
+    ROIClipper(){}
     virtual ~ROIClipper();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/selected_cluster_publisher.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/selected_cluster_publisher.h
@@ -43,15 +43,26 @@
 #include <jsk_recognition_msgs/ClusterPointIndices.h>
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/synchronizer.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros
 {
-  class SelectedClusterPublisher: public jsk_topic_tools::DiagnosticNodelet
+  class SelectedClusterPublisher: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<sensor_msgs::PointCloud2, jsk_recognition_msgs::ClusterPointIndices, jsk_recognition_msgs::Int32Stamped> SyncPolicy;
-    SelectedClusterPublisher(): DiagnosticNodelet("SelectedClusterPublisher") {}
+    SelectedClusterPublisher(){}
     virtual ~SelectedClusterPublisher();
   protected:
     ros::Publisher pub_;

--- a/jsk_pcl_ros/include/jsk_pcl_ros/snapit.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/snapit.h
@@ -46,7 +46,18 @@
 #include <jsk_recognition_msgs/ModelCoefficientsArray.h>
 #include "jsk_recognition_msgs/CallSnapIt.h"
 #include <tf/transform_listener.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include "jsk_recognition_utils/geo_util.h"
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
@@ -55,13 +66,13 @@
 #include "jsk_pcl_ros/tf_listener_singleton.h"
 namespace jsk_pcl_ros
 {
-  class SnapIt: public jsk_topic_tools::DiagnosticNodelet
+  class SnapIt: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<
       jsk_recognition_msgs::PolygonArray,
       jsk_recognition_msgs::ModelCoefficientsArray> SyncPolygonPolicy;
-    SnapIt(): DiagnosticNodelet("SnapIt") {}
+    SnapIt(){}
     virtual ~SnapIt();
   protected:
     ////////////////////////////////////////////////////////

--- a/jsk_pcl_ros/include/jsk_pcl_ros/supervoxel_segmentation.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/supervoxel_segmentation.h
@@ -37,20 +37,31 @@
 #ifndef JSK_PCL_ROS_SUPERVOXEL_SEGMENTATION_H_
 #define JSK_PCL_ROS_SUPERVOXEL_SEGMENTATION_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include "jsk_recognition_utils/pcl_conversion_util.h"
 #include <dynamic_reconfigure/server.h>
 #include <jsk_pcl_ros/SupervoxelSegmentationConfig.h>
 #include <jsk_recognition_msgs/ClusterPointIndices.h>
 namespace jsk_pcl_ros
 {
-  class SupervoxelSegmentation: public jsk_topic_tools::DiagnosticNodelet
+  class SupervoxelSegmentation: public jsk_topic_tools::NODELET
   {
   public:
     typedef pcl::PointXYZRGB PointT;
     typedef boost::shared_ptr<SupervoxelSegmentation> Ptr;
     typedef SupervoxelSegmentationConfig Config;
-    SupervoxelSegmentation(): DiagnosticNodelet("SupervoxelSegmentation") {}
+    SupervoxelSegmentation(){}
   protected:
     ////////////////////////////////////////////////////////
     // methods

--- a/jsk_pcl_ros/include/jsk_pcl_ros/target_adaptive_tracking.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/target_adaptive_tracking.h
@@ -57,13 +57,24 @@
 #include <std_msgs/Header.h>
 #include <dynamic_reconfigure/server.h>
 #include <jsk_recognition_msgs/ClusterPointIndices.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_pcl_ros/pcl_conversion_util.h>
 #include <jsk_pcl_ros/TargetAdaptiveTrackingConfig.h>
 
 namespace jsk_pcl_ros
 {
-   class TargetAdaptiveTracking: public jsk_topic_tools::DiagnosticNodelet
+   class TargetAdaptiveTracking: public jsk_topic_tools::NODELET
    {
       typedef pcl::PointXYZRGB PointT;
 

--- a/jsk_pcl_ros/include/jsk_pcl_ros/tilt_laser_listener.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/tilt_laser_listener.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_TILT_LASER_LISTENER_H_
 #define JSK_PCL_ROS_TILT_LASER_LISTENER_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/JointState.h>
 #include <jsk_recognition_msgs/TimeRange.h>
 #include "jsk_pcl_ros/line_segment_collector.h"
@@ -60,10 +71,10 @@ namespace jsk_pcl_ros
     
   };
   
-  class TiltLaserListener: public jsk_topic_tools::DiagnosticNodelet
+  class TiltLaserListener: public jsk_topic_tools::NODELET
   {
   public:
-    TiltLaserListener(): DiagnosticNodelet("TiltLaserListener") { };
+    TiltLaserListener(){ };
     enum LaserType {
       INFINITE_SPINDLE, INFINITE_SPINDLE_HALF, TILT, TILT_HALF_UP, TILT_HALF_DOWN, PERIODIC
     };
@@ -74,8 +85,10 @@ namespace jsk_pcl_ros
     virtual void onInit();
     virtual void subscribe();
     virtual void unsubscribe();
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     virtual void updateDiagnostic(
       diagnostic_updater::DiagnosticStatusWrapper &stat);
+#endif
     virtual void jointCallback(const sensor_msgs::JointState::ConstPtr& msg);
     virtual void processTiltHalfUp(const ros::Time& stamp, const double& value);
     virtual void processTiltHalfDown(const ros::Time& stamp, const double& value);

--- a/jsk_pcl_ros/include/jsk_pcl_ros/torus_finder.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/torus_finder.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_TORUS_FINDER_H_
 #define JSK_PCL_ROS_TORUS_FINDER_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/PointCloud2.h>
 #include <jsk_recognition_msgs/TorusArray.h>
 #include <jsk_recognition_msgs/Torus.h>
@@ -50,11 +61,11 @@
 
 namespace jsk_pcl_ros
 {
-  class TorusFinder: public jsk_topic_tools::DiagnosticNodelet
+  class TorusFinder: public jsk_topic_tools::NODELET
   {
   public:
     typedef TorusFinderConfig Config;
-    TorusFinder(): timer_(10), done_initialization_(false), DiagnosticNodelet("TorusFinder") {}
+    TorusFinder(): timer_(10), done_initialization_(false) {}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/uniform_sampling.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/uniform_sampling.h
@@ -37,18 +37,29 @@
 #ifndef JSK_PCL_ROS_UNIFORM_SAMPLING_H_
 #define JSK_PCL_ROS_UNIFORM_SAMPLING_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include "jsk_recognition_utils/pcl_conversion_util.h"
 #include <jsk_pcl_ros/UniformSamplingConfig.h>
 #include <dynamic_reconfigure/server.h>
 
 namespace jsk_pcl_ros
 {
-  class UniformSampling: public jsk_topic_tools::DiagnosticNodelet
+  class UniformSampling: public jsk_topic_tools::NODELET
   {
   public:
     typedef UniformSamplingConfig Config;
-    UniformSampling(): DiagnosticNodelet("UniformSampling") {}
+    UniformSampling(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_pcl_ros/include/jsk_pcl_ros/voxel_grid_downsample_decoder.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/voxel_grid_downsample_decoder.h
@@ -46,15 +46,26 @@
 #include <pcl_ros/pcl_nodelet.h>
 #include <pcl/point_types.h>
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros
 {
   class VoxelGridDownsampleDecoder :
-    public jsk_topic_tools::DiagnosticNodelet
+    public jsk_topic_tools::NODELET
   {
   public:
-    VoxelGridDownsampleDecoder() : DiagnosticNodelet("VoxelGridDownsampleDecoder") {}
+    VoxelGridDownsampleDecoder(){}
   protected:
     tf::TransformListener tf_listener;
     // utility

--- a/jsk_pcl_ros/include/jsk_pcl_ros/voxel_grid_downsample_manager.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/voxel_grid_downsample_manager.h
@@ -46,14 +46,25 @@
 // pcl
 #include <pcl_ros/pcl_nodelet.h>
 #include <pcl/point_types.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros
 {
-  class VoxelGridDownsampleManager : public jsk_topic_tools::DiagnosticNodelet
+  class VoxelGridDownsampleManager : public jsk_topic_tools::NODELET
   {
   public:
-    VoxelGridDownsampleManager() : DiagnosticNodelet("VoxelGridDownsampleManager") {}
+    VoxelGridDownsampleManager(){}
   protected:
     tf::TransformListener* tf_listener;
     std::vector<visualization_msgs::Marker::ConstPtr> grid_;

--- a/jsk_pcl_ros/include/jsk_pcl_ros/voxel_grid_large_scale.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/voxel_grid_large_scale.h
@@ -36,18 +36,29 @@
 #ifndef JSK_PCL_ROS_VOXEL_GRID_LARGE_SCALE_H_
 #define JSK_PCL_ROS_VOXEL_GRID_LARGE_SCALE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/PointCloud2.h>
 #include <dynamic_reconfigure/server.h>
 #include <jsk_pcl_ros/VoxelGridLargeScaleConfig.h>
 
 namespace jsk_pcl_ros
 {
-  class VoxelGridLargeScale: public jsk_topic_tools::DiagnosticNodelet
+  class VoxelGridLargeScale: public jsk_topic_tools::NODELET
   {
   public:
     typedef VoxelGridLargeScaleConfig Config;
-    VoxelGridLargeScale(): DiagnosticNodelet("VoxelGridLargeScale") { }
+    VoxelGridLargeScale(){ }
   protected:
     virtual void onInit();
     virtual void filter(const sensor_msgs::PointCloud2::ConstPtr& msg);

--- a/jsk_pcl_ros/src/add_color_from_image_nodelet.cpp
+++ b/jsk_pcl_ros/src/add_color_from_image_nodelet.cpp
@@ -45,7 +45,7 @@ namespace jsk_pcl_ros
 {
   void AddColorFromImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<sensor_msgs::PointCloud2>(
       *pnh_, "output", 1);
     onInitPostProcess();
@@ -129,7 +129,9 @@ namespace jsk_pcl_ros
     sensor_msgs::PointCloud2 ros_cloud;
     pcl::toROSMsg(*rgb_cloud, ros_cloud);
     ros_cloud.header = cloud_msg->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(ros_cloud);
   }
 }

--- a/jsk_pcl_ros/src/add_color_from_image_to_organized_nodelet.cpp
+++ b/jsk_pcl_ros/src/add_color_from_image_to_organized_nodelet.cpp
@@ -44,7 +44,7 @@ namespace jsk_pcl_ros
 {
   void AddColorFromImageToOrganized::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<sensor_msgs::PointCloud2>(
       *pnh_, "output", 1);
     onInitPostProcess();
@@ -125,7 +125,9 @@ namespace jsk_pcl_ros
     sensor_msgs::PointCloud2 ros_cloud;
     pcl::toROSMsg(*rgb_cloud, ros_cloud);
     ros_cloud.header = cloud_msg->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(ros_cloud);
   }
 }

--- a/jsk_pcl_ros/src/attention_clipper_nodelet.cpp
+++ b/jsk_pcl_ros/src/attention_clipper_nodelet.cpp
@@ -55,7 +55,7 @@ namespace jsk_pcl_ros
 {
   void AttentionClipper::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     tf_listener_ = TfListenerSingleton::getInstance();
     pnh_->param("negative", negative_, false);
     pnh_->param("use_multiple_attention", use_multiple_attention_, false);
@@ -317,7 +317,9 @@ namespace jsk_pcl_ros
       jsk_recognition_utils::pointFromVectorToXYZ(dimensions_[i], box.dimensions);
       box_array.boxes.push_back(box);
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_bounding_box_array_.publish(box_array);
   }
 
@@ -370,7 +372,9 @@ namespace jsk_pcl_ros
     roi.roi.width = roi_region.width;
     roi.roi.height = roi_region.height;
     roi.roi.do_rectify = true;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_camera_info_.publish(roi);
     // mask computation
     mask = cv::Mat::zeros(msg->height, msg->width, CV_8UC1);
@@ -457,7 +461,9 @@ namespace jsk_pcl_ros
       PCLIndicesMsg indices_msg;
       pcl_conversions::fromPCL(*all_indices, indices_msg);
       cluster_indices_msg.header = indices_msg.header = msg->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_indices_.publish(indices_msg);
       pub_cluster_indices_.publish(cluster_indices_msg);
       publishBoundingBox(msg->header);
@@ -515,7 +521,9 @@ namespace jsk_pcl_ros
       cv_bridge::CvImage mask_bridge(msg->header,
                                      sensor_msgs::image_encodings::MONO8,
                                      all_mask_image);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_mask_.publish(mask_bridge.toImageMsg());
       //publishBoundingBox(msg->header);
     }

--- a/jsk_pcl_ros/src/bilateral_filter_nodelet.cpp
+++ b/jsk_pcl_ros/src/bilateral_filter_nodelet.cpp
@@ -45,7 +45,7 @@ namespace jsk_pcl_ros
 {
   void BilateralFilter::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     typename dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&BilateralFilter::configCallback, this, _1, _2);
@@ -83,7 +83,9 @@ namespace jsk_pcl_ros
     pcl::toROSMsg(*output, ros_output);
     ros_output.header = msg->header;
     // hmm,,, is it keep organized??
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(ros_output);
   }
 

--- a/jsk_pcl_ros/src/border_estimator_nodelet.cpp
+++ b/jsk_pcl_ros/src/border_estimator_nodelet.cpp
@@ -45,7 +45,7 @@ namespace jsk_pcl_ros
 {
   void BorderEstimator::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     // planar or spherical
     pnh_->param("model_type", model_type_, std::string("planar"));
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
@@ -155,7 +155,9 @@ namespace jsk_pcl_ros
         }
       }
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     publishCloud(pub_border_, border_indices, header);
     publishCloud(pub_veil_, veil_indices, header);
     publishCloud(pub_shadow_, shadow_indices, header);

--- a/jsk_pcl_ros/src/bounding_box_filter_nodelet.cpp
+++ b/jsk_pcl_ros/src/bounding_box_filter_nodelet.cpp
@@ -39,7 +39,7 @@ namespace jsk_pcl_ros
 {
   void BoundingBoxFilter::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     ////////////////////////////////////////////////////////
     // dynamic reconfigure
@@ -162,7 +162,9 @@ namespace jsk_pcl_ros
     }
 
     // publish
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     filtered_box_pub_.publish(filtered_box_array);
 
     // for diagnostic
@@ -199,7 +201,9 @@ namespace jsk_pcl_ros
     }
 
     // publish
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     filtered_box_pub_.publish(filtered_box_array);
     filtered_indices_pub_.publish(filtered_indices);
 
@@ -225,6 +229,7 @@ namespace jsk_pcl_ros
     z_dimension_max_ = config.z_dimension_max;
   }
   
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
   void BoundingBoxFilter::updateDiagnostic(
     diagnostic_updater::DiagnosticStatusWrapper &stat)
   {
@@ -247,6 +252,7 @@ namespace jsk_pcl_ros
     }
     DiagnosticNodelet::updateDiagnostic(stat);
   }
+#endif
   
 }
 

--- a/jsk_pcl_ros/src/boundingbox_occlusion_rejector_nodelet.cpp
+++ b/jsk_pcl_ros/src/boundingbox_occlusion_rejector_nodelet.cpp
@@ -43,7 +43,7 @@ namespace jsk_pcl_ros
 {
   void BoundingBoxOcclusionRejector::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     tf_listener_ = TfListenerSingleton::getInstance();
     pub_ = advertise<jsk_recognition_msgs::BoundingBoxArray>(*pnh_, "output", 1);
     pub_target_image_ = advertise<sensor_msgs::Image>(*pnh_, "output/target_image", 1);
@@ -156,7 +156,9 @@ namespace jsk_pcl_ros
     for (size_t i = 0; i < candidate_indices.size(); i++) {
       rejected_boxes.boxes.push_back(candidate_boxes_msg->boxes[candidate_indices[i]]);
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(rejected_boxes);
   }
 

--- a/jsk_pcl_ros/src/capture_stereo_synchronizer_nodelet.cpp
+++ b/jsk_pcl_ros/src/capture_stereo_synchronizer_nodelet.cpp
@@ -43,7 +43,7 @@ namespace jsk_pcl_ros
 {
   void CaptureStereoSynchronizer::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     counter_ = 0;
     pnh_->param("rotational_bin_size", rotational_bin_size_, pcl::deg2rad(10.0));
     pnh_->param("positional_bin_size", positional_bin_size_, 0.1);
@@ -162,7 +162,9 @@ namespace jsk_pcl_ros
     }
     std_msgs::Int32 count;
     count.data = counter_;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_count_.publish(count);
   }
 }

--- a/jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
+++ b/jsk_pcl_ros/src/cluster_point_indices_decomposer_nodelet.cpp
@@ -79,7 +79,7 @@ namespace jsk_pcl_ros
 
   void ClusterPointIndicesDecomposer::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("publish_tf", publish_tf_, false);
     if (publish_tf_) {
       br_.reset(new tf::TransformBroadcaster);
@@ -293,6 +293,7 @@ namespace jsk_pcl_ros
               [&cloud_sizes](size_t i1, size_t i2) {return cloud_sizes[i1] < cloud_sizes[i2];});
   }
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
   void ClusterPointIndicesDecomposer::updateDiagnostic(
     diagnostic_updater::DiagnosticStatusWrapper &stat)
   {
@@ -312,6 +313,7 @@ namespace jsk_pcl_ros
     }
     DiagnosticNodelet::updateDiagnostic(stat);
   }
+#endif
   
   int ClusterPointIndicesDecomposer::findNearestPlane(
     const Eigen::Vector4f& center,
@@ -667,7 +669,9 @@ namespace jsk_pcl_ros
     const jsk_recognition_msgs::PolygonArrayConstPtr& planes,
     const jsk_recognition_msgs::ModelCoefficientsArrayConstPtr& coefficients)
   {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     if (publish_clouds_) {
       allocatePublishers(indices_input->cluster_indices.size());
     }

--- a/jsk_pcl_ros/src/collision_detector_nodelet.cpp
+++ b/jsk_pcl_ros/src/collision_detector_nodelet.cpp
@@ -41,7 +41,7 @@ namespace jsk_pcl_ros
 {
   void CollisionDetector::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     initSelfMask();
     pnh_->param<std::string>("world_frame_id", world_frame_id_, "map");
     sub_ = pnh_->subscribe("input", 1, &CollisionDetector::pointcloudCallback, this);
@@ -124,7 +124,9 @@ namespace jsk_pcl_ros
   void CollisionDetector::pointcloudCallback(const sensor_msgs::PointCloud2::ConstPtr& msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     NODELET_DEBUG("update pointcloud.");
 
     pcl::fromROSMsg(*msg, cloud_);

--- a/jsk_pcl_ros/src/color_based_region_growing_segmentation_nodelet.cpp
+++ b/jsk_pcl_ros/src/color_based_region_growing_segmentation_nodelet.cpp
@@ -46,7 +46,7 @@ namespace jsk_pcl_ros
 
   void ColorBasedRegionGrowingSegmentation::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f=
       boost::bind (&ColorBasedRegionGrowingSegmentation::configCallback, this, _1, _2);
@@ -114,7 +114,9 @@ namespace jsk_pcl_ros
       indices.indices = clusters[i].indices;
       output.cluster_indices.push_back(indices);
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(output);
   }
 }

--- a/jsk_pcl_ros/src/color_filter_nodelet.cpp
+++ b/jsk_pcl_ros/src/color_filter_nodelet.cpp
@@ -291,13 +291,17 @@ namespace jsk_pcl_ros
         unsigned char rgb_packed_[4] = {r_, g_, b_, 0};
         memcpy((void *)(&(color_space_msg_.data[j*16+12])), (const void *)rgb_packed_, 4*sizeof(unsigned char));
       }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       color_space_pub_.publish(color_space_msg_);
     }
 
     if (tmp_out.points.size() > 0) {
       toROSMsg(tmp_out, out);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_.publish(out);
     }
   }
@@ -311,7 +315,7 @@ namespace jsk_pcl_ros
   template <class PackedComparison, typename Config>
   void ColorFilter<PackedComparison, Config>::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     color_space_pub_ = pnh_->advertise<sensor_msgs::PointCloud2>("color_space", 1);
     color_space_msg_.header.frame_id = "/map";

--- a/jsk_pcl_ros/src/color_histogram_classifier_nodelet.cpp
+++ b/jsk_pcl_ros/src/color_histogram_classifier_nodelet.cpp
@@ -45,7 +45,7 @@ namespace jsk_pcl_ros
 {
   void ColorHistogramClassifier::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     classifier_name_ = "color_histogram";
 
     if (!loadReference()) return;
@@ -166,14 +166,18 @@ namespace jsk_pcl_ros
       result.label_proba.push_back(0.0);
     }
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_class_.publish(result);
   }
 
   void ColorHistogramClassifier::features(const jsk_recognition_msgs::ColorHistogramArray::ConstPtr& histograms)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
 
     jsk_recognition_msgs::ClassificationResult result;
     result.header = histograms->header;
@@ -206,7 +210,9 @@ namespace jsk_pcl_ros
       }
     }
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_class_.publish(result);
   }
 }

--- a/jsk_pcl_ros/src/color_histogram_filter_nodelet.cpp
+++ b/jsk_pcl_ros/src/color_histogram_filter_nodelet.cpp
@@ -44,7 +44,7 @@ namespace jsk_pcl_ros
 {
   void ColorHistogramFilter::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     pnh_->param("reference_histogram", reference_histogram_, std::vector<float>());
     if (reference_histogram_.empty()) {
@@ -143,7 +143,9 @@ namespace jsk_pcl_ros
       }
     }
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_histogram_.publish(out_hist);
     pub_indices_.publish(out_indices);
   }

--- a/jsk_pcl_ros/src/color_histogram_matcher_nodelet.cpp
+++ b/jsk_pcl_ros/src/color_histogram_matcher_nodelet.cpp
@@ -50,7 +50,7 @@ namespace jsk_pcl_ros
 {
   void ColorHistogramMatcher::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&ColorHistogramMatcher::configCallback, this, _1, _2);
@@ -187,7 +187,9 @@ namespace jsk_pcl_ros
       ros_histogram.histogram = histogram;
       histogram_array.histograms.push_back(ros_histogram);
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     all_histogram_pub_.publish(histogram_array);
 
     // compare histograms
@@ -388,7 +390,9 @@ namespace jsk_pcl_ros
     jsk_recognition_msgs::ColorHistogram ros_histogram;
     ros_histogram.header = input_cloud->header;
     ros_histogram.histogram = reference_histogram_;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     reference_histogram_pub_.publish(ros_histogram);
   }
   
@@ -398,7 +402,9 @@ namespace jsk_pcl_ros
     boost::mutex::scoped_lock lock(mutex_);
     NODELET_INFO("update reference");
     reference_histogram_ = input_histogram->histogram;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     reference_histogram_pub_.publish(input_histogram);
     reference_set_ = true;
   }

--- a/jsk_pcl_ros/src/color_histogram_nodelet.cpp
+++ b/jsk_pcl_ros/src/color_histogram_nodelet.cpp
@@ -51,7 +51,7 @@ namespace jsk_pcl_ros
 {
   void ColorHistogram::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared<dynamic_reconfigure::Server<Config> >(*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind(&ColorHistogram::configCallback, this, _1, _2);
@@ -150,7 +150,9 @@ namespace jsk_pcl_ros
         return;
       }
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_histogram_.publish(histogram_array);
   }
 }

--- a/jsk_pcl_ros/src/colorize_random_points_RF_nodelet.cpp
+++ b/jsk_pcl_ros/src/colorize_random_points_RF_nodelet.cpp
@@ -39,7 +39,7 @@ namespace jsk_pcl_ros
 {
   void ColorizeMapRandomForest::onInit(void)
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);
     
     srand(time(NULL));
@@ -238,7 +238,9 @@ namespace jsk_pcl_ros
     pcl::toROSMsg(*cloud_normals, _pointcloud2);
     _pointcloud2.header = pc.header;
     _pointcloud2.is_dense = false;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(_pointcloud2);
   }
 }

--- a/jsk_pcl_ros/src/container_occupancy_detector_nodelet.cpp
+++ b/jsk_pcl_ros/src/container_occupancy_detector_nodelet.cpp
@@ -42,7 +42,7 @@
 namespace jsk_pcl_ros{
 
     void ContainerOccupancyDetector::onInit(){
-        jsk_topic_tools::DiagnosticNodelet::onInit();
+        jsk_topic_tools::NODELET::onInit();
         pnh_->param("approximate_sync", approximate_sync_, false);
         pnh_->param("queue_size", queue_size_, 100);
         boxes_occupancy_pub_
@@ -131,7 +131,9 @@ namespace jsk_pcl_ros{
                     }
                     result_.boxes.at(i_box).value = sum_occupancy_ / float(n_points_);
                 }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
                 vital_checker_->poke();
+#endif
                 boxes_occupancy_pub_.publish(result_);
             }else{
                 NODELET_WARN("Failed to transform point cloud\n");
@@ -162,7 +164,7 @@ namespace jsk_pcl_ros{
             return false;
         }
     }
-
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     void ContainerOccupancyDetector::updateDiagnostic(
         diagnostic_updater::DiagnosticStatusWrapper &stat){
         if(vital_checker_ -> isAlive()){
@@ -171,6 +173,7 @@ namespace jsk_pcl_ros{
         }
         DiagnosticNodelet::updateDiagnostic(stat);
     }
+#endif
 }
 
 #include <pluginlib/class_list_macros.h>

--- a/jsk_pcl_ros/src/convex_connected_voxels_nodelet.cpp
+++ b/jsk_pcl_ros/src/convex_connected_voxels_nodelet.cpp
@@ -39,7 +39,7 @@ namespace jsk_pcl_ros
 {   
     void ConvexConnectedVoxels::onInit()
     {
-       DiagnosticNodelet::onInit();
+       jsk_topic_tools::NODELET::onInit();
        pub_indices_ = advertise<
           jsk_recognition_msgs::ClusterPointIndices>(
              *pnh_, "output/indices", 1);
@@ -68,7 +68,6 @@ namespace jsk_pcl_ros
        // ROS_INFO("PROCESSING CLOUD CALLBACK");
        
        // boost::mutex::scoped_lock lock(this->mutex_);
-       // vital_checker_->poke();
        pcl::PointCloud<PointT>::Ptr cloud (new pcl::PointCloud<PointT>);
        pcl::fromROSMsg(*cloud_msg, *cloud);
        std::vector<pcl::PointCloud<PointT>::Ptr> cloud_clusters;
@@ -105,7 +104,9 @@ namespace jsk_pcl_ros
        ros_indices.cluster_indices = pcl_conversions::convertToROSPointIndices(
           all_indices, cloud_msg->header);
        ros_indices.header = cloud_msg->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
        vital_checker_->poke();
+#endif
        pub_indices_.publish(ros_indices);
     }
 

--- a/jsk_pcl_ros/src/depth_calibration_nodelet.cpp
+++ b/jsk_pcl_ros/src/depth_calibration_nodelet.cpp
@@ -42,7 +42,7 @@ namespace jsk_pcl_ros
 {
   void DepthCalibration::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     if (pnh_->hasParam("coefficients2")) {
       jsk_topic_tools::readVectorParameter(
         *pnh_, "coefficients2", coefficients2_);
@@ -163,7 +163,9 @@ namespace jsk_pcl_ros
       }
     }
     sensor_msgs::Image::Ptr ros_image = cv_bridge::CvImage(msg->header, "32FC1", output_image).toImageMsg();
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(ros_image);
   }
 

--- a/jsk_pcl_ros/src/depth_image_creator_nodelet.cpp
+++ b/jsk_pcl_ros/src/depth_image_creator_nodelet.cpp
@@ -43,7 +43,7 @@
 
 void jsk_pcl_ros::DepthImageCreator::onInit () {
   NODELET_INFO("[%s::onInit]", getName().c_str());
-  DiagnosticNodelet::onInit();
+  jsk_topic_tools::NODELET::onInit();
   tf_listener_ = TfListenerSingleton::getInstance();
   // scale_depth
   pnh_->param("scale_depth", scale_depth, 1.0);
@@ -322,7 +322,9 @@ void jsk_pcl_ros::DepthImageCreator::publish_points(const sensor_msgs::CameraInf
     cv::resize(depth_mat, depth_mat, cv::Size(info->width, info->height));
   }
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
   vital_checker_->poke();
+#endif
   if (proc_image) {
     pub_image_.publish(cv_bridge::CvImage(info->header,
                                           sensor_msgs::image_encodings::RGB8,

--- a/jsk_pcl_ros/src/edge_depth_refinement_nodelet.cpp
+++ b/jsk_pcl_ros/src/edge_depth_refinement_nodelet.cpp
@@ -45,7 +45,7 @@ namespace jsk_pcl_ros
 {
   void EdgeDepthRefinement::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     ////////////////////////////////////////////////////////
     // publishers
@@ -397,7 +397,9 @@ namespace jsk_pcl_ros
       output_edge_msg.end_point.z = coefficients[i]->values[2] + coefficients[i]->values[5];
       output_ros_edges_msg.segments.push_back(output_edge_msg);
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub.publish(output_ros_msg);
     pub_coefficients.publish(output_ros_coefficients_msg);
     pub_edges.publish(output_ros_edges_msg);

--- a/jsk_pcl_ros/src/edgebased_cube_finder_nodelet.cpp
+++ b/jsk_pcl_ros/src/edgebased_cube_finder_nodelet.cpp
@@ -376,7 +376,7 @@ namespace jsk_pcl_ros
   
   void EdgebasedCubeFinder::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     
 
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
@@ -726,7 +726,9 @@ namespace jsk_pcl_ros
      pose_array.header = input_cloud->header;
      std::vector<jsk_recognition_utils::Cube::Ptr> cubes;
      std::vector<pcl::PointIndices::Ptr> candidate_cluster_indices;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
      vital_checker_->poke();
+#endif
      for (size_t i = 0; i < input_edges->edge_groups.size(); i++) {
        jsk_recognition_msgs::ParallelEdge parallel_edge = input_edges->edge_groups[i];
        std::vector<pcl::PointIndices::Ptr> edges

--- a/jsk_pcl_ros/src/environment_plane_modeling_nodelet.cpp
+++ b/jsk_pcl_ros/src/environment_plane_modeling_nodelet.cpp
@@ -53,7 +53,7 @@ namespace jsk_pcl_ros
 {
   void EnvironmentPlaneModeling::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     typename dynamic_reconfigure::Server<Config>::CallbackType f =
@@ -283,7 +283,9 @@ namespace jsk_pcl_ros
       std::vector<jsk_recognition_utils::ConvexPolygon::Ptr> convexes = convertToConvexPolygons(cloud, indices_msg, coefficients_msg);
       // magnify convexes
       std::vector<jsk_recognition_utils::ConvexPolygon::Ptr> magnified_convexes = magnifyConvexes(convexes);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       publishConvexPolygonsBoundaries(pub_debug_convex_point_cloud_, cloud_msg->header, magnified_convexes);
       // Publish magnified convexes for debug
       publishConvexPolygons(pub_debug_magnified_polygons_, cloud_msg->header, magnified_convexes);

--- a/jsk_pcl_ros/src/euclidean_cluster_extraction_nodelet.cpp
+++ b/jsk_pcl_ros/src/euclidean_cluster_extraction_nodelet.cpp
@@ -267,7 +267,9 @@ namespace jsk_pcl_ros
       result.cluster_indices[i].indices = clustered_indices[i].indices;
     }
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     result_pub_.publish(result);
     
     jsk_recognition_msgs::Int32Stamped::Ptr cluster_num_msg (new jsk_recognition_msgs::Int32Stamped);
@@ -275,13 +277,17 @@ namespace jsk_pcl_ros
     cluster_num_msg->data = clustered_indices.size();
     cluster_num_pub_.publish(cluster_num_msg);
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     diagnostic_updater_->update();
+#endif
   }
 
   void EuclideanClustering::multi_extract(
     const jsk_recognition_msgs::ClusterPointIndices::ConstPtr& input_cluster_indices,
     const sensor_msgs::PointCloud2::ConstPtr& input) {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pcl::PointCloud<pcl::PointXYZ>::Ptr cloud
       (new pcl::PointCloud<pcl::PointXYZ>);
     pcl::fromROSMsg(*input, *cloud);
@@ -311,7 +317,9 @@ namespace jsk_pcl_ros
       result.cluster_indices[i].indices = clustered_indices[i].indices;
     }
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     result_pub_.publish(result);
 
     jsk_recognition_msgs::Int32Stamped::Ptr cluster_num_msg (new jsk_recognition_msgs::Int32Stamped);
@@ -319,7 +327,9 @@ namespace jsk_pcl_ros
     cluster_num_msg->data = clustered_indices.size();
     cluster_num_pub_.publish(cluster_num_msg);
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     diagnostic_updater_->update();
+#endif
   }
 
   bool EuclideanClustering::serviceCallback(
@@ -378,7 +388,7 @@ namespace jsk_pcl_ros
 
   void EuclideanClustering::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     pnh_->param("multi", multi_, false);
     pnh_->param("approximate_sync", approximate_sync_, false);
@@ -446,7 +456,8 @@ namespace jsk_pcl_ros
       sub_input_.shutdown();
     }
   }
-  
+
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
   void EuclideanClustering::updateDiagnostic(
     diagnostic_updater::DiagnosticStatusWrapper &stat)
   {
@@ -472,6 +483,7 @@ namespace jsk_pcl_ros
     }
     DiagnosticNodelet::updateDiagnostic(stat);
   }
+#endif
   
   void EuclideanClustering::configCallback (Config &config, uint32_t level)
   {

--- a/jsk_pcl_ros/src/extract_cuboid_particles_top_n_nodelet.cpp
+++ b/jsk_pcl_ros/src/extract_cuboid_particles_top_n_nodelet.cpp
@@ -43,7 +43,7 @@ namespace jsk_pcl_ros
   // Do nothing
   void ExtractCuboidParticlesTopN::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     typename dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&ExtractCuboidParticlesTopN::configCallback, this, _1, _2);
@@ -93,7 +93,9 @@ namespace jsk_pcl_ros
     ex.setInputCloud(cloud);
     ex.setIndices(indices);
     ex.filter(*cloud_filtered);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     publishPointIndices(pub_, *indices, msg->header);
     publishBoxArray(*cloud_filtered, msg->header);
     publishPoseArray(*cloud_filtered, msg->header);

--- a/jsk_pcl_ros/src/extract_indices_nodelet.cpp
+++ b/jsk_pcl_ros/src/extract_indices_nodelet.cpp
@@ -49,7 +49,7 @@ namespace jsk_pcl_ros
 {
   void ExtractIndices::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("keep_organized", keep_organized_, false);
     pnh_->param("negative", negative_, false);
     pnh_->param("max_queue_size", max_queue_size_, 10);
@@ -133,7 +133,9 @@ namespace jsk_pcl_ros
     pcl_conversions::moveFromPCL(output, out_cloud_msg);
 
     out_cloud_msg.header = cloud_msg->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(out_cloud_msg);
   }
 }

--- a/jsk_pcl_ros/src/feature_registration_nodelet.cpp
+++ b/jsk_pcl_ros/src/feature_registration_nodelet.cpp
@@ -45,7 +45,7 @@ namespace jsk_pcl_ros
 {
   void FeatureRegistration::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     typename dynamic_reconfigure::Server<Config>::CallbackType f =
@@ -157,7 +157,9 @@ namespace jsk_pcl_ros
     // Maximum allowable difference between two consecutive transformations
     align.setTransformationEpsilon(transformation_epsilon_);
     align.align (*object_aligned);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     if (align.hasConverged ())
     {
       // Print results

--- a/jsk_pcl_ros/src/find_object_on_plane_nodelet.cpp
+++ b/jsk_pcl_ros/src/find_object_on_plane_nodelet.cpp
@@ -42,7 +42,7 @@ namespace jsk_pcl_ros
 {
   void FindObjectOnPlane::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_min_area_rect_image_ = advertise<sensor_msgs::Image>(
       *pnh_, "debug/min_area_rect_image", 1);
     onInitPostProcess();
@@ -151,7 +151,9 @@ namespace jsk_pcl_ros
     drawAngle(min_area_rect_image, min_search_point, min_angle,
               min_x, min_y, model, plane, cv::Scalar(0, 255, 255));
     // convert the points into 3-D
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_min_area_rect_image_.publish(
       cv_bridge::CvImage(image_msg->header,
                          sensor_msgs::image_encodings::BGR8,

--- a/jsk_pcl_ros/src/fisheye_sphere_publisher_nodelet.cpp
+++ b/jsk_pcl_ros/src/fisheye_sphere_publisher_nodelet.cpp
@@ -80,7 +80,9 @@ namespace jsk_pcl_ros
     pcl::toROSMsg(pointcloud, pc2);
     pc2.header.frame_id = "fisheye";
     pc2.header.stamp = ros::Time::now();
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_sphere_.publish(pc2);
   }
 
@@ -103,7 +105,7 @@ namespace jsk_pcl_ros
 
   void FisheyeSpherePublisher::onInit(void)
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     downsample_rate_ = 0.5;
     sphere_radius_ = 1.0;
     pub_sphere_ = pnh_->advertise<sensor_msgs::PointCloud2>("output", 1);

--- a/jsk_pcl_ros/src/fuse_images.cpp
+++ b/jsk_pcl_ros/src/fuse_images.cpp
@@ -47,7 +47,7 @@ namespace jsk_pcl_ros
 {
   void FuseImages::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_out_ = advertise<sensor_msgs::Image>(*pnh_, "output", 1);
     onInitPostProcess();
   }
@@ -263,7 +263,9 @@ namespace jsk_pcl_ros
     validateInput(in8, height, width, inputs);
 
     cv::Mat out = fuseInputs(inputs);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_out_.publish(cv_bridge::CvImage(in1->header, encoding_, out).toImageMsg());
   }
 

--- a/jsk_pcl_ros/src/geometric_consistency_grouping_nodelet.cpp
+++ b/jsk_pcl_ros/src/geometric_consistency_grouping_nodelet.cpp
@@ -43,7 +43,7 @@ namespace jsk_pcl_ros
 {
   void GeometricConsistencyGrouping::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     typename dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&GeometricConsistencyGrouping::configCallback, this, _1, _2);
@@ -162,7 +162,9 @@ namespace jsk_pcl_ros
     std::vector<Eigen::Matrix4f,
                 Eigen::aligned_allocator<Eigen::Matrix4f> > rototranslations;
     gc_clusterer.recognize(rototranslations, clustered_corrs);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     if (rototranslations.size() > 0) {
       NODELET_INFO("detected %lu objects", rototranslations.size());
       Eigen::Matrix4f result_mat = rototranslations[0];

--- a/jsk_pcl_ros/src/grid_sampler_nodelet.cpp
+++ b/jsk_pcl_ros/src/grid_sampler_nodelet.cpp
@@ -42,7 +42,7 @@ namespace jsk_pcl_ros
 {
   void GridSampler::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<jsk_recognition_msgs::ClusterPointIndices>(*pnh_, "output", 1);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&GridSampler::configCallback, this, _1, _2);
@@ -166,7 +166,9 @@ namespace jsk_pcl_ros
         }
       }
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(output);
   }
 }

--- a/jsk_pcl_ros/src/handle_estimator_nodelet.cpp
+++ b/jsk_pcl_ros/src/handle_estimator_nodelet.cpp
@@ -44,7 +44,7 @@ namespace jsk_pcl_ros
 {
   void HandleEstimator::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     output_buf.resize(100);
 
     pnh_->param("gripper_size", gripper_size_, 0.08); // defaults to pr2 gripper size
@@ -210,7 +210,9 @@ namespace jsk_pcl_ros
     best.header = pose_array.header;
     best.pose = pose_array.poses[pose_array.poses.size() / 2];
     pub_best_.publish(best);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
 
     output_buf.push_front(boost::make_tuple(pose_array, prepose_array));
   }
@@ -277,7 +279,9 @@ namespace jsk_pcl_ros
     best.header = pose_array.header;
     best.pose = pose_array.poses[pose_array.poses.size() / 2];
     pub_best_.publish(best);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
 
     output_buf.push_front(boost::make_tuple(pose_array, prepose_array));
   }
@@ -296,7 +300,9 @@ namespace jsk_pcl_ros
 
 	ps.header = prepose_array.header;
 	ps.pose = prepose_array.poses[index->data];
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
   vital_checker_->poke();
+#endif
 	pub_selected_preapproach_.publish(ps);
 	break;
       }

--- a/jsk_pcl_ros/src/heightmap_converter_nodelet.cpp
+++ b/jsk_pcl_ros/src/heightmap_converter_nodelet.cpp
@@ -46,7 +46,7 @@ namespace jsk_pcl_ros
 {
   void HeightmapConverter::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_config_ = pnh_->advertise<jsk_recognition_msgs::HeightmapConfig>(
       "output/config", 1, true);
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
@@ -163,7 +163,9 @@ namespace jsk_pcl_ros
     cv_bridge::CvImage height_map_image(msg_header,
                                         sensor_msgs::image_encodings::TYPE_32FC2,
                                         height_map);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(height_map_image.toImageMsg());
   }
 

--- a/jsk_pcl_ros/src/heightmap_morphological_filtering_nodelet.cpp
+++ b/jsk_pcl_ros/src/heightmap_morphological_filtering_nodelet.cpp
@@ -42,7 +42,7 @@ namespace jsk_pcl_ros
 {
   void HeightmapMorphologicalFiltering::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_config_ = pnh_->advertise<jsk_recognition_msgs::HeightmapConfig>("output/config",
                                                                          1, true);
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
@@ -198,7 +198,9 @@ namespace jsk_pcl_ros
       cv::merge(ret_images, filtered_image);
     }
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(cv_bridge::CvImage(
                    msg->header,
                    sensor_msgs::image_encodings::TYPE_32FC2,

--- a/jsk_pcl_ros/src/heightmap_time_accumulation_nodelet.cpp
+++ b/jsk_pcl_ros/src/heightmap_time_accumulation_nodelet.cpp
@@ -45,7 +45,7 @@ namespace jsk_pcl_ros
 {
   void HeightmapTimeAccumulation::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_config_ = pnh_->advertise<jsk_recognition_msgs::HeightmapConfig>(
       "output/config", 1, true);
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
@@ -97,7 +97,9 @@ namespace jsk_pcl_ros
   void HeightmapTimeAccumulation::publishHeightmap(
     const cv::Mat& heightmap, const std_msgs::Header& header)
   {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_output_.publish(cv_bridge::CvImage(
                           header,
                           sensor_msgs::image_encodings::TYPE_32FC2,

--- a/jsk_pcl_ros/src/heightmap_to_pointcloud_nodelet.cpp
+++ b/jsk_pcl_ros/src/heightmap_to_pointcloud_nodelet.cpp
@@ -46,7 +46,7 @@ namespace jsk_pcl_ros
 {
   void HeightmapToPointCloud::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_config_ = pnh_->advertise<jsk_recognition_msgs::HeightmapConfig>(
       "output/config", 1);
     sub_config_ = pnh_->subscribe(
@@ -101,7 +101,9 @@ namespace jsk_pcl_ros
     sensor_msgs::PointCloud2 ros_cloud;
     pcl::toROSMsg(cloud, ros_cloud);
     ros_cloud.header = msg->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(ros_cloud);
   }
 }

--- a/jsk_pcl_ros/src/hinted_handle_estimator_nodelet.cpp
+++ b/jsk_pcl_ros/src/hinted_handle_estimator_nodelet.cpp
@@ -53,7 +53,7 @@ namespace jsk_pcl_ros
 {
   void HintedHandleEstimator::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_pose_ = advertise<geometry_msgs::PoseStamped>(
                                                       *pnh_, "handle_pose", 1);
     pub_length_ = advertise<std_msgs::Float64>(
@@ -277,7 +277,9 @@ namespace jsk_pcl_ros
     handle_pose_stamped.pose.orientation.w = min_qua.getW();
     std_msgs::Float64 min_width_msg;
     min_width_msg.data = min_width;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_pose_.publish(handle_pose_stamped);
     pub_debug_marker_.publish(debug_hand_marker);
     pub_debug_marker_array_.publish(make_handle_array(handle_pose_stamped, handle));

--- a/jsk_pcl_ros/src/hinted_plane_detector_nodelet.cpp
+++ b/jsk_pcl_ros/src/hinted_plane_detector_nodelet.cpp
@@ -51,7 +51,7 @@ namespace jsk_pcl_ros {
   
   void HintedPlaneDetector::onInit() {
     pcl::console::setVerbosityLevel(pcl::console::L_ERROR);
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     typename dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&HintedPlaneDetector::configCallback, this, _1, _2);
@@ -137,7 +137,9 @@ namespace jsk_pcl_ros {
     const sensor_msgs::PointCloud2::ConstPtr& cloud_msg,
     const sensor_msgs::PointCloud2::ConstPtr& hint_cloud_msg)
   {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     boost::mutex::scoped_lock lock(mutex_);
     pcl::PointCloud<pcl::PointNormal>::Ptr
       input_cloud (new pcl::PointCloud<pcl::PointNormal>);
@@ -345,7 +347,9 @@ namespace jsk_pcl_ros {
       = jsk_recognition_utils::convexFromCoefficientsAndInliers<pcl::PointNormal>(
         input_cloud, density_filtered_indices, plane_coefficients);
     // publish to ROS
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     publishPolygon(convex, pub_polygon_, pub_polygon_array_,
                    input_cloud->header);
     PCLIndicesMsg ros_inliers;
@@ -388,7 +392,9 @@ namespace jsk_pcl_ros {
     seg.setMaxIterations (hint_max_iteration_);
     seg.setInputCloud(hint_cloud);
     seg.segment(*hint_inliers, *hint_coefficients);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     if (hint_inliers->indices.size() > hint_min_size_) { // good!
       convex = jsk_recognition_utils::convexFromCoefficientsAndInliers<pcl::PointXYZ>(
         hint_cloud, hint_inliers, hint_coefficients);

--- a/jsk_pcl_ros/src/hinted_stick_finder_nodelet.cpp
+++ b/jsk_pcl_ros/src/hinted_stick_finder_nodelet.cpp
@@ -48,7 +48,7 @@ namespace jsk_pcl_ros
 {
   void HintedStickFinder::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     typename dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&HintedStickFinder::configCallback, this, _1, _2);
@@ -253,7 +253,9 @@ namespace jsk_pcl_ros
     seg.setProbability(min_probability_);
     seg.setInputCloud(filtered_cloud);
     seg.setInputNormals(cloud_normals);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     for (size_t i = 0; i < cylinder_fitting_trial_; i++) {
       seg.segment(*inliers, *coefficients);
       if (inliers->indices.size() > min_inliers_) {
@@ -332,7 +334,9 @@ namespace jsk_pcl_ros
     output_indices.header = cloud->header;
     PCLIndicesMsg ros_indices;
     pcl_conversions::fromPCL(output_indices, ros_indices);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_line_filtered_indices_.publish(ros_indices);
   }
 

--- a/jsk_pcl_ros/src/icp_registration_nodelet.cpp
+++ b/jsk_pcl_ros/src/icp_registration_nodelet.cpp
@@ -54,7 +54,7 @@ namespace jsk_pcl_ros
   void ICPRegistration::onInit()
   {
     pcl::console::setVerbosityLevel(pcl::console::L_ERROR);
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     tf_listener_ = TfListenerSingleton::getInstance();
     ////////////////////////////////////////////////////////
     // Dynamic Reconfigure
@@ -311,7 +311,9 @@ namespace jsk_pcl_ros
       result.header = box_msg->header;
       result.pose = box_msg->pose;
       pub_icp_result.publish(result);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       return;
     }
     try
@@ -325,7 +327,9 @@ namespace jsk_pcl_ros
       Eigen::Affine3f inversed_offset = offset.inverse();
       jsk_recognition_msgs::ICPResult result = alignPointcloudWithReferences(output, inversed_offset, msg->header);
       pub_icp_result.publish(result);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
     }
     catch (tf2::ConnectivityException &e)
     {
@@ -354,7 +358,9 @@ namespace jsk_pcl_ros
       result.header = offset_msg->header;
       result.pose = offset_msg->pose;
       pub_icp_result.publish(result);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       return;
     }
     try
@@ -376,7 +382,9 @@ namespace jsk_pcl_ros
       pcl::transformPointCloud(*input, *output, inversed_offset);
       jsk_recognition_msgs::ICPResult result = alignPointcloudWithReferences(output, offset, msg->header);
       pub_icp_result.publish(result);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
     }
     catch (tf2::ConnectivityException &e)
     {
@@ -414,7 +422,9 @@ namespace jsk_pcl_ros
     }
     jsk_recognition_msgs::ICPResult result = alignPointcloudWithReferences(non_nan_cloud, offset, msg->header);
     pub_icp_result.publish(result);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
   }
   
   void ICPRegistration::align(const sensor_msgs::PointCloud2::ConstPtr& msg,
@@ -460,7 +470,9 @@ namespace jsk_pcl_ros
       sensor_msgs::PointCloud2 empty_cloud;
       empty_cloud.header = header;
       pub_result_cloud_.publish(empty_cloud);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
 
       pcl::PointCloud<PointT> empty_pcl_cloud;
       publishDebugCloud(pub_debug_source_cloud_, empty_pcl_cloud, header);
@@ -503,7 +515,9 @@ namespace jsk_pcl_ros
       geometry_msgs::PoseStamped empty_pose;
       empty_pose.header = header;
       pub_result_pose_.publish(empty_pose);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
 
       result.header = header;
       result.score = min_score;
@@ -515,7 +529,9 @@ namespace jsk_pcl_ros
       pcl::toROSMsg(*best_transformed_cloud, ros_final);
       ros_final.header = header;
       pub_result_cloud_.publish(ros_final);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
     }
     geometry_msgs::PoseStamped ros_result_pose;
     ros_result_pose.header = header;

--- a/jsk_pcl_ros/src/incremental_model_registration_nodelet.cpp
+++ b/jsk_pcl_ros/src/incremental_model_registration_nodelet.cpp
@@ -92,7 +92,7 @@ namespace jsk_pcl_ros
   
   void IncrementalModelRegistration::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("frame_id", frame_id_,
                 std::string("multisense/left_camera_optical_frame"));
     start_registration_srv_
@@ -179,7 +179,9 @@ namespace jsk_pcl_ros
     sensor_msgs::PointCloud2 ros_all_cloud;
     pcl::toROSMsg(all_cloud_, ros_all_cloud);
     ros_all_cloud.header = cloud_msg->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_cloud_non_registered_.publish(ros_all_cloud);
   }
 

--- a/jsk_pcl_ros/src/interactive_cuboid_likelihood_nodelet.cpp
+++ b/jsk_pcl_ros/src/interactive_cuboid_likelihood_nodelet.cpp
@@ -42,7 +42,7 @@ namespace jsk_pcl_ros
 {
   void InteractiveCuboidLikelihood::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     tf_ = TfListenerSingleton::getInstance();
     pub_ = pnh_->advertise<std_msgs::Float32>("output", 1);
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
@@ -144,7 +144,9 @@ namespace jsk_pcl_ros
     NODELET_INFO("likelihood: %f", l);
     std_msgs::Float32 float_msg;
     float_msg.data = l;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(float_msg);
   }
 

--- a/jsk_pcl_ros/src/intermittent_image_annotator_nodelet.cpp
+++ b/jsk_pcl_ros/src/intermittent_image_annotator_nodelet.cpp
@@ -46,7 +46,7 @@ namespace jsk_pcl_ros
 {
   void IntermittentImageAnnotator::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     listener_ = TfListenerSingleton::getInstance();
     last_publish_time_ = ros::Time::now();
     pnh_->param("fixed_frame_id", fixed_frame_id_, std::string("odom"));
@@ -290,7 +290,9 @@ namespace jsk_pcl_ros
       const sensor_msgs::CameraInfo::ConstPtr& info_msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     latest_image_msg_ = image_msg;
     latest_camera_info_msg_ = info_msg;
 

--- a/jsk_pcl_ros/src/joint_state_static_filter_nodelet.cpp
+++ b/jsk_pcl_ros/src/joint_state_static_filter_nodelet.cpp
@@ -41,7 +41,7 @@ namespace jsk_pcl_ros
 {
   void JointStateStaticFilter::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     if (!jsk_topic_tools::readVectorParameter(*pnh_,
                                               "joint_names",
@@ -76,7 +76,9 @@ namespace jsk_pcl_ros
   {
     boost::mutex::scoped_lock lock(mutex_);
     NODELET_DEBUG("Pointcloud Callback");
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     if (isStatic(msg->header.stamp)) {
       ROS_DEBUG("static");
       pub_.publish(msg);
@@ -138,7 +140,9 @@ namespace jsk_pcl_ros
       NODELET_DEBUG("cannot find the joints from the input message");
       return;
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
 
     // check the previous state...
     if (previous_joints_.size() > 0) {

--- a/jsk_pcl_ros/src/keypoints_publisher_nodelet.cpp
+++ b/jsk_pcl_ros/src/keypoints_publisher_nodelet.cpp
@@ -47,7 +47,7 @@ namespace jsk_pcl_ros
 {
   void KeypointsPublisher::onInit(void)
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     
     input_.reset(new pcl::PointCloud<pcl::PointXYZ>);
     keypoints_pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "nerf_keypoints", 10);
@@ -98,7 +98,9 @@ namespace jsk_pcl_ros
     sensor_msgs::PointCloud2 resMsg;
     pcl::toROSMsg(result, resMsg);
     resMsg.header = input_header_;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     keypoints_pub_.publish(resMsg);
   }
   

--- a/jsk_pcl_ros/src/kinfu_nodelet.cpp
+++ b/jsk_pcl_ros/src/kinfu_nodelet.cpp
@@ -82,7 +82,7 @@ namespace jsk_pcl_ros
   void
   Kinfu::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     always_subscribe_ = true;  // for mapping
 
     pnh_->param("device", device_, 0);
@@ -210,7 +210,9 @@ namespace jsk_pcl_ros
                 const sensor_msgs::Image::ConstPtr& color_msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
 
     if ((depth_msg->height != caminfo_msg->height) || (depth_msg->width != caminfo_msg->width))
     {

--- a/jsk_pcl_ros/src/line_segment_collector_nodelet.cpp
+++ b/jsk_pcl_ros/src/line_segment_collector_nodelet.cpp
@@ -125,7 +125,7 @@ namespace jsk_pcl_ros
   
   void LineSegmentCollector::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&LineSegmentCollector::configCallback, this, _1, _2);
@@ -355,7 +355,9 @@ namespace jsk_pcl_ros
       const jsk_recognition_msgs::ModelCoefficientsArray::ConstPtr& coefficients_msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     //NODELET_INFO("buffer length: %lu", pointclouds_buffer_.size());
     pointclouds_buffer_.push_back(cloud_msg);
     indices_buffer_.push_back(indices_msg);

--- a/jsk_pcl_ros/src/line_segment_detector_nodelet.cpp
+++ b/jsk_pcl_ros/src/line_segment_detector_nodelet.cpp
@@ -131,7 +131,7 @@ namespace jsk_pcl_ros
   
   void LineSegmentDetector::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     pnh_->param("approximate_sync", approximate_sync_, false);
 
@@ -205,7 +205,9 @@ namespace jsk_pcl_ros
     const pcl::PointCloud<PointT>::Ptr& cloud,
     const std::vector<LineSegment::Ptr>& segments)
   {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     std::vector<pcl::PointIndices::Ptr> indices;
     std::vector<pcl::ModelCoefficients::Ptr> coefficients;
     visualization_msgs::Marker marker;

--- a/jsk_pcl_ros/src/linemod_nodelet.cpp
+++ b/jsk_pcl_ros/src/linemod_nodelet.cpp
@@ -563,7 +563,7 @@ namespace jsk_pcl_ros
 
   void LINEMODDetector::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("template_file", template_file_, std::string("template"));
     // load original point and poses
     template_cloud_.reset(new pcl::PointCloud<pcl::PointXYZRGBA>);
@@ -679,7 +679,9 @@ namespace jsk_pcl_ros
     const sensor_msgs::PointCloud2::ConstPtr& cloud_msg)
   {
     NODELET_INFO("detect");
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     boost::mutex::scoped_lock lock(mutex_);
     pcl::PointCloud<pcl::PointXYZRGBA>::Ptr
       cloud (new pcl::PointCloud<pcl::PointXYZRGBA>);

--- a/jsk_pcl_ros/src/mask_image_cluster_filter_nodelet.cpp
+++ b/jsk_pcl_ros/src/mask_image_cluster_filter_nodelet.cpp
@@ -46,7 +46,7 @@ namespace jsk_pcl_ros
 {
   void MaskImageClusterFilter::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<PCLIndicesMsg>(
       *pnh_, "output", 1);
     onInitPostProcess();
@@ -142,7 +142,9 @@ namespace jsk_pcl_ros
             }
         }
       }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_.publish(indices);
     }
   }

--- a/jsk_pcl_ros/src/mask_image_filter_nodelet.cpp
+++ b/jsk_pcl_ros/src/mask_image_filter_nodelet.cpp
@@ -44,11 +44,11 @@ namespace jsk_pcl_ros
 {
   void MaskImageFilter::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("negative", negative_, false);
     pub_ = advertise<PCLIndicesMsg>(
       *pnh_, "output", 1);
-    DiagnosticNodelet::onInitPostProcess();
+    jsk_topic_tools::NODELET::onInitPostProcess();
   }
 
   void MaskImageFilter::subscribe()
@@ -110,7 +110,9 @@ namespace jsk_pcl_ros
           }
         }
       }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_.publish(indices);
     }
   }

--- a/jsk_pcl_ros/src/moving_least_square_smoothing_nodelet.cpp
+++ b/jsk_pcl_ros/src/moving_least_square_smoothing_nodelet.cpp
@@ -45,7 +45,9 @@ namespace jsk_pcl_ros
   void MovingLeastSquareSmoothing::smooth(const sensor_msgs::PointCloud2ConstPtr& input)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZRGB>);
     pcl::PointCloud<pcl::PointXYZRGB>::Ptr result_cloud(new pcl::PointCloud<pcl::PointXYZRGB>);
     pcl::fromROSMsg(*input, *cloud);
@@ -95,7 +97,7 @@ namespace jsk_pcl_ros
 
   void MovingLeastSquareSmoothing::onInit(void)
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("gauss_param_set", gauss_param_set_, false);
     pnh_->param("search_radius", search_radius_, 0.03);
     pnh_->param("use_polynomial_fit", use_polynomial_fit_, false);

--- a/jsk_pcl_ros/src/multi_plane_extraction_nodelet.cpp
+++ b/jsk_pcl_ros/src/multi_plane_extraction_nodelet.cpp
@@ -49,7 +49,7 @@ namespace jsk_pcl_ros
   void MultiPlaneExtraction::onInit()
   {
     pcl::console::setVerbosityLevel(pcl::console::L_ERROR);
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("use_indices", use_indices_, true);
     pnh_->param("use_async", use_async_, false);
     ////////////////////////////////////////////////////////
@@ -188,6 +188,7 @@ namespace jsk_pcl_ros
     }
   }
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
   void MultiPlaneExtraction::updateDiagnostic(
     diagnostic_updater::DiagnosticStatusWrapper &stat)
   {
@@ -200,6 +201,7 @@ namespace jsk_pcl_ros
     }
     DiagnosticNodelet::updateDiagnostic(stat);
   }
+#endif
 
   void MultiPlaneExtraction::fillEmptyIndices(
     const jsk_recognition_msgs::PolygonArray::ConstPtr &polygons)
@@ -227,7 +229,9 @@ namespace jsk_pcl_ros
                                      const jsk_recognition_msgs::PolygonArray::ConstPtr& polygons)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     // check header
     if(!jsk_recognition_utils::isSameFrameId(input->header.frame_id,
                                              indices->header.frame_id) ||
@@ -383,7 +387,9 @@ namespace jsk_pcl_ros
     pcl_conversions::fromPCL(*all_result_indices, ros_indices);
     ros_indices.header = input->header;
     pub_indices_.publish(ros_indices);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     diagnostic_updater_->update();
+#endif
   }
 }
 

--- a/jsk_pcl_ros/src/multi_plane_sac_segmentation_nodelet.cpp
+++ b/jsk_pcl_ros/src/multi_plane_sac_segmentation_nodelet.cpp
@@ -45,7 +45,7 @@ namespace jsk_pcl_ros
 {
   void MultiPlaneSACSegmentation::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&MultiPlaneSACSegmentation::configCallback, this, _1, _2);
@@ -278,7 +278,9 @@ namespace jsk_pcl_ros
     const jsk_recognition_msgs::ClusterPointIndices::ConstPtr& clusters)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pcl::PointCloud<PointT>::Ptr input (new pcl::PointCloud<PointT>);
     pcl::fromROSMsg(*msg, *input);
     std::vector<pcl::PointIndices::Ptr> cluster_indices
@@ -348,7 +350,9 @@ namespace jsk_pcl_ros
     const sensor_msgs::Imu::ConstPtr& imu_msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pcl::PointCloud<PointT>::Ptr input (new pcl::PointCloud<PointT>);
     pcl::PointCloud<pcl::Normal>::Ptr
       normal (new pcl::PointCloud<pcl::Normal>);
@@ -396,7 +400,9 @@ namespace jsk_pcl_ros
     const sensor_msgs::PointCloud2::ConstPtr& msg_normal)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pcl::PointCloud<PointT>::Ptr input (new pcl::PointCloud<PointT>);
     pcl::PointCloud<pcl::Normal>::Ptr normal (new pcl::PointCloud<pcl::Normal>);
     pcl::fromROSMsg(*msg, *input);

--- a/jsk_pcl_ros/src/normal_direction_filter_nodelet.cpp
+++ b/jsk_pcl_ros/src/normal_direction_filter_nodelet.cpp
@@ -42,7 +42,7 @@ namespace jsk_pcl_ros
 {
   void NormalDirectionFilter::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("use_imu", use_imu_, false);
     if (!use_imu_) {
       std::vector<double> direction;
@@ -141,7 +141,9 @@ namespace jsk_pcl_ros
     const sensor_msgs::Imu::ConstPtr& imu_msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pcl::PointCloud<pcl::Normal>::Ptr normal(new pcl::PointCloud<pcl::Normal>);
     pcl::fromROSMsg(*msg, *normal);
     geometry_msgs::Vector3Stamped stamped_imu, transformed_imu;
@@ -184,7 +186,9 @@ namespace jsk_pcl_ros
     const sensor_msgs::PointCloud2::ConstPtr& msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pcl::PointCloud<pcl::Normal>::Ptr normal(new pcl::PointCloud<pcl::Normal>);
     pcl::fromROSMsg(*msg, *normal);
 

--- a/jsk_pcl_ros/src/normal_estimation_integral_image_nodelet.cpp
+++ b/jsk_pcl_ros/src/normal_estimation_integral_image_nodelet.cpp
@@ -43,7 +43,7 @@ namespace jsk_pcl_ros
 {
   void NormalEstimationIntegralImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
@@ -79,7 +79,9 @@ namespace jsk_pcl_ros
   void NormalEstimationIntegralImage::compute(const sensor_msgs::PointCloud2::ConstPtr& msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
 
     pcl::PointCloud<pcl::PointXYZRGB>::Ptr input(new pcl::PointCloud<pcl::PointXYZRGB>());
     pcl::fromROSMsg(*msg, *input);

--- a/jsk_pcl_ros/src/normal_estimation_omp_nodelet.cpp
+++ b/jsk_pcl_ros/src/normal_estimation_omp_nodelet.cpp
@@ -43,7 +43,7 @@ namespace jsk_pcl_ros
   void NormalEstimationOMP::onInit()
   {
     pcl::console::setVerbosityLevel(pcl::console::L_ERROR);
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("number_of_threads", num_of_threads_, 0);
     NODELET_DEBUG_STREAM("num_of_threads: " << num_of_threads_);
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
@@ -81,7 +81,9 @@ namespace jsk_pcl_ros
     const sensor_msgs::PointCloud2::ConstPtr& cloud_msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     {
       jsk_recognition_utils::ScopedWallDurationReporter r
         = timer_.reporter(pub_latest_time_, pub_average_time_);

--- a/jsk_pcl_ros/src/octomap_server_contact_nodelet.cpp
+++ b/jsk_pcl_ros/src/octomap_server_contact_nodelet.cpp
@@ -44,7 +44,7 @@ namespace jsk_pcl_ros
 {
   OctomapServerContact::OctomapServerContact(const ros::NodeHandle &privateNh)
   : OctomapServer(privateNh),
-    DiagnosticNodelet("OctomapServerContact"),
+    
     m_octreeContact(NULL),
     m_publishUnknownSpace(false),
     m_publishFrontierSpace(false),
@@ -464,7 +464,9 @@ namespace jsk_pcl_ros
   }
 
   void OctomapServerContact::publishAll(const ros::Time& rostime) {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     ros::WallTime startTime = ros::WallTime::now();
     size_t octomapSize = m_octreeContact->size();
     // TODO: estimate num occ. voxels for size of arrays (reserve)
@@ -852,7 +854,7 @@ namespace jsk_pcl_ros
 
   void OctomapServerContact::onInit(void)
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     onInitPostProcess();
   }
 }

--- a/jsk_pcl_ros/src/octree_change_publisher_nodelet.cpp
+++ b/jsk_pcl_ros/src/octree_change_publisher_nodelet.cpp
@@ -40,7 +40,7 @@ namespace jsk_pcl_ros
 {
   void OctreeChangePublisher::onInit(void)
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     counter_ = 0;
 
     pnh_->param("resolution", resolution_, 0.02);
@@ -84,7 +84,9 @@ namespace jsk_pcl_ros
 
   void OctreeChangePublisher::cloud_cb(const sensor_msgs::PointCloud2 &pc)
   {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     if(pc.fields.size() <= 0){
       return;
     }

--- a/jsk_pcl_ros/src/octree_voxel_grid_nodelet.cpp
+++ b/jsk_pcl_ros/src/octree_voxel_grid_nodelet.cpp
@@ -122,7 +122,9 @@ namespace jsk_pcl_ros
   void OctreeVoxelGrid::generateVoxelCloud(const sensor_msgs::PointCloud2ConstPtr& input_msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     if (resolution_ == 0.0) {
       pub_cloud_.publish(input_msg);
       
@@ -172,7 +174,7 @@ namespace jsk_pcl_ros
 
   void OctreeVoxelGrid::onInit(void)
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&OctreeVoxelGrid::configCallback, this, _1, _2);

--- a/jsk_pcl_ros/src/organize_pointcloud_nodelet.cpp
+++ b/jsk_pcl_ros/src/organize_pointcloud_nodelet.cpp
@@ -42,7 +42,9 @@ namespace jsk_pcl_ros
 {
   void OrganizePointCloud::extract(const sensor_msgs::PointCloud2ConstPtr &input)
   {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     // skip empty cloud
     ROS_INFO_STREAM("received input clouds, convert range image, resolution: " << angular_resolution << ", width(deg): " << angle_width << ", height(deg):" << angle_height << ", min_points:" << min_points);
 
@@ -76,7 +78,7 @@ namespace jsk_pcl_ros
 
   void OrganizePointCloud::onInit(void)
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     
     pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);
     pnh_->param<double>("angular_resolution", angular_resolution, 1.0);

--- a/jsk_pcl_ros/src/organized_edge_detector_nodelet.cpp
+++ b/jsk_pcl_ros/src/organized_edge_detector_nodelet.cpp
@@ -51,7 +51,7 @@ namespace jsk_pcl_ros
 {
   void OrganizedEdgeDetector::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     ////////////////////////////////////////////////////////
     // setup dynamic reconfigure
@@ -316,7 +316,9 @@ namespace jsk_pcl_ros
     const sensor_msgs::PointCloud2::ConstPtr& msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     if (msg->height == 1) {
       NODELET_ERROR("[OrganizedEdgeDetector] organized pointcloud is required");
       return;

--- a/jsk_pcl_ros/src/organized_multi_plane_segmentation_nodelet.cpp
+++ b/jsk_pcl_ros/src/organized_multi_plane_segmentation_nodelet.cpp
@@ -64,7 +64,7 @@ namespace jsk_pcl_ros
 
   void OrganizedMultiPlaneSegmentation::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     previous_checked_connection_status_for_plane_ = jsk_topic_tools::NOT_SUBSCRIBED;
     previous_checked_connection_status_for_normal_ = jsk_topic_tools::NOT_SUBSCRIBED;
     pcl::console::setVerbosityLevel(pcl::console::L_ERROR);

--- a/jsk_pcl_ros/src/organized_pass_through_nodelet.cpp
+++ b/jsk_pcl_ros/src/organized_pass_through_nodelet.cpp
@@ -42,7 +42,7 @@ namespace jsk_pcl_ros
 {
   void OrganizedPassThrough::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     ////////////////////////////////////////////////////////
     // Publisher
     ////////////////////////////////////////////////////////
@@ -116,7 +116,9 @@ namespace jsk_pcl_ros
   void OrganizedPassThrough::filter(const sensor_msgs::PointCloud2::ConstPtr& msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pcl::PointCloud<PointT>::Ptr cloud (new pcl::PointCloud<PointT>);
     pcl::fromROSMsg(*msg, *cloud);
     pcl::PointIndices::Ptr indices = filterIndices(cloud);
@@ -132,9 +134,12 @@ namespace jsk_pcl_ros
     pcl::toROSMsg(output, ros_output);
     ros_output.header = msg->header;
     pub_.publish(ros_output);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     diagnostic_updater_->update();
+#endif
   }
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
   void OrganizedPassThrough::updateDiagnostic(
     diagnostic_updater::DiagnosticStatusWrapper &stat)
   {
@@ -162,6 +167,7 @@ namespace jsk_pcl_ros
     }
     DiagnosticNodelet::updateDiagnostic(stat);
   }
+#endif
 }
 
 #include <pluginlib/class_list_macros.h>

--- a/jsk_pcl_ros/src/organized_statistical_outlier_removal_nodelet.cpp
+++ b/jsk_pcl_ros/src/organized_statistical_outlier_removal_nodelet.cpp
@@ -44,7 +44,7 @@ namespace jsk_pcl_ros
 
   void OrganizedStatisticalOutlierRemoval::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);
 
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
@@ -77,7 +77,9 @@ namespace jsk_pcl_ros
   void OrganizedStatisticalOutlierRemoval::filter(const sensor_msgs::PointCloud2::ConstPtr& msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     sensor_msgs::PointCloud2 output;
 
     if (keep_organized_&& msg->is_dense) {
@@ -210,9 +212,12 @@ namespace jsk_pcl_ros
     output.is_dense = !keep_organized;
     pub_.publish(output);
 #endif
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     diagnostic_updater_->update();
+#endif
   }
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
   void OrganizedStatisticalOutlierRemoval::updateDiagnostic(
     diagnostic_updater::DiagnosticStatusWrapper &stat)
   {
@@ -230,6 +235,7 @@ namespace jsk_pcl_ros
     }
     DiagnosticNodelet::updateDiagnostic(stat);
   }
+#endif
 }
 
 #include <pluginlib/class_list_macros.h>

--- a/jsk_pcl_ros/src/parallel_edge_finder_nodelet.cpp
+++ b/jsk_pcl_ros/src/parallel_edge_finder_nodelet.cpp
@@ -41,7 +41,7 @@ namespace jsk_pcl_ros
 {
   void ParallelEdgeFinder::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     
     ////////////////////////////////////////////////////////
     // publishers
@@ -101,7 +101,9 @@ namespace jsk_pcl_ros
     const jsk_recognition_msgs::ModelCoefficientsArray::ConstPtr& input_coefficients)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     ////////////////////////////////////////////////////////
     // first, build Line instances
     ////////////////////////////////////////////////////////

--- a/jsk_pcl_ros/src/particle_filter_tracking_nodelet.cpp
+++ b/jsk_pcl_ros/src/particle_filter_tracking_nodelet.cpp
@@ -54,7 +54,7 @@ namespace jsk_pcl_ros
     // Suppress huge amount of error message.
     pcl::console::setVerbosityLevel(pcl::console::VERBOSITY_LEVEL::L_ALWAYS);
     // not implemented yet
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     
     track_target_set_ = false;
     new_cloud_ = false;
@@ -284,7 +284,9 @@ namespace jsk_pcl_ros
   //Publish the current particles
   void ParticleFilterTracking::publish_particles()
   {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     PointCloudStatePtr particles = tracker_get_particles();
     if (particles && new_cloud_ && particle_publisher_.getNumSubscribers()) {
       //Set pointCloud with particle's points
@@ -309,7 +311,9 @@ namespace jsk_pcl_ros
   //Publish model reference point cloud
   void ParticleFilterTracking::publish_result()
   {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     ParticleXYZRPY result = tracker_get_result();
     Eigen::Affine3f transformation = tracker_to_eigen_matrix(result);
 

--- a/jsk_pcl_ros/src/people_detection_nodelet.cpp
+++ b/jsk_pcl_ros/src/people_detection_nodelet.cpp
@@ -42,7 +42,7 @@
 
 namespace jsk_pcl_ros {
   void PeopleDetection::onInit() {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     pnh_->param("people_height_threshold", people_height_threshold_, 0.5);
     pnh_->param("min_confidence", min_confidence_, -1.5);
@@ -119,7 +119,9 @@ namespace jsk_pcl_ros {
   void PeopleDetection::detect(
     const sensor_msgs::PointCloud2::ConstPtr& cloud_msg) {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pcl::PointCloud<pcl::PointXYZRGBA>::Ptr input_cloud(
       new pcl::PointCloud<pcl::PointXYZRGBA>);
     pcl::fromROSMsg(*cloud_msg, *input_cloud);

--- a/jsk_pcl_ros/src/plane_supported_cuboid_estimator_nodelet.cpp
+++ b/jsk_pcl_ros/src/plane_supported_cuboid_estimator_nodelet.cpp
@@ -50,7 +50,7 @@ namespace jsk_pcl_ros
 {
   void PlaneSupportedCuboidEstimator::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     tf_ = TfListenerSingleton::getInstance();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     typename dynamic_reconfigure::Server<Config>::CallbackType f =
@@ -158,7 +158,9 @@ namespace jsk_pcl_ros
     const sensor_msgs::PointCloud2::ConstPtr& msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     if (!tracker_) {
       return;
     }

--- a/jsk_pcl_ros/src/pointcloud_localization_nodelet.cpp
+++ b/jsk_pcl_ros/src/pointcloud_localization_nodelet.cpp
@@ -46,7 +46,7 @@ namespace jsk_pcl_ros
   void PointCloudLocalization::onInit()
   {
     pcl::console::setVerbosityLevel(pcl::console::L_ERROR);
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     tf_listener_ = TfListenerSingleton::getInstance();
     // initialize localize_transform_ as identity
     localize_transform_.setIdentity();
@@ -147,7 +147,9 @@ namespace jsk_pcl_ros
   void PointCloudLocalization::cloudCallback(
     const sensor_msgs::PointCloud2::ConstPtr& cloud_msg)
   {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     boost::mutex::scoped_lock lock(mutex_);
     //NODELET_INFO("cloudCallback");
     latest_cloud_ = cloud_msg;

--- a/jsk_pcl_ros/src/pointcloud_screenpoint_nodelet.cpp
+++ b/jsk_pcl_ros/src/pointcloud_screenpoint_nodelet.cpp
@@ -46,7 +46,7 @@ namespace jsk_pcl_ros
 
 void PointcloudScreenpoint::onInit()
 {
-  DiagnosticNodelet::onInit();
+  jsk_topic_tools::NODELET::onInit();
 
 
   normals_tree_ = boost::make_shared< pcl::search::KdTree< pcl::PointXYZ > > ();
@@ -306,7 +306,9 @@ void PointcloudScreenpoint::points_cb(const sensor_msgs::PointCloud2::ConstPtr &
 
 void PointcloudScreenpoint::point_cb (const geometry_msgs::PointStampedConstPtr& pt_ptr)
 {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
   vital_checker_->poke();
+#endif
   if (latest_cloud_.empty())
   {
     NODELET_ERROR_THROTTLE(1.0, "no point cloud was received");
@@ -338,7 +340,9 @@ void PointcloudScreenpoint::point_cb (const geometry_msgs::PointStampedConstPtr&
 
 void PointcloudScreenpoint::point_array_cb (const sensor_msgs::PointCloud2ConstPtr& pt_arr_ptr)
 {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
   vital_checker_->poke();
+#endif
   if (latest_cloud_.empty())
   {
     NODELET_ERROR_THROTTLE(1.0, "no point cloud was received");

--- a/jsk_pcl_ros/src/ppf_registration_nodelet.cpp
+++ b/jsk_pcl_ros/src/ppf_registration_nodelet.cpp
@@ -44,7 +44,7 @@ namespace jsk_pcl_ros
 {
   void PPFRegistration::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&PPFRegistration::configCallback, this, _1, _2);
@@ -147,7 +147,9 @@ namespace jsk_pcl_ros
   (const sensor_msgs::PointCloud2::ConstPtr& input_cloud,
    const sensor_msgs::PointCloud2::ConstPtr& input_reference_cloud)
   {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pcl::PointCloud<pcl::PointXYZ>::Ptr cloud (new pcl::PointCloud<pcl::PointXYZ> ());
     pcl::fromROSMsg(*input_cloud, *cloud);
 
@@ -213,7 +215,9 @@ namespace jsk_pcl_ros
   (const sensor_msgs::PointCloud2::ConstPtr& input_cloud,
    const jsk_recognition_msgs::PointsArray::ConstPtr& input_reference_points_array)
   {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pcl::PointCloud<pcl::PointXYZ>::Ptr cloud (new pcl::PointCloud<pcl::PointXYZ> ());
     pcl::fromROSMsg(*input_cloud, *cloud);
 

--- a/jsk_pcl_ros/src/primitive_shape_classifier_nodelet.cpp
+++ b/jsk_pcl_ros/src/primitive_shape_classifier_nodelet.cpp
@@ -53,7 +53,7 @@ namespace jsk_pcl_ros
 {
   void PrimitiveShapeClassifier::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     srv_ = boost::make_shared<dynamic_reconfigure::Server<Config> >(*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
@@ -160,7 +160,9 @@ namespace jsk_pcl_ros
                                     const jsk_recognition_msgs::PolygonArray::ConstPtr& ros_polygons)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
 
     if (!checkFrameId(ros_cloud, ros_normal, ros_indices, ros_polygons)) return;
 

--- a/jsk_pcl_ros/src/rearrange_bounding_box_nodelet.cpp
+++ b/jsk_pcl_ros/src/rearrange_bounding_box_nodelet.cpp
@@ -37,7 +37,7 @@
 namespace jsk_pcl_ros
 {
   void RearrangeBoundingBox::onInit () {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     pnh_->param("offset_x", offset_x_, 0.0);
     pnh_->param("offset_y", offset_y_, 0.0);
@@ -86,7 +86,9 @@ namespace jsk_pcl_ros
 
   void RearrangeBoundingBox::rearrangeBoundingBoxCallback(const jsk_recognition_msgs::BoundingBoxArray::ConstPtr& box_array) {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     jsk_recognition_msgs::BoundingBoxArray bba;
     bba.header = box_array->header;
     bba.boxes = box_array->boxes;

--- a/jsk_pcl_ros/src/region_growing_multiple_plane_segmentation_nodelet.cpp
+++ b/jsk_pcl_ros/src/region_growing_multiple_plane_segmentation_nodelet.cpp
@@ -46,7 +46,7 @@ namespace jsk_pcl_ros
 
   void RegionGrowingMultiplePlaneSegmentation::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
@@ -143,7 +143,9 @@ namespace jsk_pcl_ros
     if (!done_initialization_) {
       return;
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     {
       jsk_recognition_utils::ScopedWallDurationReporter r
         = timer_.reporter(pub_latest_time_, pub_average_time_);

--- a/jsk_pcl_ros/src/region_growing_segmentation_nodelet.cpp
+++ b/jsk_pcl_ros/src/region_growing_segmentation_nodelet.cpp
@@ -46,7 +46,7 @@ namespace jsk_pcl_ros
 
   void RegionGrowingSegmentation::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&RegionGrowingSegmentation::configCallback, this, _1, _2);
@@ -89,7 +89,9 @@ namespace jsk_pcl_ros
   void RegionGrowingSegmentation::segment(const sensor_msgs::PointCloud2::ConstPtr& msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pcl::search::Search<pcl::PointNormal>::Ptr tree = boost::shared_ptr<pcl::search::Search<pcl::PointNormal> > (new pcl::search::KdTree<pcl::PointNormal>);
     pcl::PointCloud<pcl::PointNormal> cloud;
     pcl::fromROSMsg(*msg, cloud);

--- a/jsk_pcl_ros/src/resize_points_publisher_nodelet.cpp
+++ b/jsk_pcl_ros/src/resize_points_publisher_nodelet.cpp
@@ -14,7 +14,18 @@
 #include <message_filters/synchronizer.h>
 
 #include "jsk_recognition_utils/pcl_conversion_util.h"
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 #include <dynamic_reconfigure/server.h>
 #include <jsk_pcl_ros/ResizePointsPublisherConfig.h>
@@ -24,13 +35,13 @@
 
 namespace jsk_pcl_ros
 {
-  class ResizePointsPublisher : public jsk_topic_tools::DiagnosticNodelet
+  class ResizePointsPublisher : public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<sensor_msgs::PointCloud2,
                                                       PCLIndicesMsg> SyncPolicy;
     typedef jsk_pcl_ros::ResizePointsPublisherConfig Config;
-    ResizePointsPublisher(): DiagnosticNodelet("ResizePointsPublisher") {}
+    ResizePointsPublisher(){}
 
   private:
     int step_x_, step_y_;
@@ -45,7 +56,7 @@ namespace jsk_pcl_ros
     boost::mutex mutex_;
     bool use_indices_;
     void onInit () {
-      DiagnosticNodelet::onInit();
+      jsk_topic_tools::NODELET::onInit();
       pnh_->param("use_indices", use_indices_, false);
       pnh_->param("not_use_rgb", not_use_rgb_, false);
       srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
@@ -140,7 +151,9 @@ namespace jsk_pcl_ros
     
     template<class T> void filter (const sensor_msgs::PointCloud2::ConstPtr &input,
                                    const PCLIndicesMsg::ConstPtr &indices) {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pcl::PointCloud<T> pcl_input_cloud, output;
       fromROSMsg(*input, pcl_input_cloud);
       boost::mutex::scoped_lock lock (mutex_);

--- a/jsk_pcl_ros/src/roi_clipper_nodelet.cpp
+++ b/jsk_pcl_ros/src/roi_clipper_nodelet.cpp
@@ -46,7 +46,7 @@ namespace jsk_pcl_ros
 {
   void ROIClipper::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pcl::console::setVerbosityLevel(pcl::console::L_ERROR);
     pnh_->param("not_sync", not_sync_, false);
     pnh_->param("keep_organized", keep_organized_, false);
@@ -106,7 +106,9 @@ namespace jsk_pcl_ros
   void ROIClipper::clip(const sensor_msgs::Image::ConstPtr& image_msg,
                         const sensor_msgs::CameraInfo::ConstPtr& camera_info_msg)
   {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     try {
       cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(image_msg, sensor_msgs::image_encodings::RGB8);
       cv::Mat image = cv_ptr->image;
@@ -148,7 +150,9 @@ namespace jsk_pcl_ros
     const sensor_msgs::PointCloud2::ConstPtr& cloud_msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     if (latest_camera_info_) {
       image_geometry::PinholeCameraModel model;
       PCLIndicesMsg indices;

--- a/jsk_pcl_ros/src/selected_cluster_publisher_nodelet.cpp
+++ b/jsk_pcl_ros/src/selected_cluster_publisher_nodelet.cpp
@@ -42,7 +42,7 @@ namespace jsk_pcl_ros
 {
   void SelectedClusterPublisher::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("keep_organized", keep_organized_, false);
     pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);
     onInitPostProcess();
@@ -80,7 +80,9 @@ namespace jsk_pcl_ros
                                          const jsk_recognition_msgs::ClusterPointIndices::ConstPtr& indices,
                                          const jsk_recognition_msgs::Int32Stamped::ConstPtr& index)
   {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     if (indices->cluster_indices.size() <= index->data) {
       NODELET_ERROR("the selected index %d is out of clusters array %lu",
                     index->data,

--- a/jsk_pcl_ros/src/snapit_nodelet.cpp
+++ b/jsk_pcl_ros/src/snapit_nodelet.cpp
@@ -58,7 +58,7 @@ namespace jsk_pcl_ros
 {
   void SnapIt::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     tf_listener_ = TfListenerSingleton::getInstance();
     pnh_->param("use_service", use_service_, false);
     polygon_aligned_pub_ = advertise<geometry_msgs::PoseStamped>(
@@ -120,7 +120,9 @@ namespace jsk_pcl_ros
     const jsk_recognition_msgs::ModelCoefficientsArray::ConstPtr& coefficients_msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     polygons_ = polygon_msg;
   }
 

--- a/jsk_pcl_ros/src/supervoxel_segmentation_nodelet.cpp
+++ b/jsk_pcl_ros/src/supervoxel_segmentation_nodelet.cpp
@@ -40,7 +40,7 @@ namespace jsk_pcl_ros
 {
   void SupervoxelSegmentation::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (
@@ -67,7 +67,9 @@ namespace jsk_pcl_ros
     const sensor_msgs::PointCloud2::ConstPtr& cloud_msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     if (cloud_msg->data.size() > 0) {
       pcl::PointCloud<PointT>::Ptr cloud (new pcl::PointCloud<PointT>);
       pcl::fromROSMsg(*cloud_msg, *cloud);

--- a/jsk_pcl_ros/src/target_adaptive_tracking_nodelet.cpp
+++ b/jsk_pcl_ros/src/target_adaptive_tracking_nodelet.cpp
@@ -8,7 +8,7 @@
 namespace jsk_pcl_ros 
 {
    TargetAdaptiveTracking::TargetAdaptiveTracking() :
-      DiagnosticNodelet("target_adaptive_tracking"),
+      
       init_counter_(0),
       update_counter_(0),
       growth_rate_(1.15)
@@ -33,7 +33,7 @@ namespace jsk_pcl_ros
 
    void TargetAdaptiveTracking::onInit()
    {
-      DiagnosticNodelet::onInit();
+      jsk_topic_tools::NODELET::onInit();
 
       pnh_->param("use_tf", use_tf_, false);
       pnh_->param("parent_frame_id", parent_frame_id_, std::string("/track_result"));
@@ -116,7 +116,9 @@ namespace jsk_pcl_ros
       const sensor_msgs::PointCloud2::ConstPtr &bkgd_msg,
       const geometry_msgs::PoseStamped::ConstPtr &pose_msg)
    {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pcl::PointCloud<PointT>::Ptr cloud (new pcl::PointCloud<PointT>);
       pcl::fromROSMsg(*cloud_msg, *cloud);
       pcl::PointCloud<PointT>::Ptr bkgd_cloud (new pcl::PointCloud<PointT>);
@@ -175,7 +177,9 @@ namespace jsk_pcl_ros
    void TargetAdaptiveTracking::callback(
       const sensor_msgs::PointCloud2::ConstPtr &cloud_msg,
       const geometry_msgs::PoseStamped::ConstPtr &pose_msg) {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       if (this->object_reference_->empty())
       {
          ROS_WARN("No Model To Track Selected");

--- a/jsk_pcl_ros/src/tilt_laser_listener_nodelet.cpp
+++ b/jsk_pcl_ros/src/tilt_laser_listener_nodelet.cpp
@@ -48,7 +48,7 @@ namespace jsk_pcl_ros
   
   void TiltLaserListener::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     skip_counter_ = 0;
     if (pnh_->hasParam("joint_name")) {
       pnh_->getParam("joint_name", joint_name_);
@@ -126,7 +126,9 @@ namespace jsk_pcl_ros
   void TiltLaserListener::timerCallback(const ros::TimerEvent& e)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     publishTimeRange(e.current_real, e.last_real, e.current_real);
     start_time_ = e.current_real; // not used??
   }
@@ -141,6 +143,7 @@ namespace jsk_pcl_ros
 
   }
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
   void TiltLaserListener::updateDiagnostic(
     diagnostic_updater::DiagnosticStatusWrapper &stat)
   {
@@ -165,6 +168,7 @@ namespace jsk_pcl_ros
     }
     DiagnosticNodelet::updateDiagnostic(stat);
   }
+#endif
 
   void TiltLaserListener::cloudCallback(
     const sensor_msgs::PointCloud2::ConstPtr& msg)
@@ -425,7 +429,9 @@ namespace jsk_pcl_ros
     for (size_t i = 0; i < msg->name.size(); i++) {
       std::string name = msg->name[i];
       if (name == joint_name_) {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
         vital_checker_->poke();
+#endif
         if(msg->position.size() <= i) {
           ROS_WARN("size of position (%zu) is smaller than joint(%s) position(%zu)",
                    msg->position.size(), name.c_str(), i);

--- a/jsk_pcl_ros/src/torus_finder_nodelet.cpp
+++ b/jsk_pcl_ros/src/torus_finder_nodelet.cpp
@@ -45,7 +45,7 @@ namespace jsk_pcl_ros
 {
   void TorusFinder::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pcl::console::setVerbosityLevel(pcl::console::L_ERROR);
     pnh_->param("use_hint", use_hint_, false);
     if (use_hint_) {
@@ -144,7 +144,9 @@ namespace jsk_pcl_ros
       return;
     }
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pcl::PointCloud<pcl::PointNormal>::Ptr cloud
       (new pcl::PointCloud<pcl::PointNormal>);
     pcl::fromROSMsg(*cloud_msg, *cloud);

--- a/jsk_pcl_ros/src/uniform_sampling_nodelet.cpp
+++ b/jsk_pcl_ros/src/uniform_sampling_nodelet.cpp
@@ -46,7 +46,7 @@ namespace jsk_pcl_ros
 {
   void UniformSampling::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     typename dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&UniformSampling::configCallback, this, _1, _2);
@@ -77,7 +77,9 @@ namespace jsk_pcl_ros
     const sensor_msgs::PointCloud2::ConstPtr& msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pcl::PointCloud<pcl::PointXYZ>::Ptr
       cloud (new pcl::PointCloud<pcl::PointXYZ>);
     pcl::fromROSMsg(*msg, *cloud);

--- a/jsk_pcl_ros/src/voxel_grid_downsample_decoder_nodelet.cpp
+++ b/jsk_pcl_ros/src/voxel_grid_downsample_decoder_nodelet.cpp
@@ -64,7 +64,9 @@ namespace jsk_pcl_ros
   
   void VoxelGridDownsampleDecoder::pointCB(const jsk_recognition_msgs::SlicedPointCloudConstPtr &input)
   {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     NODELET_INFO_STREAM("new pointcloud!" << input->point_cloud.header.frame_id);
     
     int id = getPointcloudID(input);
@@ -153,7 +155,7 @@ namespace jsk_pcl_ros
   
   void VoxelGridDownsampleDecoder::onInit(void)
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     previous_id_ = -1;
     // decoded output
     pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);

--- a/jsk_pcl_ros/src/voxel_grid_downsample_manager_nodelet.cpp
+++ b/jsk_pcl_ros/src/voxel_grid_downsample_manager_nodelet.cpp
@@ -53,7 +53,9 @@ namespace jsk_pcl_ros
   
   void VoxelGridDownsampleManager::pointCB(const sensor_msgs::PointCloud2ConstPtr &input)
   {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     try {
     pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud (new pcl::PointCloud<pcl::PointXYZRGB>);
     pcl::PointCloud<pcl::PointXYZRGB>::Ptr output_cloud (new pcl::PointCloud<pcl::PointXYZRGB>);
@@ -219,7 +221,7 @@ namespace jsk_pcl_ros
   
   void VoxelGridDownsampleManager::onInit(void)
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("base_frame", base_frame_, std::string("pelvis"));
     tf_listener = TfListenerSingleton::getInstance();
     initializeGrid();

--- a/jsk_pcl_ros/src/voxel_grid_large_scale_nodelet.cpp
+++ b/jsk_pcl_ros/src/voxel_grid_large_scale_nodelet.cpp
@@ -46,7 +46,7 @@ namespace jsk_pcl_ros
 {
   void VoxelGridLargeScale::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     typename dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind(&VoxelGridLargeScale::configCallback, this, _1, _2);
@@ -68,7 +68,9 @@ namespace jsk_pcl_ros
   void VoxelGridLargeScale::filter(const sensor_msgs::PointCloud2::ConstPtr& msg)
   {
     boost::mutex::scoped_lock lock(mutex_);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     if (leaf_size_ == 0.0) {
       pub_.publish(msg);
     }

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/add_point_indices.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/add_point_indices.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_ADD_POINT_INDICES_H_
 #define JSK_PERCEPTION_ADD_POINT_INDICES_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 #include "jsk_recognition_utils/pcl_conversion_util.h"
 #include "jsk_recognition_utils/pcl_util.h"
@@ -50,7 +61,7 @@
 
 namespace jsk_pcl_ros_utils
 {
-  class AddPointIndices: public jsk_topic_tools::DiagnosticNodelet
+  class AddPointIndices: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<
@@ -60,7 +71,7 @@ namespace jsk_pcl_ros_utils
     PCLIndicesMsg,
     PCLIndicesMsg > ASyncPolicy;
   
-    AddPointIndices(): DiagnosticNodelet("AddPointIndices") {}
+    AddPointIndices(){}
     virtual ~AddPointIndices();
 
   protected:

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/bounding_box_array_to_bounding_box.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/bounding_box_array_to_bounding_box.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_UTILS_BOUNDING_BOX_ARRAY_TO_BOUNDING_BOX_H_
 #define JSK_PCL_ROS_UTILS_BOUNDING_BOX_ARRAY_TO_BOUNDING_BOX_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <dynamic_reconfigure/server.h>
 #include <jsk_pcl_ros_utils/BoundingBoxArrayToBoundingBoxConfig.h>
 #include <jsk_recognition_msgs/BoundingBoxArray.h>
@@ -45,11 +56,11 @@
 namespace jsk_pcl_ros_utils
 {
 
-class BoundingBoxArrayToBoundingBox: public jsk_topic_tools::DiagnosticNodelet
+class BoundingBoxArrayToBoundingBox: public jsk_topic_tools::NODELET
 {
 public:
   typedef jsk_pcl_ros_utils::BoundingBoxArrayToBoundingBoxConfig Config;
-  BoundingBoxArrayToBoundingBox(): DiagnosticNodelet("BoundingBoxArrayToBoundingBox") { }
+  BoundingBoxArrayToBoundingBox(){ }
 protected:
   virtual void onInit();
   virtual void subscribe();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/centroid_publisher.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/centroid_publisher.h
@@ -49,14 +49,25 @@
 #include <pcl/common/centroid.h>
 #include <pcl/filters/extract_indices.h>
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros_utils
 {
-  class CentroidPublisher: public jsk_topic_tools::DiagnosticNodelet
+  class CentroidPublisher: public jsk_topic_tools::NODELET
   {
   public:
-    CentroidPublisher(): DiagnosticNodelet("CentroidPublisher") {}
+    CentroidPublisher(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/cloud_on_plane.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/cloud_on_plane.h
@@ -38,7 +38,18 @@
 #ifndef JSK_PCL_ROS_UTILS_CLOUD_ON_PLANE_H_
 #define JSK_PCL_ROS_UTILS_CLOUD_ON_PLANE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_recognition_msgs/PolygonArray.h>
 #include <jsk_recognition_utils/geo/convex_polygon.h>
 #include <message_filters/subscriber.h>
@@ -53,7 +64,7 @@
 
 namespace jsk_pcl_ros_utils
 {
-  class CloudOnPlane: public jsk_topic_tools::DiagnosticNodelet
+  class CloudOnPlane: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<CloudOnPlane> Ptr;
@@ -65,7 +76,7 @@ namespace jsk_pcl_ros_utils
       sensor_msgs::PointCloud2,
       jsk_recognition_msgs::PolygonArray> ApproximateSyncPolicy;
 
-    CloudOnPlane(): DiagnosticNodelet("CloudOnPlane") {}
+    CloudOnPlane(){}
     virtual ~CloudOnPlane();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/cluster_point_indices_label_filter.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/cluster_point_indices_label_filter.h
@@ -36,7 +36,18 @@
 #ifndef JSK_PCL_ROS_UTILS_CLUSTER_POINT_INDICES_LABEL_FILTER_H_
 #define JSK_PCL_ROS_UTILS_CLUSTER_POINT_INDICES_LABEL_FILTER_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/synchronizer.h>
@@ -51,12 +62,10 @@
 namespace jsk_pcl_ros_utils
 {
 
-  class ClusterPointIndicesLabelFilter: public jsk_topic_tools::DiagnosticNodelet
+  class ClusterPointIndicesLabelFilter: public jsk_topic_tools::NODELET
   {
   public:
-    ClusterPointIndicesLabelFilter(): DiagnosticNodelet("ClusterPointIndicesLabelFilter")
-    {
-    }
+    ClusterPointIndicesLabelFilter(){}
     ~ClusterPointIndicesLabelFilter()
     {
       // message_filters::Synchronizer needs to be called reset

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/cluster_point_indices_to_point_indices.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/cluster_point_indices_to_point_indices.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_UTILS_CLUSTER_POINT_INDICES_TO_POINT_INDICES_H_
 #define JSK_PCL_ROS_UTILS_CLUSTER_POINT_INDICES_TO_POINT_INDICES_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <dynamic_reconfigure/server.h>
 #include <jsk_pcl_ros_utils/ClusterPointIndicesToPointIndicesConfig.h>
 #include <jsk_recognition_msgs/ClusterPointIndices.h>
@@ -45,11 +56,11 @@
 namespace jsk_pcl_ros_utils
 {
 
-class ClusterPointIndicesToPointIndices: public jsk_topic_tools::DiagnosticNodelet
+class ClusterPointIndicesToPointIndices: public jsk_topic_tools::NODELET
 {
 public:
   typedef jsk_pcl_ros_utils::ClusterPointIndicesToPointIndicesConfig Config;
-  ClusterPointIndicesToPointIndices(): DiagnosticNodelet("ClusterPointIndicesToPointIndices") { }
+  ClusterPointIndicesToPointIndices(){ }
 protected:
   virtual void onInit();
   virtual void subscribe();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/colorize_distance_from_plane.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/colorize_distance_from_plane.h
@@ -49,11 +49,22 @@
 #include <dynamic_reconfigure/server.h>
 #include <jsk_pcl_ros_utils/ColorizeDistanceFromPlaneConfig.h>
 #include "jsk_recognition_utils/geo_util.h"
-#include "jsk_topic_tools/diagnostic_nodelet.h"
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros_utils
 {
-  class ColorizeDistanceFromPlane: public jsk_topic_tools::DiagnosticNodelet
+  class ColorizeDistanceFromPlane: public jsk_topic_tools::NODELET
   {
   public:
     typedef pcl::PointXYZRGB PointT;
@@ -64,7 +75,7 @@ namespace jsk_pcl_ros_utils
       jsk_recognition_msgs::PolygonArray
       > SyncPolicy;
     typedef ColorizeDistanceFromPlaneConfig Config;
-    ColorizeDistanceFromPlane() : DiagnosticNodelet("ColorizeDistanceFromPlane") {}
+    ColorizeDistanceFromPlane(){}
     virtual ~ColorizeDistanceFromPlane();
   protected:
     ////////////////////////////////////////////////////////

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/colorize_height_2d_mapping.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/colorize_height_2d_mapping.h
@@ -37,17 +37,28 @@
 #ifndef JSK_PCL_ROS_UTILS_COLORIZE_HEIGHT_2D_MAPPING_H_
 #define JSK_PCL_ROS_UTILS_COLORIZE_HEIGHT_2D_MAPPING_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/PointCloud2.h>
 
 namespace jsk_pcl_ros_utils
 {
-  class ColorizeHeight2DMapping: public jsk_topic_tools::DiagnosticNodelet
+  class ColorizeHeight2DMapping: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<ColorizeHeight2DMapping> Ptr;
     
-    ColorizeHeight2DMapping(): DiagnosticNodelet("ColorizeHeight2DMapping") {}
+    ColorizeHeight2DMapping(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/delay_pointcloud.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/delay_pointcloud.h
@@ -38,7 +38,18 @@
 
 #include <pcl_ros/pcl_nodelet.h>
 #include <sensor_msgs/PointCloud.h>
-#include "jsk_topic_tools/diagnostic_nodelet.h"
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 #include "jsk_pcl_ros_utils/DelayPointCloudConfig.h"
 #include <dynamic_reconfigure/server.h>
@@ -49,13 +60,13 @@
 namespace jsk_pcl_ros_utils
 {
 
-  class DelayPointCloud: public jsk_topic_tools::DiagnosticNodelet
+  class DelayPointCloud: public jsk_topic_tools::NODELET
   {
     
   public:
 
     typedef jsk_pcl_ros_utils::DelayPointCloudConfig Config;
-    DelayPointCloud() : DiagnosticNodelet("DelayPointCloud") {}
+    DelayPointCloud(){}
 
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/depth_image_error.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/depth_image_error.h
@@ -47,13 +47,24 @@
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/approximate_time.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/CameraInfo.h>
 #include <string>
 
 namespace jsk_pcl_ros_utils
 {
-  class DepthImageError: public jsk_topic_tools::DiagnosticNodelet
+  class DepthImageError: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ApproximateTime<
@@ -67,7 +78,7 @@ namespace jsk_pcl_ros_utils
     sensor_msgs::CameraInfo
      > SyncPolicy;
     ros::Publisher depth_error_publisher_;
-    DepthImageError() : DiagnosticNodelet("DepthImageError") {}
+    DepthImageError(){}
     virtual ~DepthImageError();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/label_to_cluster_point_indices.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/label_to_cluster_point_indices.h
@@ -37,16 +37,27 @@
 #ifndef JSK_PCL_ROS_UTILS_LABEL_TO_CLUSTER_POINT_INDICES_H_
 #define JSK_PCL_ROS_UTILS_LABEL_TO_CLUSTER_POINT_INDICES_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 
 namespace jsk_pcl_ros_utils
 {
 
-class LabelToClusterPointIndices: public jsk_topic_tools::DiagnosticNodelet
+class LabelToClusterPointIndices: public jsk_topic_tools::NODELET
 {
 public:
-  LabelToClusterPointIndices(): DiagnosticNodelet("LabelToClusterPointIndices") { }
+  LabelToClusterPointIndices(){ }
 protected:
   ////////////////////////////////////////////////////////
   // methods

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/marker_array_voxel_to_pointcloud.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/marker_array_voxel_to_pointcloud.h
@@ -37,16 +37,27 @@
 #ifndef JSK_PCL_ROS_UTILS_MARKER_ARRAY_VOXEL_TO_POINTCLOUD_H_
 #define JSK_PCL_ROS_UTILS_MARKER_ARRAY_VOXEL_TO_POINTCLOUD_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <visualization_msgs/MarkerArray.h>
 
 namespace jsk_pcl_ros_utils
 {
 
-class MarkerArrayVoxelToPointCloud: public jsk_topic_tools::DiagnosticNodelet
+class MarkerArrayVoxelToPointCloud: public jsk_topic_tools::NODELET
 {
 public:
-  MarkerArrayVoxelToPointCloud(): DiagnosticNodelet("MarkerArrayVoxelToPointCloud") { }
+  MarkerArrayVoxelToPointCloud(){ }
 protected:
   virtual void onInit();
   virtual void subscribe();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/mask_image_to_depth_considered_mask_image.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/mask_image_to_depth_considered_mask_image.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_UTILS_MASK_IMAGE_TO_DEPTH_CONSIDERED_MASK_IMAGE_H_
 #define JSK_PCL_ROS_UTILS_MASK_IMAGE_TO_DEPTH_CONSIDERED_MASK_IMAGE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 #include <dynamic_reconfigure/server.h>
 #include "jsk_recognition_utils/pcl_conversion_util.h"
@@ -49,7 +60,7 @@
 
 namespace jsk_pcl_ros_utils
 {
-  class MaskImageToDepthConsideredMaskImage: public jsk_topic_tools::DiagnosticNodelet
+  class MaskImageToDepthConsideredMaskImage: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ApproximateTime<
@@ -60,7 +71,7 @@ namespace jsk_pcl_ros_utils
       sensor_msgs::Image > SyncPolicy;
     typedef jsk_pcl_ros_utils::MaskImageToDepthConsideredMaskImageConfig Config;
 
-    MaskImageToDepthConsideredMaskImage(): DiagnosticNodelet("MaskImageToDepthConsideredMaskImage") { }
+    MaskImageToDepthConsideredMaskImage(){ }
     virtual ~MaskImageToDepthConsideredMaskImage();
   protected:
     ////////////////////////////////////////////////////////

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/mask_image_to_point_indices.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/mask_image_to_point_indices.h
@@ -37,17 +37,28 @@
 #ifndef JSK_PCL_ROS_UTILS_MASK_IMAGE_TO_POINT_INDICES_H_
 #define JSK_PCL_ROS_UTILS_MASK_IMAGE_TO_POINT_INDICES_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 #include <jsk_recognition_msgs/ClusterPointIndices.h>
 #include "jsk_recognition_utils/pcl_conversion_util.h"
 
 namespace jsk_pcl_ros_utils
 {
-  class MaskImageToPointIndices: public jsk_topic_tools::DiagnosticNodelet
+  class MaskImageToPointIndices: public jsk_topic_tools::NODELET
   {
   public:
-    MaskImageToPointIndices(): DiagnosticNodelet("MaskImageToPointIndices") { }
+    MaskImageToPointIndices(){ }
   protected:
     ////////////////////////////////////////////////////////
     // methods

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/normal_concatenater.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/normal_concatenater.h
@@ -48,16 +48,27 @@
 #include <pcl/point_types.h>
 #include <pcl/common/centroid.h>
 #include <pcl/filters/extract_indices.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros_utils
 {
-  class NormalConcatenater: public jsk_topic_tools::DiagnosticNodelet
+  class NormalConcatenater: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<sensor_msgs::PointCloud2, sensor_msgs::PointCloud2> SyncPolicy;
     typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::PointCloud2, sensor_msgs::PointCloud2> ASyncPolicy;
-    NormalConcatenater(): DiagnosticNodelet("NormalConcatenater") { }
+    NormalConcatenater(){ }
     virtual ~NormalConcatenater();
   protected:
     ros::Publisher pub_;

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/normal_flip_to_frame.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/normal_flip_to_frame.h
@@ -37,17 +37,28 @@
 #ifndef JSK_PCL_ROS_UTILS_NORMAL_FLIP_TO_FRAME_H_
 #define JSK_PCL_ROS_UTILS_NORMAL_FLIP_TO_FRAME_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/PointCloud2.h>
 #include "jsk_recognition_utils/tf_listener_singleton.h"
 
 namespace jsk_pcl_ros_utils
 {
-  class NormalFlipToFrame: public jsk_topic_tools::DiagnosticNodelet
+  class NormalFlipToFrame: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<NormalFlipToFrame> Ptr;
-    NormalFlipToFrame(): DiagnosticNodelet("NormalFlipToFrame") {}
+    NormalFlipToFrame(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pcd_reader_with_pose.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pcd_reader_with_pose.h
@@ -38,17 +38,28 @@
 
 #include <pcl_ros/pcl_nodelet.h>
 #include "jsk_recognition_utils/tf_listener_singleton.h"
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <geometry_msgs/PoseStamped.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <pcl_ros/transforms.h>
 
 namespace jsk_pcl_ros_utils
 {
-  class PCDReaderWithPose: public jsk_topic_tools::DiagnosticNodelet
+  class PCDReaderWithPose: public jsk_topic_tools::NODELET
   {
   public:
-    PCDReaderWithPose(): DiagnosticNodelet("PCDReaderWithPose") {}
+    PCDReaderWithPose(){}
   typedef pcl::PointXYZRGBNormal PointT;
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/planar_pointcloud_simulator.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/planar_pointcloud_simulator.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_UTILS_PLANAR_POINTCLOUD_SIMULATOR_H_
 #define JSK_PCL_ROS_UTILS_PLANAR_POINTCLOUD_SIMULATOR_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include "jsk_recognition_utils/pcl_conversion_util.h"
 #include <jsk_pcl_ros_utils/PlanarPointCloudSimulatorConfig.h>
 #include <dynamic_reconfigure/server.h>
@@ -72,12 +83,11 @@ namespace jsk_pcl_ros_utils
    * Nodelet implementation of jsk_pcl/PlanarPointCloudSimulator
    */
   class PlanarPointCloudSimulatorNodelet:
-    public jsk_topic_tools::DiagnosticNodelet
+    public jsk_topic_tools::NODELET
   {
   public:
     typedef PlanarPointCloudSimulatorConfig Config;
-    PlanarPointCloudSimulatorNodelet():
-      DiagnosticNodelet("PlanarPointCloudSimulatorNodelet") {}
+    PlanarPointCloudSimulatorNodelet(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/plane_concatenator.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/plane_concatenator.h
@@ -43,7 +43,18 @@
 
 #include <jsk_pcl_ros_utils/PlaneConcatenatorConfig.h>
 #include <dynamic_reconfigure/server.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/synchronizer.h>
@@ -52,7 +63,7 @@
 
 namespace jsk_pcl_ros_utils
 {
-  class PlaneConcatenator: public jsk_topic_tools::DiagnosticNodelet
+  class PlaneConcatenator: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<PlaneConcatenator> Ptr;
@@ -64,7 +75,7 @@ namespace jsk_pcl_ros_utils
       jsk_recognition_msgs::PolygonArray,
       jsk_recognition_msgs::ModelCoefficientsArray
       > SyncPolicy;
-    PlaneConcatenator(): DiagnosticNodelet("PlaneConcatenator") {}
+    PlaneConcatenator(){}
     virtual ~PlaneConcatenator();
   protected:
     ////////////////////////////////////////////////////////

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/plane_reasoner.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/plane_reasoner.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_UTILS_PLANE_REASONER_H_
 #define JSK_PCL_ROS_UTILS_PLANE_REASONER_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include "jsk_recognition_msgs/ClusterPointIndices.h"
 #include "jsk_recognition_msgs/PolygonArray.h"
 #include "jsk_recognition_msgs/ModelCoefficientsArray.h"
@@ -60,7 +71,7 @@ namespace jsk_pcl_ros_utils
                        geometry_msgs::PolygonStamped>
   PlaneInfoContainer;
   
-  class PlaneReasoner: public jsk_topic_tools::DiagnosticNodelet
+  class PlaneReasoner: public jsk_topic_tools::NODELET
   {
   public:
     ////////////////////////////////////////////////////////
@@ -75,7 +86,7 @@ namespace jsk_pcl_ros_utils
     typedef pcl::PointXYZRGB PointT;
     
     
-    PlaneReasoner(): DiagnosticNodelet("PlaneReasoner") { }
+    PlaneReasoner(){ }
     virtual ~PlaneReasoner();
 
   protected:

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/plane_rejector.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/plane_rejector.h
@@ -62,12 +62,23 @@
 #include <diagnostic_updater/publisher.h>
 #include <jsk_topic_tools/rosparam_utils.h>
 #include "jsk_recognition_utils/pcl_util.h"
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 
 namespace jsk_pcl_ros_utils
 {
-  class PlaneRejector: public jsk_topic_tools::DiagnosticNodelet
+  class PlaneRejector: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime< jsk_recognition_msgs::PolygonArray,
@@ -77,7 +88,7 @@ namespace jsk_pcl_ros_utils
                                                        jsk_recognition_msgs::ClusterPointIndices
                                                        > SyncInlierPolicy;
     typedef jsk_pcl_ros_utils::PlaneRejectorConfig Config;
-    PlaneRejector() : DiagnosticNodelet("PlaneRejector") {}
+    PlaneRejector(){}
     virtual ~PlaneRejector();
   protected:
     virtual void onInit();
@@ -88,8 +99,9 @@ namespace jsk_pcl_ros_utils
                         const jsk_recognition_msgs::ClusterPointIndices::ConstPtr& inliers);
     virtual void configCallback (Config &config, uint32_t level);
 
-    
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     virtual void updateDiagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat);
+#endif
     virtual void subscribe();
     virtual void unsubscribe();
     

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/point_indices_to_cluster_point_indices.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/point_indices_to_cluster_point_indices.h
@@ -36,15 +36,26 @@
 #ifndef JSK_PCL_ROS_UTILS_POINT_INDICES_TO_CLUSTER_POINT_INDICES_H_
 #define JSK_PCL_ROS_UTILS_POINT_INDICES_TO_CLUSTER_POINT_INDICES_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_recognition_msgs/ClusterPointIndices.h>
 
 namespace jsk_pcl_ros_utils
 {
-  class PointIndicesToClusterPointIndices: public jsk_topic_tools::DiagnosticNodelet
+  class PointIndicesToClusterPointIndices: public jsk_topic_tools::NODELET
   {
   public:
-    PointIndicesToClusterPointIndices(): DiagnosticNodelet("PointIndicesToClusterPointIndices") {}
+    PointIndicesToClusterPointIndices(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/point_indices_to_mask_image.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/point_indices_to_mask_image.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_UTILS_POINT_INDICES_TO_MASK_IMAGE_H_
 #define JSK_PCL_ROS_UTILS_POINT_INDICES_TO_MASK_IMAGE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 #include "jsk_recognition_utils/pcl_conversion_util.h"
 #include <message_filters/subscriber.h>
@@ -47,7 +58,7 @@
 
 namespace jsk_pcl_ros_utils
 {
-  class PointIndicesToMaskImage: public jsk_topic_tools::DiagnosticNodelet
+  class PointIndicesToMaskImage: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ApproximateTime<
@@ -57,7 +68,7 @@ namespace jsk_pcl_ros_utils
       PCLIndicesMsg,
       sensor_msgs::Image > SyncPolicy;
 
-    PointIndicesToMaskImage(): DiagnosticNodelet("PointIndicesToMaskImage") { }
+    PointIndicesToMaskImage(){ }
     virtual ~PointIndicesToMaskImage();
   protected:
     ////////////////////////////////////////////////////////

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pointcloud_relative_from_pose_stamped.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pointcloud_relative_from_pose_stamped.h
@@ -36,7 +36,18 @@
 #ifndef JSK_PCL_ROS_UTILS_POINTCLOUD_RELATIVE_FROM_POSE_STAMPED_H_
 #define JSK_PCL_ROS_UTILS_POINTCLOUD_RELATIVE_FROM_POSE_STAMPED_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/synchronizer.h>
@@ -47,7 +58,7 @@
 
 namespace jsk_pcl_ros_utils
 {
-  class PointCloudRelativeFromPoseStamped: public jsk_topic_tools::DiagnosticNodelet
+  class PointCloudRelativeFromPoseStamped: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<
@@ -56,7 +67,7 @@ namespace jsk_pcl_ros_utils
     typedef message_filters::sync_policies::ApproximateTime<
     sensor_msgs::PointCloud2,
     geometry_msgs::PoseStamped > ApproximateSyncPolicy;
-    PointCloudRelativeFromPoseStamped(): DiagnosticNodelet("PointCloudRelativeFromPoseStamped") {}
+    PointCloudRelativeFromPoseStamped(){}
     virtual ~PointCloudRelativeFromPoseStamped();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pointcloud_to_cluster_point_indices.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pointcloud_to_cluster_point_indices.h
@@ -36,16 +36,27 @@
 #ifndef JSK_PCL_ROS_UTILS_POINTCLOUD_TO_CLUSTER_POINT_INDICES_H_
 #define JSK_PCL_ROS_UTILS_POINTCLOUD_TO_CLUSTER_POINT_INDICES_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_recognition_msgs/ClusterPointIndices.h>
 #include <sensor_msgs/PointCloud2.h>
 
 namespace jsk_pcl_ros_utils
 {
-  class PointCloudToClusterPointIndices: public jsk_topic_tools::DiagnosticNodelet
+  class PointCloudToClusterPointIndices: public jsk_topic_tools::NODELET
   {
   public:
-    PointCloudToClusterPointIndices(): DiagnosticNodelet("PointCloudToClusterPointIndices") {}
+    PointCloudToClusterPointIndices(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pointcloud_to_mask_image.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pointcloud_to_mask_image.h
@@ -40,7 +40,18 @@
 #include <boost/shared_ptr.hpp>
 
 #include <dynamic_reconfigure/server.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/PointCloud2.h>
 
@@ -48,11 +59,11 @@
 
 namespace jsk_pcl_ros_utils
 {
-  class PointCloudToMaskImage: public jsk_topic_tools::DiagnosticNodelet
+  class PointCloudToMaskImage: public jsk_topic_tools::NODELET
   {
   public:
     typedef PointCloudToMaskImageConfig Config;
-    PointCloudToMaskImage(): DiagnosticNodelet("PointCloudToMaskImage") { }
+    PointCloudToMaskImage(){ }
   protected:
     ////////////////////////////////////////////////////////
     // methods

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pointcloud_to_point_indices.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pointcloud_to_point_indices.h
@@ -37,15 +37,26 @@
 #ifndef JSK_PCL_ROS_UTILS_POINTCLOUD_TO_POINT_INDICES_H_
 #define JSK_PCL_ROS_UTILS_POINTCLOUD_TO_POINT_INDICES_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/PointCloud2.h>
 
 namespace jsk_pcl_ros_utils
 {
-  class PointCloudToPointIndices: public jsk_topic_tools::DiagnosticNodelet
+  class PointCloudToPointIndices: public jsk_topic_tools::NODELET
   {
   public:
-    PointCloudToPointIndices(): DiagnosticNodelet("PointCloudToPointIndices") { }
+    PointCloudToPointIndices(){ }
   protected:
     ////////////////////////////////////////////////////////
     // methods

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pointcloud_xyz_to_xyzrgb.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pointcloud_xyz_to_xyzrgb.h
@@ -35,17 +35,28 @@
 #ifndef JSK_PCL_ROS_UTILS_POINTCLOUD_XYZ_TO_XYZRGB_H_
 #define JSK_PCL_ROS_UTILS_POINTCLOUD_XYZ_TO_XYZRGB_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 #include <sensor_msgs/PointCloud2.h>
 
 namespace jsk_pcl_ros_utils
 {
 
-class PointCloudXYZToXYZRGB: public jsk_topic_tools::DiagnosticNodelet
+class PointCloudXYZToXYZRGB: public jsk_topic_tools::NODELET
 {
 public:
-  PointCloudXYZToXYZRGB(): DiagnosticNodelet("PointCloudXYZToXYZRGB") { }
+  PointCloudXYZToXYZRGB(){ }
 protected:
   virtual void onInit();
   virtual void subscribe();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pointcloud_xyzrgb_to_xyz.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pointcloud_xyzrgb_to_xyz.h
@@ -35,17 +35,28 @@
 #ifndef JSK_PCL_ROS_UTILS_POINTCLOUD_XYZRGB_TO_XYZ_H_
 #define JSK_PCL_ROS_UTILS_POINTCLOUD_XYZRGB_TO_XYZ_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 #include <sensor_msgs/PointCloud2.h>
 
 namespace jsk_pcl_ros_utils
 {
 
-class PointCloudXYZRGBToXYZ: public jsk_topic_tools::DiagnosticNodelet
+class PointCloudXYZRGBToXYZ: public jsk_topic_tools::NODELET
 {
 public:
-  PointCloudXYZRGBToXYZ(): DiagnosticNodelet("PointCloudXYZRGBToXYZ") { }
+  PointCloudXYZRGBToXYZ(){ }
 protected:
   virtual void onInit();
   virtual void subscribe();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_appender.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_appender.h
@@ -44,17 +44,28 @@
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/synchronizer.h>
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros_utils
 {
-  class PolygonAppender: public jsk_topic_tools::DiagnosticNodelet
+  class PolygonAppender: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<
     jsk_recognition_msgs::PolygonArray, jsk_recognition_msgs::ModelCoefficientsArray,
     jsk_recognition_msgs::PolygonArray, jsk_recognition_msgs::ModelCoefficientsArray> SyncPolicy2;
-    PolygonAppender() : DiagnosticNodelet("PolygonAppender") {}
+    PolygonAppender(){}
     virtual ~PolygonAppender();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_array_angle_likelihood.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_array_angle_likelihood.h
@@ -37,7 +37,18 @@
 #define JSK_PCL_ROS_UTILS_POLYGON_ARRAY_ANGLE_LIKELIHOOD_H_
 
 #include <jsk_recognition_msgs/PolygonArray.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 #include <tf/message_filter.h>
 #include <message_filters/subscriber.h>
@@ -45,11 +56,11 @@
 
 namespace jsk_pcl_ros_utils
 {
-  class PolygonArrayAngleLikelihood: public jsk_topic_tools::DiagnosticNodelet
+  class PolygonArrayAngleLikelihood: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<PolygonArrayAngleLikelihood> Ptr;
-    PolygonArrayAngleLikelihood(): DiagnosticNodelet("PolygonArrayAngleLikelihood") {}
+    PolygonArrayAngleLikelihood(){}
 
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_array_area_likelihood.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_array_area_likelihood.h
@@ -37,7 +37,18 @@
 #define JSK_PCL_ROS_UTILS_POLYGON_ARRAY_AREA_LIKELIHOOD_H_
 
 #include <jsk_recognition_msgs/PolygonArray.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 #include <tf/message_filter.h>
 #include <message_filters/subscriber.h>
@@ -46,12 +57,12 @@
 
 namespace jsk_pcl_ros_utils
 {
-  class PolygonArrayAreaLikelihood: public jsk_topic_tools::DiagnosticNodelet
+  class PolygonArrayAreaLikelihood: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<PolygonArrayAreaLikelihood> Ptr;
     typedef PolygonArrayAreaLikelihoodConfig Config;
-    PolygonArrayAreaLikelihood(): DiagnosticNodelet("PolygonArrayAreaLikelihood") {}
+    PolygonArrayAreaLikelihood(){}
 
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_array_distance_likelihood.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_array_distance_likelihood.h
@@ -37,18 +37,29 @@
 #define JSK_PCL_ROS_UTILS_POLYGON_ARRAY_DISTANCE_LIKELIHOOD_H_
 
 #include <jsk_recognition_msgs/PolygonArray.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 #include <tf/message_filter.h>
 #include <message_filters/subscriber.h>
 
 namespace jsk_pcl_ros_utils
 {
-  class PolygonArrayDistanceLikelihood: public jsk_topic_tools::DiagnosticNodelet
+  class PolygonArrayDistanceLikelihood: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<PolygonArrayDistanceLikelihood> Ptr;
-    PolygonArrayDistanceLikelihood(): DiagnosticNodelet("PolygonArrayDistanceLikelihood") {}
+    PolygonArrayDistanceLikelihood(){}
 
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_array_foot_angle_likelihood.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_array_foot_angle_likelihood.h
@@ -37,7 +37,18 @@
 #define JSK_PCL_ROS_UTILS_POLYGON_ARRAY_FOOT_ANGLE_LIKELIHOOD_H_
 
 #include <jsk_recognition_msgs/PolygonArray.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 #include <tf/message_filter.h>
 #include <message_filters/subscriber.h>
@@ -45,11 +56,11 @@
 
 namespace jsk_pcl_ros_utils
 {
-  class PolygonArrayFootAngleLikelihood: public jsk_topic_tools::DiagnosticNodelet
+  class PolygonArrayFootAngleLikelihood: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<PolygonArrayFootAngleLikelihood> Ptr;
-    PolygonArrayFootAngleLikelihood(): DiagnosticNodelet("PolygonArrayFootAngleLikelihood") {}
+    PolygonArrayFootAngleLikelihood(){}
 
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_array_likelihood_filter.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_array_likelihood_filter.h
@@ -45,12 +45,23 @@
 #include <jsk_pcl_ros_utils/PolygonArrayLikelihoodFilterConfig.h>
 #include <jsk_recognition_msgs/PolygonArray.h>
 #include <jsk_recognition_msgs/ModelCoefficientsArray.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 
 namespace jsk_pcl_ros_utils
 {
-  class PolygonArrayLikelihoodFilter: public jsk_topic_tools::DiagnosticNodelet
+  class PolygonArrayLikelihoodFilter: public jsk_topic_tools::NODELET
   {
   public:
     typedef PolygonArrayLikelihoodFilterConfig Config;
@@ -58,7 +69,7 @@ namespace jsk_pcl_ros_utils
       jsk_recognition_msgs::PolygonArray,
       jsk_recognition_msgs::ModelCoefficientsArray>
     SyncPolicy;
-    PolygonArrayLikelihoodFilter(): DiagnosticNodelet("PolygonArrayLikelihoodFilter") {}
+    PolygonArrayLikelihoodFilter(){}
     virtual ~PolygonArrayLikelihoodFilter();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_array_transformer.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_array_transformer.h
@@ -52,17 +52,28 @@
 #include <message_filters/synchronizer.h>
 
 #include "jsk_recognition_utils/pcl_conversion_util.h"
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros_utils
 {
-  class PolygonArrayTransformer: public jsk_topic_tools::DiagnosticNodelet
+  class PolygonArrayTransformer: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<
     jsk_recognition_msgs::PolygonArray,
     jsk_recognition_msgs::ModelCoefficientsArray > SyncPolicy;
-    PolygonArrayTransformer() : DiagnosticNodelet("PolygonArrayTransformer") {}
+    PolygonArrayTransformer(){}
     virtual ~PolygonArrayTransformer();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_array_unwrapper.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_array_unwrapper.h
@@ -46,12 +46,23 @@
 #include <jsk_pcl_ros_utils/PolygonArrayUnwrapperConfig.h>
 #include <jsk_recognition_msgs/PolygonArray.h>
 #include <jsk_recognition_msgs/ModelCoefficientsArray.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 
 namespace jsk_pcl_ros_utils
 {
-  class PolygonArrayUnwrapper: public jsk_topic_tools::DiagnosticNodelet
+  class PolygonArrayUnwrapper: public jsk_topic_tools::NODELET
   {
   public:
     typedef PolygonArrayUnwrapperConfig Config;
@@ -59,7 +70,7 @@ namespace jsk_pcl_ros_utils
     jsk_recognition_msgs::PolygonArray,
     jsk_recognition_msgs::ModelCoefficientsArray>
     SyncPolicy;
-    PolygonArrayUnwrapper() : DiagnosticNodelet("PolygonArrayUnwrapper") {}
+    PolygonArrayUnwrapper(){}
     virtual ~PolygonArrayUnwrapper();
 
   protected:

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_array_wrapper.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_array_wrapper.h
@@ -44,16 +44,27 @@
 #include <geometry_msgs/PolygonStamped.h>
 #include <jsk_recognition_msgs/PolygonArray.h>
 #include <jsk_recognition_msgs/ModelCoefficientsArray.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros_utils
 {
-  class PolygonArrayWrapper: public jsk_topic_tools::DiagnosticNodelet
+  class PolygonArrayWrapper: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<
       geometry_msgs::PolygonStamped, pcl_msgs::ModelCoefficients> SyncPolicy;
-    PolygonArrayWrapper() : DiagnosticNodelet("PolygonArrayWrapper") {}
+    PolygonArrayWrapper(){}
     virtual ~PolygonArrayWrapper();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_flipper.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_flipper.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_UTILS_POLYGON_FLIPPER_H_
 #define JSK_PCL_ROS_UTILS_POLYGON_FLIPPER_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_recognition_msgs/PolygonArray.h>
 #include <jsk_recognition_msgs/ModelCoefficientsArray.h>
 #include <jsk_recognition_msgs/ClusterPointIndices.h>
@@ -52,7 +63,7 @@
 
 namespace jsk_pcl_ros_utils
 {
-  class PolygonFlipper: public jsk_topic_tools::DiagnosticNodelet
+  class PolygonFlipper: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<PolygonFlipper> Ptr;
@@ -60,7 +71,7 @@ namespace jsk_pcl_ros_utils
       jsk_recognition_msgs::PolygonArray,
       jsk_recognition_msgs::ClusterPointIndices,
       jsk_recognition_msgs::ModelCoefficientsArray > SyncPolicy;
-    PolygonFlipper(): DiagnosticNodelet("PolygonFlipper") {}
+    PolygonFlipper(){}
     virtual ~PolygonFlipper();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_magnifier.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_magnifier.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_UTILS_POLYGON_MAGNIFIER_H_
 #define JSK_PCL_ROS_UTILS_POLYGON_MAGNIFIER_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 #include <jsk_pcl_ros_utils/PolygonMagnifierConfig.h>
 #include <dynamic_reconfigure/server.h>
@@ -46,12 +57,12 @@
 
 namespace jsk_pcl_ros_utils
 {
-  class PolygonMagnifier: public jsk_topic_tools::DiagnosticNodelet
+  class PolygonMagnifier: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<PolygonMagnifier> Ptr;
     typedef PolygonMagnifierConfig Config;
-    PolygonMagnifier(): DiagnosticNodelet("PolygonMagnifier") {}
+    PolygonMagnifier(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_points_sampler.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/polygon_points_sampler.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_UTILS_POLYGON_POINTS_SAMPLER_H_
 #define JSK_PCL_ROS_UTILS_POLYGON_POINTS_SAMPLER_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include "jsk_recognition_utils/geo_util.h"
 
 #include <jsk_pcl_ros_utils/PolygonPointsSamplerConfig.h>
@@ -51,7 +62,7 @@
 #include <jsk_recognition_msgs/ModelCoefficientsArray.h>
 namespace jsk_pcl_ros_utils
 {
-  class PolygonPointsSampler: public jsk_topic_tools::DiagnosticNodelet
+  class PolygonPointsSampler: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<PolygonPointsSampler> Ptr;
@@ -61,7 +72,7 @@ namespace jsk_pcl_ros_utils
       jsk_recognition_msgs::PolygonArray,
       jsk_recognition_msgs::ModelCoefficientsArray > SyncPolicy;
     
-    PolygonPointsSampler(): DiagnosticNodelet("PolygonPointsSampler") {}
+    PolygonPointsSampler(){}
     virtual ~PolygonPointsSampler();
   protected:
     virtual void onInit();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pose_with_covariance_stamped_to_gaussian_pointcloud.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/pose_with_covariance_stamped_to_gaussian_pointcloud.h
@@ -37,19 +37,29 @@
 #ifndef JSK_PCL_ROS_UTILS_POSE_WITH_COVARIANCE_STAMPED_TO_GAUSSIAN_POINTCLOUD_H_
 #define JSK_PCL_ROS_UTILS_POSE_WITH_COVARIANCE_STAMPED_TO_GAUSSIAN_POINTCLOUD_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
 #include <jsk_pcl_ros_utils/PoseWithCovarianceStampedToGaussianPointCloudConfig.h>
 #include <Eigen/Geometry>
 #include <dynamic_reconfigure/server.h>
 namespace jsk_pcl_ros_utils
 {
-  class PoseWithCovarianceStampedToGaussianPointCloud: public jsk_topic_tools::DiagnosticNodelet
+  class PoseWithCovarianceStampedToGaussianPointCloud: public jsk_topic_tools::NODELET
   {
   public:
     typedef PoseWithCovarianceStampedToGaussianPointCloudConfig Config;
-    PoseWithCovarianceStampedToGaussianPointCloud(): 
-      DiagnosticNodelet("PoseWithCovarianceStampedToGaussianPointCloud") {}
+    PoseWithCovarianceStampedToGaussianPointCloud(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/spherical_pointcloud_simulator.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/spherical_pointcloud_simulator.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_UTILS_SPHERICAL_POINTCLOUD_SIMULATOR_H_
 #define JSK_PCL_ROS_UTILS_SPHERICAL_POINTCLOUD_SIMULATOR_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_pcl_ros_utils/SphericalPointCloudSimulatorConfig.h>
 #include <pcl_conversions/pcl_conversions.h>
 #include <dynamic_reconfigure/server.h>
@@ -48,12 +59,11 @@ namespace jsk_pcl_ros_utils
    * This is a class for jsk_pcl/SphericalPointCloudSimulator nodelet.
    *
    */
-  class SphericalPointCloudSimulator: public jsk_topic_tools::DiagnosticNodelet
+  class SphericalPointCloudSimulator: public jsk_topic_tools::NODELET
   {
   public:
     typedef SphericalPointCloudSimulatorConfig Config;
-    SphericalPointCloudSimulator():
-      DiagnosticNodelet("SphericalPointCloudSimulator") {}
+    SphericalPointCloudSimulator(){}
   protected:
     /** @brief
      * Initialization function.

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/static_polygon_array_publisher.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/static_polygon_array_publisher.h
@@ -55,19 +55,30 @@
 #include <jsk_recognition_msgs/Int32Stamped.h>
 #include <std_msgs/Header.h>
 #include "jsk_recognition_utils/pcl_conversion_util.h"
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_pcl_ros_utils
 {
 
   class StaticPolygonArrayPublisher:
-    public jsk_topic_tools::DiagnosticNodelet
+    public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ApproximateTime<
     sensor_msgs::PointCloud2,
     jsk_recognition_msgs::Int32Stamped > SyncPolicy;
-    StaticPolygonArrayPublisher() : DiagnosticNodelet("StaticPolygonArrayPublisher") {}
+    StaticPolygonArrayPublisher(){}
     virtual ~StaticPolygonArrayPublisher();
 
   protected:

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/subtract_point_indices.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/subtract_point_indices.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PCL_ROS_UTILS_SUBTRACT_POINT_INDICES_H_
 #define JSK_PCL_ROS_UTILS_SUBTRACT_POINT_INDICES_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 #include "jsk_recognition_utils/pcl_conversion_util.h"
 #include "jsk_recognition_utils/pcl_util.h"
@@ -50,7 +61,7 @@
 
 namespace jsk_pcl_ros_utils
 {
-  class SubtractPointIndices: public jsk_topic_tools::DiagnosticNodelet
+  class SubtractPointIndices: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<
@@ -60,7 +71,7 @@ namespace jsk_pcl_ros_utils
     PCLIndicesMsg,
     PCLIndicesMsg > ASyncPolicy;
 
-    SubtractPointIndices(): DiagnosticNodelet("SubtractPointIndices") {}
+    SubtractPointIndices(){}
     virtual ~SubtractPointIndices();
 
   protected:

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/tf_transform_bounding_box.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/tf_transform_bounding_box.h
@@ -37,7 +37,18 @@
 #define JSK_PCL_ROS_UTILS_TF_TRANFORM_BOUNDING_BOX_H_
 
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_recognition_msgs/BoundingBox.h>
 
 #include "jsk_recognition_utils/tf_listener_singleton.h"
@@ -47,10 +58,10 @@
 namespace jsk_pcl_ros_utils
 {
 
-  class TfTransformBoundingBox: public jsk_topic_tools::DiagnosticNodelet
+  class TfTransformBoundingBox: public jsk_topic_tools::NODELET
   {
   public:
-    TfTransformBoundingBox(): DiagnosticNodelet("TfTransformBoundingBox") {}
+    TfTransformBoundingBox(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/tf_transform_bounding_box_array.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/tf_transform_bounding_box_array.h
@@ -37,7 +37,18 @@
 #define JSK_PCL_ROS_UTILS_TF_TRANFORM_BOUNDING_BOX_ARRAY_H_
 
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_recognition_msgs/BoundingBoxArray.h>
 
 #include "jsk_recognition_utils/tf_listener_singleton.h"
@@ -47,10 +58,10 @@
 namespace jsk_pcl_ros_utils
 {
 
-  class TfTransformBoundingBoxArray: public jsk_topic_tools::DiagnosticNodelet
+  class TfTransformBoundingBoxArray: public jsk_topic_tools::NODELET
   {
   public:
-    TfTransformBoundingBoxArray(): DiagnosticNodelet("TfTransformBoundingBoxArray") {}
+    TfTransformBoundingBoxArray(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/tf_transform_cloud.h
+++ b/jsk_pcl_ros_utils/include/jsk_pcl_ros_utils/tf_transform_cloud.h
@@ -47,7 +47,18 @@
 #include <pcl_ros/pcl_nodelet.h>
 #include <pcl/point_types.h>
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include "jsk_recognition_utils/tf_listener_singleton.h"
 
 #include <tf/message_filter.h>
@@ -55,10 +66,10 @@
 
 namespace jsk_pcl_ros_utils
 {
-  class TfTransformCloud: public jsk_topic_tools::DiagnosticNodelet
+  class TfTransformCloud: public jsk_topic_tools::NODELET
   {
   public:
-    TfTransformCloud(): DiagnosticNodelet("TfTransformCloud") {}
+    TfTransformCloud(){}
   protected:
     ros::Subscriber sub_cloud_;
     message_filters::Subscriber<sensor_msgs::PointCloud2> sub_cloud_message_filters_;

--- a/jsk_pcl_ros_utils/src/add_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/add_point_indices_nodelet.cpp
@@ -41,7 +41,7 @@ namespace jsk_pcl_ros_utils
 {
   void AddPointIndices::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("approximate_sync", approximate_sync_, false);
     pub_ = advertise<PCLIndicesMsg>(*pnh_, "output", 1);
     onInitPostProcess();
@@ -97,7 +97,9 @@ namespace jsk_pcl_ros_utils
     PCLIndicesMsg ros_indices;
     pcl_conversions::fromPCL(*c, ros_indices);
     ros_indices.header = src1->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(ros_indices);
   }
 }

--- a/jsk_pcl_ros_utils/src/bounding_box_array_to_bounding_box_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/bounding_box_array_to_bounding_box_nodelet.cpp
@@ -43,7 +43,7 @@ namespace jsk_pcl_ros_utils
 
   void BoundingBoxArrayToBoundingBox::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     // dynamic_reconfigure
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
@@ -87,7 +87,9 @@ namespace jsk_pcl_ros_utils
       NODELET_ERROR_THROTTLE(10, "Invalid ~index %d is specified for array size %d.", index_, array_size);
     }
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(bbox_msg);
   }
 

--- a/jsk_pcl_ros_utils/src/centroid_publisher_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/centroid_publisher_nodelet.cpp
@@ -49,7 +49,9 @@ namespace jsk_pcl_ros_utils
 {
   void CentroidPublisher::extract(const sensor_msgs::PointCloud2ConstPtr& input)
   {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pcl::PointCloud<pcl::PointXYZ> cloud_xyz;
     pcl::fromROSMsg(*input, cloud_xyz);
     Eigen::Vector4f center;
@@ -111,7 +113,9 @@ namespace jsk_pcl_ros_utils
       pose_array.poses[i].orientation.z = q.z();
       pose_array.poses[i].orientation.w = q.w();
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_pose_array_.publish(pose_array);
   }
 
@@ -129,7 +133,7 @@ namespace jsk_pcl_ros_utils
   
   void CentroidPublisher::onInit(void)
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("publish_tf", publish_tf_, false);
     if (publish_tf_) {
       if (!pnh_->getParam("frame", frame_))

--- a/jsk_pcl_ros_utils/src/cloud_on_plane_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/cloud_on_plane_nodelet.cpp
@@ -42,7 +42,7 @@ namespace jsk_pcl_ros_utils
 {
   void CloudOnPlane::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pcl::console::setVerbosityLevel(pcl::console::L_ALWAYS);
     pnh_->param("approximate_sync", approximate_sync_, false);
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
@@ -136,7 +136,9 @@ namespace jsk_pcl_ros_utils
     jsk_recognition_msgs::BoolStamped bool_stamped;
     bool_stamped.header = header;
     bool_stamped.data = v;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(bool_stamped);
   }
 }

--- a/jsk_pcl_ros_utils/src/cluster_point_indices_label_filter_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/cluster_point_indices_label_filter_nodelet.cpp
@@ -40,7 +40,7 @@ namespace jsk_pcl_ros_utils
 
   void ClusterPointIndicesLabelFilter::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("approximate_sync", approximate_sync_, false);
     pnh_->param("queue_size", queue_size_, 100);
 
@@ -95,7 +95,9 @@ namespace jsk_pcl_ros_utils
       if(label_msg->labels[i].id == label_value_)
         filtered_msg.cluster_indices.push_back(cluster_msg->cluster_indices[i]);
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(filtered_msg);
   }
 

--- a/jsk_pcl_ros_utils/src/cluster_point_indices_to_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/cluster_point_indices_to_point_indices_nodelet.cpp
@@ -43,7 +43,7 @@ namespace jsk_pcl_ros_utils
 
   void ClusterPointIndicesToPointIndices::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     // dynamic_reconfigure
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
@@ -93,7 +93,9 @@ namespace jsk_pcl_ros_utils
     } else {
       NODELET_ERROR_THROTTLE(10, "Invalid ~index %d is specified for cluster size %d.", index_, cluster_size);
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(indices_msg);
   }
 

--- a/jsk_pcl_ros_utils/src/colorize_distance_from_plane_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/colorize_distance_from_plane_nodelet.cpp
@@ -40,7 +40,7 @@ namespace jsk_pcl_ros_utils
 {
   void ColorizeDistanceFromPlane::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     ////////////////////////////////////////////////////////
     // publisher
@@ -182,7 +182,9 @@ namespace jsk_pcl_ros_utils
     sensor_msgs::PointCloud2 ros_output;
     pcl::toROSMsg(*output_cloud, ros_output);
     ros_output.header = cloud_msg->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(ros_output);
   }
   

--- a/jsk_pcl_ros_utils/src/colorize_height_2d_mapping_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/colorize_height_2d_mapping_nodelet.cpp
@@ -43,7 +43,7 @@ namespace jsk_pcl_ros_utils
 {
   void ColorizeHeight2DMapping::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);
     onInitPostProcess();
   }
@@ -80,7 +80,9 @@ namespace jsk_pcl_ros_utils
     sensor_msgs::PointCloud2 ros_cloud;
     pcl::toROSMsg(colorized_cloud, ros_cloud);
     ros_cloud.header = msg->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(ros_cloud);
   }
 }

--- a/jsk_pcl_ros_utils/src/delay_pointcloud_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/delay_pointcloud_nodelet.cpp
@@ -40,7 +40,7 @@ namespace jsk_pcl_ros_utils
 {
   void DelayPointCloud::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
@@ -65,7 +65,9 @@ namespace jsk_pcl_ros_utils
   {
     sensor_msgs::PointCloud2 out_cloud_msg = *msg;
     out_cloud_msg.header.stamp = ros::Time::now();
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(out_cloud_msg);
   }
 

--- a/jsk_pcl_ros_utils/src/depth_image_error_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/depth_image_error_nodelet.cpp
@@ -42,7 +42,7 @@ namespace jsk_pcl_ros_utils
 {
   void DepthImageError::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("approximate_sync", approximate_sync_, false);
     depth_error_publisher_ = advertise<jsk_recognition_msgs::DepthErrorResult>(*pnh_, "output", 1);
     onInitPostProcess();
@@ -107,7 +107,9 @@ namespace jsk_pcl_ros_utils
       result.center_v = camera_info->P[6];
       result.true_depth = uv_point->point.z;
       result.observed_depth = depth_from_depth_sensor;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       depth_error_publisher_.publish(result);
     }
   }

--- a/jsk_pcl_ros_utils/src/label_to_cluster_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/label_to_cluster_point_indices_nodelet.cpp
@@ -45,7 +45,7 @@ namespace jsk_pcl_ros_utils
 
   void LabelToClusterPointIndices::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("bg_label", bg_label_, 0);
     pnh_->param("ignore_labels", ignore_labels_, std::vector<int>());
     pub_ = advertise<jsk_recognition_msgs::ClusterPointIndices>(*pnh_, "output", 1);
@@ -112,7 +112,9 @@ namespace jsk_pcl_ros_utils
         cluster_indices_msg.cluster_indices.push_back(label_to_indices[i]);
       }
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_bg_.publish(bg_indices_msg);
     pub_.publish(cluster_indices_msg);
   }

--- a/jsk_pcl_ros_utils/src/marker_array_voxel_to_pointcloud_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/marker_array_voxel_to_pointcloud_nodelet.cpp
@@ -42,7 +42,7 @@ namespace jsk_pcl_ros_utils
 
   void MarkerArrayVoxelToPointCloud::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);
     onInitPostProcess();
@@ -80,7 +80,9 @@ namespace jsk_pcl_ros_utils
     sensor_msgs::PointCloud2 ros_cloud;
     pcl::toROSMsg(*cloud, ros_cloud);
     ros_cloud.header = marker_array_msg->markers[0].header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(ros_cloud);
   }
 

--- a/jsk_pcl_ros_utils/src/mask_image_to_depth_considered_mask_image_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/mask_image_to_depth_considered_mask_image_nodelet.cpp
@@ -43,7 +43,7 @@ namespace jsk_pcl_ros_utils
 {
   void MaskImageToDepthConsideredMaskImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<sensor_msgs::Image>(*pnh_, "output", 1);
     applypub_ = advertise<sensor_msgs::Image>(*pnh_, "applyoutput", 1);
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
@@ -236,7 +236,9 @@ namespace jsk_pcl_ros_utils
           cv_bridge::CvImage mask_bridge(point_cloud2_msg->header,
                                          sensor_msgs::image_encodings::MONO8,
                                          mask_image);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
           vital_checker_->poke();
+#endif
           pub_.publish(mask_bridge.toImageMsg());
           if (use_mask_region_ == false || region_width_ == 0 | region_height_ == 0) {
             applypub_.publish(mask_bridge.toImageMsg());
@@ -295,7 +297,9 @@ namespace jsk_pcl_ros_utils
         cv_bridge::CvImage mask_bridge(point_cloud2_msg->header,
                                        sensor_msgs::image_encodings::MONO8,
                                        tmp_mask);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
         vital_checker_->poke();
+#endif
         pub_.publish(mask_bridge.toImageMsg());
         if (use_mask_region_ == false || region_width_ == 0 | region_height_ == 0) {
           applypub_.publish(mask_bridge.toImageMsg());

--- a/jsk_pcl_ros_utils/src/mask_image_to_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/mask_image_to_point_indices_nodelet.cpp
@@ -42,7 +42,7 @@ namespace jsk_pcl_ros_utils
 {
   void MaskImageToPointIndices::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("use_multi_channels", use_multi_channels_, false);
     pnh_->param("target_channel", target_channel_, -1);
 
@@ -87,7 +87,9 @@ namespace jsk_pcl_ros_utils
             }
           }
         }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
         vital_checker_->poke();
+#endif
         pub_.publish(cluster_msg);
       } else {
         if (target_channel_ > image.channels() - 1) {
@@ -104,7 +106,9 @@ namespace jsk_pcl_ros_utils
             }
           }
         }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
         vital_checker_->poke();
+#endif
         pub_.publish(indices_msg);
       }
     } else {
@@ -120,7 +124,9 @@ namespace jsk_pcl_ros_utils
           }
         }
       }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_.publish(indices_msg);
     }
   }

--- a/jsk_pcl_ros_utils/src/normal_concatenater_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/normal_concatenater_nodelet.cpp
@@ -73,13 +73,15 @@ namespace jsk_pcl_ros_utils
     sensor_msgs::PointCloud2 output_cloud;
     pcl::toROSMsg(concatenated_cloud, output_cloud);
     output_cloud.header = xyz->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(output_cloud);
   }
   
   void NormalConcatenater::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pcl::console::setVerbosityLevel(pcl::console::L_ERROR);
     pnh_->param("use_async", use_async_, false);
     pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);

--- a/jsk_pcl_ros_utils/src/normal_flip_to_frame_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/normal_flip_to_frame_nodelet.cpp
@@ -43,7 +43,7 @@ namespace jsk_pcl_ros_utils
 {
   void NormalFlipToFrame::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pcl::console::setVerbosityLevel(pcl::console::L_ERROR);
     tf_listener_ = jsk_recognition_utils::TfListenerSingleton::getInstance();
     if (!pnh_->getParam("frame_id", frame_id_)) {
@@ -124,7 +124,9 @@ namespace jsk_pcl_ros_utils
       sensor_msgs::PointCloud2 ros_cloud;
       pcl::toROSMsg(*flipped_cloud, ros_cloud);
       ros_cloud.header = cloud_msg->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_.publish(ros_cloud);
     }
     catch (tf2::ConnectivityException &e)

--- a/jsk_pcl_ros_utils/src/pcd_reader_with_pose_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/pcd_reader_with_pose_nodelet.cpp
@@ -46,7 +46,7 @@ namespace jsk_pcl_ros_utils
   void PCDReaderWithPose::onInit()
   {
     pcl::console::setVerbosityLevel(pcl::console::L_ERROR);
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     std::string file_name;
     pnh_->param("pcd_file", file_name, std::string(""));
     if (file_name == std::string("") || pcl::io::loadPCDFile (file_name, template_cloud_) == -1){
@@ -76,7 +76,9 @@ namespace jsk_pcl_ros_utils
     Eigen::Matrix4f transform = pose_eigen.matrix();
     pcl_ros::transformPointCloud(transform ,template_cloud_, ros_out);
     ros_out.header = pose_stamped->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_cloud_.publish(ros_out);
   }
 }

--- a/jsk_pcl_ros_utils/src/planar_pointcloud_simulator_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/planar_pointcloud_simulator_nodelet.cpp
@@ -72,7 +72,7 @@ namespace jsk_pcl_ros_utils
 
   void PlanarPointCloudSimulatorNodelet::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     typename dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&PlanarPointCloudSimulatorNodelet::configCallback, this, _1, _2);
@@ -112,7 +112,9 @@ namespace jsk_pcl_ros_utils
     sensor_msgs::PointCloud2 ros_cloud;
     pcl::toROSMsg(*cloud, ros_cloud);
     ros_cloud.header = info_msg->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(ros_cloud);
   }
   

--- a/jsk_pcl_ros_utils/src/plane_concatenator_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/plane_concatenator_nodelet.cpp
@@ -45,7 +45,7 @@ namespace jsk_pcl_ros_utils
 {
   void PlaneConcatenator::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pcl::console::setVerbosityLevel(pcl::console::L_ALWAYS);
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
@@ -196,7 +196,9 @@ namespace jsk_pcl_ros_utils
     // new_ros_coefficients.coefficients
     //   = pcl_conversions::convertToROSModelCoefficients(
     //     new_refined_coefficients, cloud_msg->header);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_indices_.publish(new_ros_indices);
     pub_polygon_.publish(new_ros_polygons);
     pub_coefficients_.publish(new_ros_coefficients);

--- a/jsk_pcl_ros_utils/src/plane_reasoner_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/plane_reasoner_nodelet.cpp
@@ -44,7 +44,7 @@ namespace jsk_pcl_ros_utils
     ////////////////////////////////////////////////////////
     // Diagnostics
     ////////////////////////////////////////////////////////
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     tf_listener_ = jsk_recognition_utils::TfListenerSingleton::getInstance();
     
     ////////////////////////////////////////////////////////
@@ -193,7 +193,9 @@ namespace jsk_pcl_ros_utils
       = pcl_conversions::convertToROSModelCoefficients(
         coefficients, header);
     ros_polygons.polygons = polygons;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_inlier.publish(ros_indices);
     pub_coefficients.publish(ros_coefficients);
     pub_polygons.publish(ros_polygons);

--- a/jsk_pcl_ros_utils/src/plane_rejector_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/plane_rejector_nodelet.cpp
@@ -43,7 +43,7 @@ namespace jsk_pcl_ros_utils
 {
   void PlaneRejector::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     tf_success_.reset(new jsk_recognition_utils::SeriesedBoolean(30));
     listener_ = jsk_recognition_utils::TfListenerSingleton::getInstance();
 
@@ -122,7 +122,8 @@ namespace jsk_pcl_ros_utils
     sub_polygons_.unsubscribe();
     sub_coefficients_.unsubscribe();
   }
-  
+
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
   void PlaneRejector::updateDiagnostic(
     diagnostic_updater::DiagnosticStatusWrapper &stat)
   {
@@ -150,6 +151,7 @@ namespace jsk_pcl_ros_utils
     }
     DiagnosticNodelet::updateDiagnostic(stat);
   }
+#endif
 
   void PlaneRejector::configCallback (Config &config, uint32_t level)
   {
@@ -223,13 +225,17 @@ namespace jsk_pcl_ros_utils
     }
     rejected_plane_counter_.add(rejected_plane_counter);
     passed_plane_counter_.add(passed_plane_counter);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     polygons_pub_.publish(result_polygons);
     coefficients_pub_.publish(result_coefficients);
     if (use_inliers_) {
       inliers_pub_.publish(result_inliers);
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     diagnostic_updater_->update();
+#endif
   }
   
 }

--- a/jsk_pcl_ros_utils/src/point_indices_to_cluster_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/point_indices_to_cluster_point_indices_nodelet.cpp
@@ -40,7 +40,7 @@ namespace jsk_pcl_ros_utils
 {
   void PointIndicesToClusterPointIndices::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<jsk_recognition_msgs::ClusterPointIndices>(*pnh_, "output", 1);
     onInitPostProcess();
   }
@@ -62,7 +62,9 @@ namespace jsk_pcl_ros_utils
     jsk_recognition_msgs::ClusterPointIndices cluster_indices_msg;
     cluster_indices_msg.header = indices_msg->header;
     cluster_indices_msg.cluster_indices.push_back(*indices_msg);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(cluster_indices_msg);
   }
 }

--- a/jsk_pcl_ros_utils/src/point_indices_to_mask_image_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/point_indices_to_mask_image_nodelet.cpp
@@ -42,7 +42,7 @@ namespace jsk_pcl_ros_utils
 {
   void PointIndicesToMaskImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("approximate_sync", approximate_sync_, false);
     pnh_->param("queue_size", queue_size_, 100);
     pnh_->param("static_image_size", static_image_size_, false);
@@ -113,7 +113,9 @@ namespace jsk_pcl_ros_utils
     cv_bridge::CvImage mask_bridge(indices_msg->header,
                                    sensor_msgs::image_encodings::MONO8,
                                    mask_image);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(mask_bridge.toImageMsg());
   }
 

--- a/jsk_pcl_ros_utils/src/pointcloud_relative_from_pose_stamped_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/pointcloud_relative_from_pose_stamped_nodelet.cpp
@@ -45,7 +45,7 @@ namespace jsk_pcl_ros_utils
 {
   void PointCloudRelativeFromPoseStamped::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);
     pnh_->param<bool>("approximate_sync", approximate_sync_, false);
     onInitPostProcess();
@@ -104,7 +104,9 @@ namespace jsk_pcl_ros_utils
     sensor_msgs::PointCloud2 ros_cloud;
     pcl::toROSMsg(*transformed_cloud, ros_cloud);
     ros_cloud.header = cloud_msg->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(ros_cloud);
   }
 }

--- a/jsk_pcl_ros_utils/src/pointcloud_to_cluster_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/pointcloud_to_cluster_point_indices_nodelet.cpp
@@ -43,7 +43,7 @@ namespace jsk_pcl_ros_utils
 {
   void PointCloudToClusterPointIndices::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<jsk_recognition_msgs::ClusterPointIndices>(*pnh_, "output", 1);
     pnh_->param<bool>("skip_nan", skip_nan_, false);
     onInitPostProcess();
@@ -79,7 +79,9 @@ namespace jsk_pcl_ros_utils
     indices.header = msg->header;
     cluster_indices.header = msg->header;
     cluster_indices.cluster_indices.push_back(indices);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(cluster_indices);
   }
 }

--- a/jsk_pcl_ros_utils/src/pointcloud_to_mask_image_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/pointcloud_to_mask_image_nodelet.cpp
@@ -44,7 +44,7 @@ namespace jsk_pcl_ros_utils
 {
   void PointCloudToMaskImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     srv_ = boost::make_shared<dynamic_reconfigure::Server<Config> >(*pnh_);
     typename dynamic_reconfigure::Server<Config>::CallbackType f =
@@ -109,7 +109,9 @@ namespace jsk_pcl_ros_utils
     cv_bridge::CvImage mask_bridge(cloud_msg->header,
                                    sensor_msgs::image_encodings::MONO8,
                                    mask_image);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(mask_bridge.toImageMsg());
   }
 
@@ -161,7 +163,9 @@ namespace jsk_pcl_ros_utils
       return;
     }
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(mask_img->toImageMsg());
   }
 }

--- a/jsk_pcl_ros_utils/src/pointcloud_to_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/pointcloud_to_point_indices_nodelet.cpp
@@ -42,7 +42,7 @@ namespace jsk_pcl_ros_utils
 {
   void PointCloudToPointIndices::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<PCLIndicesMsg>(*pnh_, "output", 1);
     onInitPostProcess();
   }
@@ -70,7 +70,9 @@ namespace jsk_pcl_ros_utils
       }
     }
     indices_msg.header = cloud_msg->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(indices_msg);
   }
 }

--- a/jsk_pcl_ros_utils/src/pointcloud_xyz_to_xyzrgb_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/pointcloud_xyz_to_xyzrgb_nodelet.cpp
@@ -44,7 +44,7 @@ namespace jsk_pcl_ros_utils
 
 void PointCloudXYZToXYZRGB::onInit()
 {
-  DiagnosticNodelet::onInit();
+  jsk_topic_tools::NODELET::onInit();
   pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);
   onInitPostProcess();
 }
@@ -82,7 +82,9 @@ void PointCloudXYZToXYZRGB::convert(const sensor_msgs::PointCloud2::ConstPtr& cl
   sensor_msgs::PointCloud2 out_cloud_msg;
   pcl::toROSMsg(*cloud_xyzrgb, out_cloud_msg);
   out_cloud_msg.header = cloud_msg->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
   vital_checker_->poke();
+#endif
   pub_.publish(out_cloud_msg);
 }
 

--- a/jsk_pcl_ros_utils/src/pointcloud_xyzrgb_to_xyz_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/pointcloud_xyzrgb_to_xyz_nodelet.cpp
@@ -43,7 +43,7 @@ namespace jsk_pcl_ros_utils
 
 void PointCloudXYZRGBToXYZ::onInit()
 {
-  DiagnosticNodelet::onInit();
+  jsk_topic_tools::NODELET::onInit();
   pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", 1);
   onInitPostProcess();
 }
@@ -78,7 +78,9 @@ void PointCloudXYZRGBToXYZ::convert(const sensor_msgs::PointCloud2::ConstPtr& cl
   sensor_msgs::PointCloud2 out_cloud_msg;
   pcl::toROSMsg(*cloud_xyz, out_cloud_msg);
   out_cloud_msg.header = cloud_msg->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
   vital_checker_->poke();
+#endif
   pub_.publish(out_cloud_msg);
 }
 

--- a/jsk_pcl_ros_utils/src/polygon_appender_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_appender_nodelet.cpp
@@ -40,7 +40,7 @@ namespace jsk_pcl_ros_utils
 {
   void PolygonAppender::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_polygon_ = advertise<jsk_recognition_msgs::PolygonArray>(*pnh_, "output", 1);
     pub_coefficients_ = advertise<jsk_recognition_msgs::ModelCoefficientsArray>(*pnh_,
       "output_coefficients", 1);
@@ -119,7 +119,9 @@ namespace jsk_pcl_ros_utils
         new_array.polygons.push_back(polygon);
       }
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_polygon_.publish(new_array);
 
     jsk_recognition_msgs::ModelCoefficientsArray coefficients_new_array;

--- a/jsk_pcl_ros_utils/src/polygon_array_angle_likelihood_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_array_angle_likelihood_nodelet.cpp
@@ -45,7 +45,7 @@ namespace jsk_pcl_ros_utils
 {
   void PolygonArrayAngleLikelihood::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     if (!pnh_->getParam("target_frame_id", target_frame_id_)) {
       ROS_ERROR("You need to specify ~target_frame_id");
       return;
@@ -128,7 +128,9 @@ namespace jsk_pcl_ros_utils
           new_msg.likelihood[i] = new_msg.likelihood[i] * likelihood;
         }
       }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_.publish(new_msg);
     }
     catch (...)

--- a/jsk_pcl_ros_utils/src/polygon_array_area_likelihood_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_array_area_likelihood_nodelet.cpp
@@ -44,7 +44,7 @@ namespace jsk_pcl_ros_utils
 {
   void PolygonArrayAreaLikelihood::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     typename dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&PolygonArrayAreaLikelihood::configCallback, this, _1, _2);
@@ -93,7 +93,9 @@ namespace jsk_pcl_ros_utils
         new_msg.likelihood[i] = new_msg.likelihood[i] * likelihood;
       }
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(new_msg);
   }
 

--- a/jsk_pcl_ros_utils/src/polygon_array_distance_likelihood_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_array_distance_likelihood_nodelet.cpp
@@ -44,7 +44,7 @@ namespace jsk_pcl_ros_utils
 {
   void PolygonArrayDistanceLikelihood::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     if (!pnh_->getParam("target_frame_id", target_frame_id_)) {
       ROS_ERROR("You need to specify ~target_frame_id");
       return;
@@ -117,7 +117,9 @@ namespace jsk_pcl_ros_utils
           new_msg.likelihood[i] = new_msg.likelihood[i] * likelihood;
         }
       }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_.publish(new_msg);
     }
     catch (...)

--- a/jsk_pcl_ros_utils/src/polygon_array_foot_angle_likelihood_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_array_foot_angle_likelihood_nodelet.cpp
@@ -45,7 +45,7 @@ namespace jsk_pcl_ros_utils
 {
   void PolygonArrayFootAngleLikelihood::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     if (!pnh_->getParam("target_frame_id", target_frame_id_)) {
       ROS_ERROR("You need to specify ~target_frame_id");
       return;
@@ -126,7 +126,9 @@ namespace jsk_pcl_ros_utils
           new_msg.likelihood[i] = new_msg.likelihood[i] * likelihood;
         }
       }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_.publish(new_msg);
     }
     catch (...)

--- a/jsk_pcl_ros_utils/src/polygon_array_likelihood_filter_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_array_likelihood_filter_nodelet.cpp
@@ -40,7 +40,7 @@ namespace jsk_pcl_ros_utils
 {
   void PolygonArrayLikelihoodFilter::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     srv_ = boost::make_shared<dynamic_reconfigure::Server<Config> >(*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
@@ -164,7 +164,9 @@ namespace jsk_pcl_ros_utils
     }
 
     ret_polygons.header = polygons->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_polygons_.publish(ret_polygons);
     if (use_coefficients_) {
       ret_coefficients.header = coefficients->header;

--- a/jsk_pcl_ros_utils/src/polygon_array_transformer_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_array_transformer_nodelet.cpp
@@ -43,7 +43,7 @@ namespace jsk_pcl_ros_utils
 
   void PolygonArrayTransformer::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     if (!pnh_->getParam("frame_id", frame_id_)) {
       NODELET_FATAL("~frame_id is not specified");
       return;
@@ -216,7 +216,9 @@ namespace jsk_pcl_ros_utils
         return;
       }
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     polygons_pub_.publish(transformed_polygon_array);
     coefficients_pub_.publish(transformed_model_coefficients_array);
   }

--- a/jsk_pcl_ros_utils/src/polygon_array_unwrapper_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_array_unwrapper_nodelet.cpp
@@ -40,7 +40,7 @@ namespace jsk_pcl_ros_utils
 {
   void PolygonArrayUnwrapper::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_polygon_ = advertise<geometry_msgs::PolygonStamped>(
       *pnh_, "output_polygon", 1);
     pub_coefficients_
@@ -108,7 +108,9 @@ namespace jsk_pcl_ros_utils
       }
       geometry_msgs::PolygonStamped polygon_msg = polygons->polygons[selected_index];
       pcl_msgs::ModelCoefficients coefficients_msg = coefficients->coefficients[selected_index];
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_polygon_.publish(polygon_msg);
       pub_coefficients_.publish(coefficients_msg);
     }

--- a/jsk_pcl_ros_utils/src/polygon_array_wrapper_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_array_wrapper_nodelet.cpp
@@ -39,7 +39,7 @@ namespace jsk_pcl_ros_utils
 {
   void PolygonArrayWrapper::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_polygon_array_ = advertise<jsk_recognition_msgs::PolygonArray>(*pnh_,
       "output_polygons", 1);
     pub_coefficients_array_
@@ -84,7 +84,9 @@ namespace jsk_pcl_ros_utils
     array_msg.header = polygon->header;
     geometry_msgs::PolygonStamped new_polygon(*polygon);
     array_msg.polygons.push_back(new_polygon);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_polygon_array_.publish(array_msg);
 
     jsk_recognition_msgs::ModelCoefficientsArray coefficients_array;

--- a/jsk_pcl_ros_utils/src/polygon_flipper_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_flipper_nodelet.cpp
@@ -43,7 +43,7 @@ namespace jsk_pcl_ros_utils
 {
   void PolygonFlipper::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     if (!pnh_->getParam("sensor_frame", sensor_frame_)) {
       NODELET_FATAL("no ~sensor_frame is specified");
       return;
@@ -183,7 +183,9 @@ namespace jsk_pcl_ros_utils
           }
         }
       }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_polygons_.publish(flipped_polygons);
       pub_coefficients_.publish(flipped_coefficients);
       if (use_indices_)

--- a/jsk_pcl_ros_utils/src/polygon_magnifier_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_magnifier_nodelet.cpp
@@ -41,7 +41,7 @@ namespace jsk_pcl_ros_utils
 {
   void PolygonMagnifier::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     typename dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&PolygonMagnifier::configCallback, this, _1, _2);
@@ -90,7 +90,9 @@ namespace jsk_pcl_ros_utils
 
       ret_polygon_array.polygons[i].polygon = magnified_poly->toROSMsg();
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(ret_polygon_array);
   }
 }

--- a/jsk_pcl_ros_utils/src/polygon_points_sampler_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_points_sampler_nodelet.cpp
@@ -41,7 +41,7 @@ namespace jsk_pcl_ros_utils
 {
   void PolygonPointsSampler::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     typename dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&PolygonPointsSampler::configCallback, this, _1, _2);
@@ -142,7 +142,9 @@ namespace jsk_pcl_ros_utils
     sensor_msgs::PointCloud2 ros_cloud;
     pcl::toROSMsg(*cloud, ros_cloud);
     ros_cloud.header = polygon_msg->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(ros_cloud);
     sensor_msgs::PointCloud2 ros_xyz_cloud;
     pcl::toROSMsg(*xyz_cloud, ros_xyz_cloud);

--- a/jsk_pcl_ros_utils/src/pose_with_covariance_stamped_to_gaussian_pointcloud_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/pose_with_covariance_stamped_to_gaussian_pointcloud_nodelet.cpp
@@ -43,7 +43,7 @@ namespace jsk_pcl_ros_utils
 {
   void PoseWithCovarianceStampedToGaussianPointCloud::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     typename dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&PoseWithCovarianceStampedToGaussianPointCloud::configCallback, this, _1, _2);
@@ -153,7 +153,9 @@ namespace jsk_pcl_ros_utils
     sensor_msgs::PointCloud2 ros_cloud;
     pcl::toROSMsg(*cloud, ros_cloud);
     ros_cloud.header = msg->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(ros_cloud);
   }
   

--- a/jsk_pcl_ros_utils/src/spherical_pointcloud_simulator_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/spherical_pointcloud_simulator_nodelet.cpp
@@ -39,7 +39,7 @@ namespace jsk_pcl_ros_utils
 {
   void SphericalPointCloudSimulator::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->getParam("frame_id", frame_id_);
     rotate_velocity_ = 0.5;
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
@@ -123,7 +123,9 @@ namespace jsk_pcl_ros_utils
     else {
       ros_cloud.header.frame_id = cloud->header.frame_id;
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(ros_cloud);
   }
 

--- a/jsk_pcl_ros_utils/src/static_polygon_array_publisher_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/static_polygon_array_publisher_nodelet.cpp
@@ -41,7 +41,7 @@ namespace jsk_pcl_ros_utils
 
   void StaticPolygonArrayPublisher::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("use_periodic", use_periodic_, false);
     pnh_->param("use_message", use_message_, false);
     pnh_->param("use_trigger", use_trigger_, false);
@@ -259,7 +259,9 @@ namespace jsk_pcl_ros_utils
     for (size_t i = 0; i < coefficients_.coefficients.size(); i++) {
       coefficients_.coefficients[i].header.stamp = stamp;
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     polygon_pub_.publish(polygons_);
     coefficients_pub_.publish(coefficients_);
   }

--- a/jsk_pcl_ros_utils/src/subtract_point_indices_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/subtract_point_indices_nodelet.cpp
@@ -41,7 +41,7 @@ namespace jsk_pcl_ros_utils
 {
   void SubtractPointIndices::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("approximate_sync", approximate_sync_, false);
     pub_ = advertise<PCLIndicesMsg>(*pnh_, "output", 1);
     onInitPostProcess();
@@ -97,7 +97,9 @@ namespace jsk_pcl_ros_utils
     PCLIndicesMsg ros_indices;
     pcl_conversions::fromPCL(*c, ros_indices);
     ros_indices.header = src1->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(ros_indices);
   }
 }

--- a/jsk_pcl_ros_utils/src/tf_transform_bounding_box_array_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/tf_transform_bounding_box_array_nodelet.cpp
@@ -42,7 +42,7 @@ namespace jsk_pcl_ros_utils
 
   void TfTransformBoundingBoxArray::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     if (!pnh_->getParam("target_frame_id", target_frame_id_)) {
       ROS_FATAL("~target_frame_id is not specified");
       return;
@@ -111,7 +111,9 @@ namespace jsk_pcl_ros_utils
         box.header.frame_id = target_frame_id_;
         transformed_box.boxes.push_back(box);
       }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_.publish(transformed_box);
     }
     catch (tf2::ConnectivityException &e)

--- a/jsk_pcl_ros_utils/src/tf_transform_bounding_box_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/tf_transform_bounding_box_nodelet.cpp
@@ -42,7 +42,7 @@ namespace jsk_pcl_ros_utils
 
   void TfTransformBoundingBox::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     if (!pnh_->getParam("target_frame_id", target_frame_id_)) {
       ROS_FATAL("~target_frame_id is not specified");
       return;
@@ -105,7 +105,9 @@ namespace jsk_pcl_ros_utils
       tf::transformTFToEigen(tf_transform, transform);
       Eigen::Affine3f new_pose = transform * pose;
       tf::poseEigenToMsg(new_pose, transformed_box.pose);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_.publish(transformed_box);
     }
     catch (tf2::ConnectivityException &e)

--- a/jsk_pcl_ros_utils/src/tf_transform_cloud_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/tf_transform_cloud_nodelet.cpp
@@ -52,14 +52,18 @@ namespace jsk_pcl_ros_utils
         if (pcl_ros::transformPointCloud(target_frame_id_, latest_pointcloud, output,
                                          *tf_listener_)) {
           output.header.stamp = input->header.stamp;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
           vital_checker_->poke();
+#endif
           pub_cloud_.publish(output);
         }
       }
       else {
         if (pcl_ros::transformPointCloud(target_frame_id_, *input, output,
                                          *tf_listener_)) {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
           vital_checker_->poke();
+#endif
           pub_cloud_.publish(output);
         }
       }
@@ -80,7 +84,7 @@ namespace jsk_pcl_ros_utils
 
   void TfTransformCloud::onInit(void)
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     
     if (!pnh_->getParam("target_frame_id", target_frame_id_))
     {

--- a/jsk_perception/include/jsk_perception/add_mask_image.h
+++ b/jsk_perception/include/jsk_perception/add_mask_image.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_ADD_MASK_IMAGE_H_
 #define JSK_PERCEPTION_ADD_MASK_IMAGE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 
 #include <message_filters/subscriber.h>
@@ -47,7 +58,7 @@
 
 namespace jsk_perception
 {
-  class AddMaskImage: public jsk_topic_tools::DiagnosticNodelet
+  class AddMaskImage: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<
@@ -57,7 +68,7 @@ namespace jsk_perception
     sensor_msgs::Image,
     sensor_msgs::Image > ApproxSyncPolicy;
     
-    AddMaskImage(): DiagnosticNodelet("AddMaskImage") {}
+    AddMaskImage(){}
     virtual ~AddMaskImage();
   protected:
     virtual void onInit();

--- a/jsk_perception/include/jsk_perception/apply_mask_image.h
+++ b/jsk_perception/include/jsk_perception/apply_mask_image.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_APPLY_MASK_IMAGE_H_
 #define JSK_PERCEPTION_APPLY_MASK_IMAGE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <message_filters/subscriber.h>
@@ -47,7 +58,7 @@
 
 namespace jsk_perception
 {
-  class ApplyMaskImage: public jsk_topic_tools::DiagnosticNodelet
+  class ApplyMaskImage: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ApproximateTime<
@@ -56,7 +67,7 @@ namespace jsk_perception
     typedef message_filters::sync_policies::ExactTime<
     sensor_msgs::Image,
     sensor_msgs::Image > SyncPolicy;
-    ApplyMaskImage(): DiagnosticNodelet("ApplyMaskImage") {}
+    ApplyMaskImage(){}
     virtual ~ApplyMaskImage();
   protected:
 

--- a/jsk_perception/include/jsk_perception/background_substraction.h
+++ b/jsk_perception/include/jsk_perception/background_substraction.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_BACKGROUND_SUBSTRACTION_H_
 #define JSK_PERCEPTION_BACKGROUND_SUBSTRACTION_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <opencv2/opencv.hpp>
 #if ( CV_MAJOR_VERSION >= 4)
 #else
@@ -54,10 +65,10 @@
 
 namespace jsk_perception
 {
-  class BackgroundSubstraction: public jsk_topic_tools::DiagnosticNodelet
+  class BackgroundSubstraction: public jsk_topic_tools::NODELET
   {
   public:
-    BackgroundSubstraction(): DiagnosticNodelet("BackgroundSubstraction") {}
+    BackgroundSubstraction(){}
     typedef jsk_perception::BackgroundSubstractionConfig Config;
   protected:
     ////////////////////////////////////////////////////////

--- a/jsk_perception/include/jsk_perception/bing.h
+++ b/jsk_perception/include/jsk_perception/bing.h
@@ -37,17 +37,28 @@
 #ifndef JSK_PERCEPTION_BING_H_
 #define JSK_PERCEPTION_BING_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 #include <opencv2/opencv.hpp>
 #include <opencv2/saliency.hpp>
 
 namespace jsk_perception
 {
-  class Bing: public jsk_topic_tools::DiagnosticNodelet
+  class Bing: public jsk_topic_tools::NODELET
   {
   public:
-    Bing(): DiagnosticNodelet("Bing") {}
+    Bing(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/blob_detector.h
+++ b/jsk_perception/include/jsk_perception/blob_detector.h
@@ -37,18 +37,29 @@
 #ifndef JSK_PERCEPTION_BLOB_DETECTOR_H_
 #define JSK_PERCEPTION_BLOB_DETECTOR_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <dynamic_reconfigure/server.h>
 #include <jsk_perception/BlobDetectorConfig.h>
 #include <sensor_msgs/Image.h>
 
 namespace jsk_perception
 {
-  class BlobDetector: public jsk_topic_tools::DiagnosticNodelet
+  class BlobDetector: public jsk_topic_tools::NODELET
   {
   public:
     typedef BlobDetectorConfig Config;
-    BlobDetector() : DiagnosticNodelet("BlobDetector") {}
+    BlobDetector(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/bounding_box_to_rect.h
+++ b/jsk_perception/include/jsk_perception/bounding_box_to_rect.h
@@ -41,7 +41,18 @@
 #include <jsk_recognition_msgs/RectArray.h>
 #include <jsk_recognition_msgs/BoundingBoxArrayWithCameraInfo.h>
 #include <sensor_msgs/CameraInfo.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <message_filters/subscriber.h>
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/exact_time.h>
@@ -51,7 +62,7 @@
 
 namespace jsk_perception
 {
-  class BoundingBoxToRect: public jsk_topic_tools::DiagnosticNodelet
+  class BoundingBoxToRect: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<BoundingBoxToRect> Ptr;
@@ -68,7 +79,7 @@ namespace jsk_perception
       sensor_msgs::CameraInfo,
       jsk_recognition_msgs::BoundingBox > ApproximateSyncPolicyBox;
 
-    BoundingBoxToRect(): DiagnosticNodelet("BoundingBoxToRect") {}
+    BoundingBoxToRect(){}
     virtual ~BoundingBoxToRect();
   protected:
     virtual void onInit();

--- a/jsk_perception/include/jsk_perception/bounding_object_mask_image.h
+++ b/jsk_perception/include/jsk_perception/bounding_object_mask_image.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_BOUNDING_OBJECT_MASK_IMAGE_H_
 #define JSK_PERCEPTION_BOUNDING_OBJECT_MASK_IMAGE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <geometry_msgs/PolygonStamped.h>
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/CameraInfo.h>
@@ -45,10 +56,10 @@
 
 namespace jsk_perception
 {
-  class BoundingObjectMaskImage: public jsk_topic_tools::DiagnosticNodelet
+  class BoundingObjectMaskImage: public jsk_topic_tools::NODELET
   {
   public:
-    BoundingObjectMaskImage(): DiagnosticNodelet("BoundingObjectMaskImage") {}
+    BoundingObjectMaskImage(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/bounding_rect_mask_image.h
+++ b/jsk_perception/include/jsk_perception/bounding_rect_mask_image.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_BOUNDING_RECT_MASK_IMAGE_H_
 #define JSK_PERCEPTION_BOUNDING_RECT_MASK_IMAGE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <geometry_msgs/PolygonStamped.h>
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/CameraInfo.h>
@@ -45,10 +56,10 @@
 
 namespace jsk_perception
 {
-  class BoundingRectMaskImage: public jsk_topic_tools::DiagnosticNodelet
+  class BoundingRectMaskImage: public jsk_topic_tools::NODELET
   {
   public:
-    BoundingRectMaskImage(): DiagnosticNodelet("BoundingRectMaskImage") {}
+    BoundingRectMaskImage(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/color_histogram.h
+++ b/jsk_perception/include/jsk_perception/color_histogram.h
@@ -49,11 +49,22 @@
 #include <jsk_perception/ColorHistogramConfig.h>
 #include "opencv2/highgui/highgui.hpp"
 #include "opencv2/imgproc/imgproc.hpp"
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace jsk_perception
 {
-  class ColorHistogram: public jsk_topic_tools::DiagnosticNodelet
+  class ColorHistogram: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ApproximateTime<
@@ -64,7 +75,7 @@ namespace jsk_perception
       sensor_msgs::Image,
       sensor_msgs::Image> MaskSyncPolicy;
     typedef jsk_perception::ColorHistogramConfig Config;
-    ColorHistogram(): DiagnosticNodelet("ColorHistogram") {}
+    ColorHistogram(){}
     virtual ~ColorHistogram();
   protected:
     boost::shared_ptr<message_filters::Synchronizer<SyncPolicy> > sync_;

--- a/jsk_perception/include/jsk_perception/color_histogram_label_match.h
+++ b/jsk_perception/include/jsk_perception/color_histogram_label_match.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_COLOR_HISTOGRAM_LABEL_MATCH_H_
 #define JSK_PERCEPTION_COLOR_HISTOGRAM_LABEL_MATCH_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 #include <jsk_recognition_msgs/ColorHistogram.h>
 
@@ -53,7 +64,7 @@
 
 namespace jsk_perception
 {
-  class ColorHistogramLabelMatch: public jsk_topic_tools::DiagnosticNodelet
+  class ColorHistogramLabelMatch: public jsk_topic_tools::NODELET
   {
   public:
     typedef ColorHistogramLabelMatchConfig Config;
@@ -68,7 +79,7 @@ namespace jsk_perception
       sensor_msgs::Image         // label
       > SyncPolicyWithoutMask;
 
-    ColorHistogramLabelMatch(): DiagnosticNodelet("ColorHistogramLabelMatch") {}
+    ColorHistogramLabelMatch(){}
     virtual ~ColorHistogramLabelMatch();
   protected:
     virtual void onInit();

--- a/jsk_perception/include/jsk_perception/colorize_float_image.h
+++ b/jsk_perception/include/jsk_perception/colorize_float_image.h
@@ -37,16 +37,27 @@
 #define JSK_PERCEPTION_COLORIZE_FLOAT_IMAAGE_H_
 
 #include <sensor_msgs/Image.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_topic_tools/color_utils.h>
 #include <cv_bridge/cv_bridge.h>
 
 namespace jsk_perception
 {
-  class ColorizeFloatImage: public jsk_topic_tools::DiagnosticNodelet
+  class ColorizeFloatImage: public jsk_topic_tools::NODELET
   {
   public:
-    ColorizeFloatImage(): DiagnosticNodelet("ColorizeFloatImage") {}
+    ColorizeFloatImage(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/colorize_labels.h
+++ b/jsk_perception/include/jsk_perception/colorize_labels.h
@@ -37,15 +37,26 @@
 #ifndef JSK_PERCEPTION_COLORIZE_LABELS_H_
 #define JSK_PERCEPTION_COLORIZE_LABELS_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 
 namespace jsk_perception
 {
-  class ColorizeLabels: public jsk_topic_tools::DiagnosticNodelet
+  class ColorizeLabels: public jsk_topic_tools::NODELET
   {
   public:
-    ColorizeLabels(): DiagnosticNodelet("ColorizeLabels") {}
+    ColorizeLabels(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/concave_hull_mask_image.h
+++ b/jsk_perception/include/jsk_perception/concave_hull_mask_image.h
@@ -43,16 +43,27 @@
 #include <cv_bridge/cv_bridge.h>
 #include <sensor_msgs/image_encodings.h>
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_perception/ConcaveHullMaskImageConfig.h>
 
 
 namespace jsk_perception
 {
-  class ConcaveHullMaskImage: public jsk_topic_tools::DiagnosticNodelet
+  class ConcaveHullMaskImage: public jsk_topic_tools::NODELET
   {
   public:
-    ConcaveHullMaskImage(): DiagnosticNodelet("ConcaveHullMaskImage") {}
+    ConcaveHullMaskImage(){}
     typedef jsk_perception::ConcaveHullMaskImageConfig Config;
   protected:
     virtual void onInit();

--- a/jsk_perception/include/jsk_perception/consensus_tracking.h
+++ b/jsk_perception/include/jsk_perception/consensus_tracking.h
@@ -42,16 +42,27 @@
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/exact_time.h>
 #include <message_filters/sync_policies/approximate_time.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 
 namespace jsk_perception
 {
-  class ConsensusTracking : public jsk_topic_tools::DiagnosticNodelet
+  class ConsensusTracking : public jsk_topic_tools::NODELET
   {
   public:
     ConsensusTracking() :
-      DiagnosticNodelet("ConsensusTracking"),
+      
       window_initialized_(false) {}
     virtual ~ConsensusTracking();
     typedef message_filters::sync_policies::ApproximateTime<

--- a/jsk_perception/include/jsk_perception/contour_finder.h
+++ b/jsk_perception/include/jsk_perception/contour_finder.h
@@ -37,15 +37,26 @@
 #ifndef JSK_PERCEPTION_CONTOUR_FINDER_H_
 #define JSK_PERCEPTION_CONTOUR_FINDER_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 
 namespace jsk_perception
 {
-  class ContourFinder: public jsk_topic_tools::DiagnosticNodelet
+  class ContourFinder: public jsk_topic_tools::NODELET
   {
   public:
-    ContourFinder(): DiagnosticNodelet("ContourFinder") {}
+    ContourFinder(){}
   protected:
 
     virtual void onInit();

--- a/jsk_perception/include/jsk_perception/convex_hull_mask_image.h
+++ b/jsk_perception/include/jsk_perception/convex_hull_mask_image.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_CONVEX_HULL_MASK_IMAGE_H_
 #define JSK_PERCEPTION_CONVEX_HULL_MASK_IMAGE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <geometry_msgs/PolygonStamped.h>
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/CameraInfo.h>
@@ -45,10 +56,10 @@
 
 namespace jsk_perception
 {
-  class ConvexHullMaskImage: public jsk_topic_tools::DiagnosticNodelet
+  class ConvexHullMaskImage: public jsk_topic_tools::NODELET
   {
   public:
-    ConvexHullMaskImage(): DiagnosticNodelet("ConvexHullMaskImage") {}
+    ConvexHullMaskImage(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/draw_rects.h
+++ b/jsk_perception/include/jsk_perception/draw_rects.h
@@ -50,7 +50,18 @@
 
 #include <cv_bridge/cv_bridge.h>
 #include <dynamic_reconfigure/server.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <message_filters/pass_through.h>
 #include <message_filters/subscriber.h>
 #include <message_filters/synchronizer.h>
@@ -66,7 +77,7 @@
 
 namespace jsk_perception
 {
-  class DrawRects : public jsk_topic_tools::DiagnosticNodelet
+  class DrawRects : public jsk_topic_tools::NODELET
   {
   public:
     typedef DrawRectsConfig Config;
@@ -79,7 +90,7 @@ namespace jsk_perception
     jsk_recognition_msgs::RectArray,
     jsk_recognition_msgs::ClassificationResult> AsyncPolicy;
 
-    DrawRects(): DiagnosticNodelet("DrawRects") {}
+    DrawRects(){}
     virtual ~DrawRects();
   protected:
     virtual void onInit();

--- a/jsk_perception/include/jsk_perception/dual_fisheye_to_panorama.h
+++ b/jsk_perception/include/jsk_perception/dual_fisheye_to_panorama.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_DUAL_FISHEYE_TO_PANORAMA_H_
 #define JSK_PERCEPTION_DUAL_FISHEYE_TO_PANORAMA_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <jsk_recognition_msgs/PanoramaInfo.h>
@@ -56,7 +67,7 @@
 
 namespace jsk_perception
 {
-  class DualFisheyeToPanorama: public jsk_topic_tools::DiagnosticNodelet
+  class DualFisheyeToPanorama: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ApproximateTime<
@@ -65,7 +76,7 @@ namespace jsk_perception
       > SyncPolicy;
     typedef jsk_perception::DualFisheyeConfig Config;
 
-    DualFisheyeToPanorama(): DiagnosticNodelet("DualFisheyeToPanorama") {}
+    DualFisheyeToPanorama(){}
   protected:
     boost::shared_ptr<dynamic_reconfigure::Server<Config> > srv_;
     void configCallback(Config &new_config, uint32_t level);

--- a/jsk_perception/include/jsk_perception/filter_mask_image_with_size.h
+++ b/jsk_perception/include/jsk_perception/filter_mask_image_with_size.h
@@ -37,7 +37,18 @@
 #define JSK_PERCEPTION_FILTER_MASK_IMAGE_WITH_SIZE_H_
 
 #include <dynamic_reconfigure/server.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <message_filters/subscriber.h>
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/exact_time.h>
@@ -48,10 +59,10 @@
 
 namespace jsk_perception
 {
-  class FilterMaskImageWithSize: public jsk_topic_tools::DiagnosticNodelet
+  class FilterMaskImageWithSize: public jsk_topic_tools::NODELET
   {
   public:
-    FilterMaskImageWithSize(): DiagnosticNodelet("FilterMaskImageWithSize") {}
+    FilterMaskImageWithSize(){}
     virtual ~FilterMaskImageWithSize();
     typedef message_filters::sync_policies::ExactTime<
       sensor_msgs::Image, sensor_msgs::Image > SyncPolicy;

--- a/jsk_perception/include/jsk_perception/fisheye_to_panorama.h
+++ b/jsk_perception/include/jsk_perception/fisheye_to_panorama.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_FISHEYE_TO_PANORAMA_H_
 #define JSK_PERCEPTION_FISHEYE_TO_PANORAMA_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/CameraInfo.h>
 
@@ -52,7 +63,7 @@
 
 namespace jsk_perception
 {
-  class FisheyeToPanorama: public jsk_topic_tools::DiagnosticNodelet
+  class FisheyeToPanorama: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ApproximateTime<
@@ -61,7 +72,7 @@ namespace jsk_perception
       > SyncPolicy;
     typedef jsk_perception::FisheyeConfig Config;
 
-    FisheyeToPanorama(): DiagnosticNodelet("FisheyeToPanorama") {}
+    FisheyeToPanorama(){}
     virtual ~FisheyeToPanorama();
   protected:
     boost::shared_ptr<dynamic_reconfigure::Server<Config> > srv_;

--- a/jsk_perception/include/jsk_perception/flow_velocity_thresholding.h
+++ b/jsk_perception/include/jsk_perception/flow_velocity_thresholding.h
@@ -36,7 +36,18 @@
 #ifndef JSK_PERCEPTION_FLOW_VELOCITY_THRESHOLDING_H_
 #define JSK_PERCEPTION_FLOW_VELOCITY_THRESHOLDING_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <message_filters/subscriber.h>
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/exact_time.h>
@@ -48,10 +59,10 @@
 
 namespace jsk_perception
 {
-  class FlowVelocityThresholding: public jsk_topic_tools::DiagnosticNodelet
+  class FlowVelocityThresholding: public jsk_topic_tools::NODELET
   {
   public:
-    FlowVelocityThresholding(): DiagnosticNodelet("FlowVelocityThresholding") {}
+    FlowVelocityThresholding(){}
     virtual ~FlowVelocityThresholding();
     typedef jsk_perception::FlowVelocityThresholdingConfig Config;
     typedef message_filters::sync_policies::ApproximateTime<

--- a/jsk_perception/include/jsk_perception/gaussian_blur.h
+++ b/jsk_perception/include/jsk_perception/gaussian_blur.h
@@ -37,18 +37,29 @@
 #ifndef JSK_PERCEPTION_GAUSSIAN_BLUR_H_
 #define JSK_PERCEPTION_GAUSSIAN_BLUR_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <dynamic_reconfigure/server.h>
 #include <jsk_perception/GaussianBlurConfig.h>
 #include <sensor_msgs/Image.h>
 
 namespace jsk_perception
 {
-  class GaussianBlur: public jsk_topic_tools::DiagnosticNodelet
+  class GaussianBlur: public jsk_topic_tools::NODELET
   {
   public:
     typedef jsk_perception::GaussianBlurConfig Config;
-    GaussianBlur(): DiagnosticNodelet("GaussianBlur") {}
+    GaussianBlur(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/grabcut.h
+++ b/jsk_perception/include/jsk_perception/grabcut.h
@@ -43,13 +43,24 @@
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/synchronizer.h>
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <dynamic_reconfigure/server.h>
 #include "jsk_perception/GrabCutConfig.h"
 
 namespace jsk_perception
 {
-  class GrabCut: public jsk_topic_tools::DiagnosticNodelet
+  class GrabCut: public jsk_topic_tools::NODELET
   {
   public:
     typedef GrabCutConfig Config;
@@ -59,7 +70,7 @@ namespace jsk_perception
     sensor_msgs::Image> SyncPolicy;
     
     typedef boost::shared_ptr<GrabCut> Ptr;
-    GrabCut() : DiagnosticNodelet("GrabCut") {}
+    GrabCut(){}
     virtual ~GrabCut();
 
   protected:

--- a/jsk_perception/include/jsk_perception/grid_label.h
+++ b/jsk_perception/include/jsk_perception/grid_label.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_GRID_LABEL_H_
 #define JSK_PERCEPTION_GRID_LABEL_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_perception/GridLabelConfig.h>
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/CameraInfo.h>
@@ -46,11 +57,11 @@
 
 namespace jsk_perception
 {
-  class GridLabel: public jsk_topic_tools::DiagnosticNodelet
+  class GridLabel: public jsk_topic_tools::NODELET
   {
   public:
     typedef GridLabelConfig Config;
-    GridLabel(): DiagnosticNodelet("GridLabel") {}
+    GridLabel(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/hsv_decomposer.h
+++ b/jsk_perception/include/jsk_perception/hsv_decomposer.h
@@ -37,15 +37,26 @@
 #ifndef JSK_PERCEPTION_HSV_DECOMPOSER_H_
 #define JSK_PERCEPTION_HSV_DECOMPOSER_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 
 namespace jsk_perception
 {
-  class HSVDecomposer: public jsk_topic_tools::DiagnosticNodelet
+  class HSVDecomposer: public jsk_topic_tools::NODELET
   {
   public:
-    HSVDecomposer(): DiagnosticNodelet("HSVDecomposer") {}
+    HSVDecomposer(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/kmeans.h
+++ b/jsk_perception/include/jsk_perception/kmeans.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_KMEANS_H_
 #define JSK_PERCEPTION_KMEANS_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 #include <dynamic_reconfigure/server.h>
 #include <jsk_perception/KMeansConfig.h>
@@ -45,11 +56,11 @@
 
 namespace jsk_perception
 {
-  class KMeans: public jsk_topic_tools::DiagnosticNodelet
+  class KMeans: public jsk_topic_tools::NODELET
   {
   public:
     typedef jsk_perception::KMeansConfig Config;
-    KMeans(): DiagnosticNodelet("KMeans") {}
+    KMeans(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/lab_decomposer.h
+++ b/jsk_perception/include/jsk_perception/lab_decomposer.h
@@ -37,15 +37,26 @@
 #ifndef JSK_PERCEPTION_LAB_DECOMPOSER_H_
 #define JSK_PERCEPTION_LAB_DECOMPOSER_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 
 namespace jsk_perception
 {
-  class LabDecomposer: public jsk_topic_tools::DiagnosticNodelet
+  class LabDecomposer: public jsk_topic_tools::NODELET
   {
   public:
-    LabDecomposer(): DiagnosticNodelet("LabDecomposer") {}
+    LabDecomposer(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/label_array_to_mask_image.h
+++ b/jsk_perception/include/jsk_perception/label_array_to_mask_image.h
@@ -37,18 +37,29 @@
 #ifndef JSK_PERCEPTION_LABEL_ARRAY_TO_MASK_IMAGE_H_
 #define JSK_PERCEPTION_LABEL_ARRAY_TO_MASK_IMAGE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 #include <vector>
 
 namespace jsk_perception
 {
 
-class LabelArrayToMaskImage: public jsk_topic_tools::DiagnosticNodelet
+class LabelArrayToMaskImage: public jsk_topic_tools::NODELET
 {
 public:
 
-  LabelArrayToMaskImage(): DiagnosticNodelet("LabelArrayToMaskImage") { }
+  LabelArrayToMaskImage(){ }
 protected:
   virtual void onInit();
   virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/label_to_mask_image.h
+++ b/jsk_perception/include/jsk_perception/label_to_mask_image.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_LABEL_TO_MASK_IMAGE_H_
 #define JSK_PERCEPTION_LABEL_TO_MASK_IMAGE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <dynamic_reconfigure/server.h>
 #include <jsk_perception/LabelToMaskImageConfig.h>
 #include <sensor_msgs/Image.h>
@@ -45,11 +56,11 @@
 namespace jsk_perception
 {
 
-class LabelToMaskImage: public jsk_topic_tools::DiagnosticNodelet
+class LabelToMaskImage: public jsk_topic_tools::NODELET
 {
 public:
   typedef jsk_perception::LabelToMaskImageConfig Config;
-  LabelToMaskImage(): DiagnosticNodelet("LabelToMaskImage") { }
+  LabelToMaskImage(){ }
 protected:
   virtual void onInit();
   virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/mask_image_generator.h
+++ b/jsk_perception/include/jsk_perception/mask_image_generator.h
@@ -39,17 +39,28 @@
 
 #include <jsk_perception/MaskImageGeneratorConfig.h>
 #include <sensor_msgs/Image.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <dynamic_reconfigure/server.h>
 
 namespace jsk_perception
 {
-  class MaskImageGenerator: public jsk_topic_tools::DiagnosticNodelet
+  class MaskImageGenerator: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<MaskImageGenerator> Ptr;
     typedef MaskImageGeneratorConfig Config;
-    MaskImageGenerator(): DiagnosticNodelet("MaskImageGenerator") {}
+    MaskImageGenerator(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/mask_image_to_rect.h
+++ b/jsk_perception/include/jsk_perception/mask_image_to_rect.h
@@ -37,17 +37,28 @@
 #ifndef JSK_PERCEPTION_MASK_IMAGE_TO_RECT_H_
 #define JSK_PERCEPTION_MASK_IMAGE_TO_RECT_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/CameraInfo.h>
 #include <sensor_msgs/Image.h>
 #include <jsk_recognition_msgs/RectArray.h>
 
 namespace jsk_perception
 {
-  class MaskImageToRect: public jsk_topic_tools::DiagnosticNodelet
+  class MaskImageToRect: public jsk_topic_tools::NODELET
   {
   public:
-    MaskImageToRect(): DiagnosticNodelet("MaskImageToRect") {}
+    MaskImageToRect(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/mask_image_to_roi.h
+++ b/jsk_perception/include/jsk_perception/mask_image_to_roi.h
@@ -37,16 +37,27 @@
 #ifndef JSK_PERCEPTION_MASK_IMAGE_TO_ROI_H_
 #define JSK_PERCEPTION_MASK_IMAGE_TO_ROI_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/CameraInfo.h>
 #include <sensor_msgs/Image.h>
 
 namespace jsk_perception
 {
-  class MaskImageToROI: public jsk_topic_tools::DiagnosticNodelet
+  class MaskImageToROI: public jsk_topic_tools::NODELET
   {
   public:
-    MaskImageToROI(): DiagnosticNodelet("MaskImageToROI") {}
+    MaskImageToROI(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/morphological_operator.h
+++ b/jsk_perception/include/jsk_perception/morphological_operator.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_MORPHOLOGICAL_OPERATOR_H_
 #define JSK_PERCEPTION_MORPHOLOGICAL_OPERATOR_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 #include <dynamic_reconfigure/server.h>
 #include <jsk_perception/MorphologicalMaskImageOperatorConfig.h>
@@ -47,12 +58,11 @@ namespace jsk_perception
 {
 
   class MorphologicalImageOperatorNodelet:
-    public jsk_topic_tools::DiagnosticNodelet
+    public jsk_topic_tools::NODELET
   {
   public:
     typedef jsk_perception::MorphologicalMaskImageOperatorConfig Config;
-    MorphologicalImageOperatorNodelet(const std::string& name):
-      DiagnosticNodelet(name) {}
+    MorphologicalImageOperatorNodelet(const std::string& name) {}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/multiply_mask_image.h
+++ b/jsk_perception/include/jsk_perception/multiply_mask_image.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_MULTIPLY_MASK_IMAGE_H_
 #define JSK_PERCEPTION_MULTIPLY_MASK_IMAGE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 
 #include <message_filters/subscriber.h>
@@ -47,7 +58,7 @@
 
 namespace jsk_perception
 {
-  class MultiplyMaskImage: public jsk_topic_tools::DiagnosticNodelet
+  class MultiplyMaskImage: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<
@@ -57,7 +68,7 @@ namespace jsk_perception
     sensor_msgs::Image,
     sensor_msgs::Image > ApproxSyncPolicy;
     
-    MultiplyMaskImage(): DiagnosticNodelet("MultiplyMaskImage") {}
+    MultiplyMaskImage(){}
     virtual ~MultiplyMaskImage();
   protected:
     virtual void onInit();

--- a/jsk_perception/include/jsk_perception/overlay_image_color_on_mono.h
+++ b/jsk_perception/include/jsk_perception/overlay_image_color_on_mono.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_APPLY_MASK_IMAGE_H_
 #define JSK_PERCEPTION_APPLY_MASK_IMAGE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <dynamic_reconfigure/server.h>
 #include <jsk_perception/OverlayImageColorOnMonoConfig.h>
 #include <sensor_msgs/Image.h>
@@ -48,14 +59,14 @@
 
 namespace jsk_perception
 {
-  class OverlayImageColorOnMono: public jsk_topic_tools::DiagnosticNodelet
+  class OverlayImageColorOnMono: public jsk_topic_tools::NODELET
   {
   public:
     typedef OverlayImageColorOnMonoConfig Config;
     typedef message_filters::sync_policies::ApproximateTime<
       sensor_msgs::Image, sensor_msgs::Image > ApproximateSyncPolicy;
     typedef message_filters::sync_policies::ExactTime<sensor_msgs::Image, sensor_msgs::Image > SyncPolicy;
-    OverlayImageColorOnMono(): DiagnosticNodelet("OverlayImageColorOnMono") {}
+    OverlayImageColorOnMono(){}
     virtual ~OverlayImageColorOnMono();
   protected:
 

--- a/jsk_perception/include/jsk_perception/polygon_array_color_histogram.h
+++ b/jsk_perception/include/jsk_perception/polygon_array_color_histogram.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_POLYGON_ARRAY_COLOR_HISTOGRAM_H_
 #define JSK_PERCEPTION_POLYGON_ARRAY_COLOR_HISTOGRAM_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <jsk_recognition_msgs/PolygonArray.h>
@@ -51,14 +62,14 @@
 
 namespace jsk_perception
 {
-  class PolygonArrayColorHistogram: public jsk_topic_tools::DiagnosticNodelet
+  class PolygonArrayColorHistogram: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ApproximateTime<
     sensor_msgs::Image,
     jsk_recognition_msgs::PolygonArray > ApproximateSyncPolicy;
     typedef jsk_perception::PolygonArrayColorHistogramConfig Config;
-    PolygonArrayColorHistogram(): DiagnosticNodelet("PolygonArrayColorHistogram") {}
+    PolygonArrayColorHistogram(){}
     virtual ~PolygonArrayColorHistogram();
   protected:
     virtual void onInit();

--- a/jsk_perception/include/jsk_perception/polygon_array_color_likelihood.h
+++ b/jsk_perception/include/jsk_perception/polygon_array_color_likelihood.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_POLYGON_ARRAY_COLOR_LIKELIHOOD_H_
 #define JSK_PERCEPTION_POLYGON_ARRAY_COLOR_LIKELIHOOD_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_recognition_msgs/PolygonArray.h>
 #include <jsk_recognition_msgs/HistogramWithRangeArray.h>
 #include <message_filters/subscriber.h>
@@ -49,12 +60,12 @@
 
 namespace jsk_perception
 {
-  class PolygonArrayColorLikelihood: public jsk_topic_tools::DiagnosticNodelet
+  class PolygonArrayColorLikelihood: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<PolygonArrayColorLikelihood> Ptr;
     typedef PolygonArrayColorLikelihoodConfig Config;
-    PolygonArrayColorLikelihood(): DiagnosticNodelet("PolygonArrayColorLikelihood") {}
+    PolygonArrayColorLikelihood(){}
     virtual ~PolygonArrayColorLikelihood();
     typedef message_filters::sync_policies::ExactTime<
       jsk_recognition_msgs::PolygonArray,

--- a/jsk_perception/include/jsk_perception/polygon_array_to_label_image.h
+++ b/jsk_perception/include/jsk_perception/polygon_array_to_label_image.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_POLYGON_ARRAY_TO_LABEL_IMAGE_H_
 #define JSK_PERCEPTION_POLYGON_ARRAY_TO_LABEL_IMAGE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_recognition_msgs/PolygonArray.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <sensor_msgs/Image.h>
@@ -45,10 +56,10 @@
 
 namespace jsk_perception
 {
-  class PolygonArrayToLabelImage: public jsk_topic_tools::DiagnosticNodelet
+  class PolygonArrayToLabelImage: public jsk_topic_tools::NODELET
   {
   public:
-    PolygonArrayToLabelImage(): DiagnosticNodelet("PolygonArrayToLabelImage") {}
+    PolygonArrayToLabelImage(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/polygon_to_mask_image.h
+++ b/jsk_perception/include/jsk_perception/polygon_to_mask_image.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_POLYGON_TO_MASK_IMAGE_H_
 #define JSK_PERCEPTION_POLYGON_TO_MASK_IMAGE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <geometry_msgs/PolygonStamped.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <sensor_msgs/Image.h>
@@ -45,10 +56,10 @@
 
 namespace jsk_perception
 {
-  class PolygonToMaskImage: public jsk_topic_tools::DiagnosticNodelet
+  class PolygonToMaskImage: public jsk_topic_tools::NODELET
   {
   public:
-    PolygonToMaskImage(): DiagnosticNodelet("PolygonToMaskImage") {}
+    PolygonToMaskImage(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/project_image_point.h
+++ b/jsk_perception/include/jsk_perception/project_image_point.h
@@ -43,18 +43,29 @@
 
 #include <image_geometry/pinhole_camera_model.h>
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <dynamic_reconfigure/server.h>
 #include <jsk_perception/ProjectImagePointConfig.h>
 
 namespace jsk_perception
 {
-  class ProjectImagePoint: public jsk_topic_tools::DiagnosticNodelet
+  class ProjectImagePoint: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<ProjectImagePoint> Ptr;
     typedef ProjectImagePointConfig Config;
-    ProjectImagePoint(): DiagnosticNodelet("ProjectImagePoint") {}
+    ProjectImagePoint(){}
     
   protected:
     virtual void onInit();

--- a/jsk_perception/include/jsk_perception/rect_array_actual_size_filter.h
+++ b/jsk_perception/include/jsk_perception/rect_array_actual_size_filter.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_RECT_ARRAY_ACTUAL_SIZE_FILTER_H_
 #define JSK_PERCEPTION_RECT_ARRAY_ACTUAL_SIZE_FILTER_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <jsk_recognition_msgs/RectArray.h>
@@ -51,7 +62,7 @@
 
 namespace jsk_perception
 {
-  class RectArrayActualSizeFilter: public jsk_topic_tools::DiagnosticNodelet
+  class RectArrayActualSizeFilter: public jsk_topic_tools::NODELET
   {
   public:
     typedef boost::shared_ptr<RectArrayActualSizeFilter> Ptr;
@@ -65,7 +76,7 @@ namespace jsk_perception
       sensor_msgs::Image,
       sensor_msgs::CameraInfo> ApproxSyncPolicy;
 
-    RectArrayActualSizeFilter(): DiagnosticNodelet("RectArrayActualSizeFilter") {}
+    RectArrayActualSizeFilter(){}
     virtual ~RectArrayActualSizeFilter();
   protected:
     virtual void onInit();

--- a/jsk_perception/include/jsk_perception/rect_array_to_density_image.h
+++ b/jsk_perception/include/jsk_perception/rect_array_to_density_image.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_RECT_ARRAY_TO_DENSITY_IMAGE_H_
 #define JSK_PERCEPTION_RECT_ARRAY_TO_DENSITY_IMAGE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 #include <jsk_recognition_msgs/RectArray.h>
 #include <message_filters/subscriber.h>
@@ -47,14 +58,14 @@
 
 namespace jsk_perception
 {
-  class RectArrayToDensityImage: public jsk_topic_tools::DiagnosticNodelet
+  class RectArrayToDensityImage: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ApproximateTime<
       sensor_msgs::Image, jsk_recognition_msgs::RectArray > ApproximateSyncPolicy;
     typedef message_filters::sync_policies::ExactTime<
       sensor_msgs::Image, jsk_recognition_msgs::RectArray > SyncPolicy;
-    RectArrayToDensityImage(): DiagnosticNodelet("RectArrayToDensityImage") {}
+    RectArrayToDensityImage(){}
     virtual ~RectArrayToDensityImage();
   protected:
 

--- a/jsk_perception/include/jsk_perception/rect_to_mask_image.h
+++ b/jsk_perception/include/jsk_perception/rect_to_mask_image.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_RECT_TO_MASK_IMAGE_H_
 #define JSK_PERCEPTION_RECT_TO_MASK_IMAGE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <geometry_msgs/PolygonStamped.h>
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/CameraInfo.h>
@@ -45,10 +56,10 @@
 
 namespace jsk_perception
 {
-  class RectToMaskImage: public jsk_topic_tools::DiagnosticNodelet
+  class RectToMaskImage: public jsk_topic_tools::NODELET
   {
   public:
-    RectToMaskImage(): DiagnosticNodelet("RectToMaskImag") {}
+    RectToMaskImage(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/rect_to_roi.h
+++ b/jsk_perception/include/jsk_perception/rect_to_roi.h
@@ -37,16 +37,27 @@
 #ifndef JSK_PERCEPTION_RECT_TO_ROI_H_
 #define JSK_PERCEPTION_RECT_TO_ROI_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/CameraInfo.h>
 #include <geometry_msgs/PolygonStamped.h>
 
 namespace jsk_perception
 {
-  class RectToROI: public jsk_topic_tools::DiagnosticNodelet
+  class RectToROI: public jsk_topic_tools::NODELET
   {
   public:
-    RectToROI(): DiagnosticNodelet("RectToROI") {}
+    RectToROI(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/rgb_decomposer.h
+++ b/jsk_perception/include/jsk_perception/rgb_decomposer.h
@@ -37,15 +37,26 @@
 #ifndef JSK_PERCEPTION_RGB_DECOMPOSER_H_
 #define JSK_PERCEPTION_RGB_DECOMPOSER_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 
 namespace jsk_perception
 {
-  class RGBDecomposer: public jsk_topic_tools::DiagnosticNodelet
+  class RGBDecomposer: public jsk_topic_tools::NODELET
   {
   public:
-    RGBDecomposer(): DiagnosticNodelet("RGBDecomposer") {}
+    RGBDecomposer(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/robot_to_mask_image.h
+++ b/jsk_perception/include/jsk_perception/robot_to_mask_image.h
@@ -38,7 +38,18 @@
 #define JSK_PERCEPTION_ROBOT_TO_MASK_IMAGE_H_
 
 #include <robot_self_filter/self_mask.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <geometry_msgs/PolygonStamped.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <sensor_msgs/Image.h>
@@ -46,10 +57,10 @@
 
 namespace jsk_perception
 {
-  class RobotToMaskImage: public jsk_topic_tools::DiagnosticNodelet
+  class RobotToMaskImage: public jsk_topic_tools::NODELET
   {
   public:
-    RobotToMaskImage(): DiagnosticNodelet("RobotToMaskImage") {}
+    RobotToMaskImage(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/roi_to_mask_image.h
+++ b/jsk_perception/include/jsk_perception/roi_to_mask_image.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_ROI_TO_MASK_IMAGE_H_
 #define JSK_PERCEPTION_ROI_TO_MASK_IMAGE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/CameraInfo.h>
 #include <sensor_msgs/Image.h>
 #include <cv_bridge/cv_bridge.h>
@@ -46,10 +57,10 @@
 
 namespace jsk_perception
 {
-  class ROIToMaskImage: public jsk_topic_tools::DiagnosticNodelet
+  class ROIToMaskImage: public jsk_topic_tools::NODELET
   {
   public:
-    ROIToMaskImage(): DiagnosticNodelet("ROIToMaskImage") {}
+    ROIToMaskImage(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/roi_to_rect.h
+++ b/jsk_perception/include/jsk_perception/roi_to_rect.h
@@ -37,16 +37,27 @@
 #ifndef JSK_PERCEPTION_ROI_TO_RECT_H_
 #define JSK_PERCEPTION_ROI_TO_RECT_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <geometry_msgs/PolygonStamped.h>
 #include <sensor_msgs/CameraInfo.h>
 
 namespace jsk_perception
 {
-  class ROIToRect: public jsk_topic_tools::DiagnosticNodelet
+  class ROIToRect: public jsk_topic_tools::NODELET
   {
   public:
-    ROIToRect(): DiagnosticNodelet("ROIToRect") {}
+    ROIToRect(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/saliency_map_generator.h
+++ b/jsk_perception/include/jsk_perception/saliency_map_generator.h
@@ -11,7 +11,18 @@
 #include <cv_bridge/cv_bridge.h>
 #include <boost/thread/mutex.hpp>
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 #include <omp.h>
 #include <time.h>
@@ -19,7 +30,7 @@
 
 namespace jsk_perception
 {
-   class SaliencyMapGenerator: public jsk_topic_tools::DiagnosticNodelet
+   class SaliencyMapGenerator: public jsk_topic_tools::NODELET
    {
     private:
       void calcIntensityChannel(cv::Mat, cv::Mat);
@@ -45,7 +56,7 @@ namespace jsk_perception
       void unsubscribe();
 
     public:
-      SaliencyMapGenerator(): DiagnosticNodelet("SaliencyMapGenerator"),
+      SaliencyMapGenerator(): 
                               counter_(0), num_threads_(2) {}
       bool computeSaliencyImpl(cv::Mat, cv::Mat &);
       void setNumThreads(int);

--- a/jsk_perception/include/jsk_perception/single_channel_histogram.h
+++ b/jsk_perception/include/jsk_perception/single_channel_histogram.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_SINGLE_CHANNEL_HISTOGRAM_H_
 #define JSK_PERCEPTION_SINGLE_CHANNEL_HISTOGRAM_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 #include <jsk_recognition_msgs/ColorHistogram.h>
 
@@ -51,14 +62,14 @@
 
 namespace jsk_perception
 {
-  class SingleChannelHistogram: public jsk_topic_tools::DiagnosticNodelet
+  class SingleChannelHistogram: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ApproximateTime<
     sensor_msgs::Image,
     sensor_msgs::Image > SyncPolicy;
     typedef SingleChannelHistogramConfig Config;
-    SingleChannelHistogram(): DiagnosticNodelet("SingleChannelHistogram") {}
+    SingleChannelHistogram(){}
     virtual ~SingleChannelHistogram();
   protected:
     virtual void onInit();

--- a/jsk_perception/include/jsk_perception/skeletonization.h
+++ b/jsk_perception/include/jsk_perception/skeletonization.h
@@ -40,7 +40,18 @@
 #include <ros/ros.h>
 #include <ros/console.h>
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 #include <cv_bridge/cv_bridge.h>
 #include <sensor_msgs/image_encodings.h>
@@ -53,10 +64,10 @@
 
 namespace jsk_perception
 {
-   class Skeletonization: public jsk_topic_tools::DiagnosticNodelet
+   class Skeletonization: public jsk_topic_tools::NODELET
    {
     public:
-      Skeletonization(): DiagnosticNodelet("Skeletonization"),
+      Skeletonization(): 
                          num_threads_(1) {}
       virtual void imageCallback(const sensor_msgs::Image::ConstPtr&);
       virtual void skeletonization(cv::Mat &);

--- a/jsk_perception/include/jsk_perception/sliding_window_object_detector.h
+++ b/jsk_perception/include/jsk_perception/sliding_window_object_detector.h
@@ -3,7 +3,18 @@
 #ifndef JSK_PERCEPTION_SLIDING_WINDOW_OBJECT_DETECTOR_H
 #define JSK_PERCEPTION_SLIDING_WINDOW_OBJECT_DETECTOR_H
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_perception/histogram_of_oriented_gradients.h>
 #include <jsk_recognition_msgs/RectArray.h>
 #include <jsk_recognition_msgs/ClusterPointIndices.h>
@@ -34,12 +45,11 @@
 
 namespace jsk_perception
 {
-   class SlidingWindowObjectDetector: public jsk_topic_tools::DiagnosticNodelet,
+   class SlidingWindowObjectDetector: public jsk_topic_tools::NODELET,
                                       public HOGFeatureDescriptor
    {
     public:
-      SlidingWindowObjectDetector():
-         DiagnosticNodelet("SlidingWindowObjectDetector") {}
+      SlidingWindowObjectDetector(){}
       
       virtual void readTrainingManifestFromDirectory();
       virtual void loadTrainedDetectorModel();

--- a/jsk_perception/include/jsk_perception/sliding_window_object_detector_trainer.h
+++ b/jsk_perception/include/jsk_perception/sliding_window_object_detector_trainer.h
@@ -55,7 +55,7 @@ namespace jsk_perception
 
     public:
       SlidingWindowObjectDetectorTrainer();
-      // :DiagnosticNodelet("SlidingWindowObjectDetectorTrainer");
+      // :;
       
       virtual void trainObjectClassifier(
          std::string, std::string);

--- a/jsk_perception/include/jsk_perception/snake_segmentation.h
+++ b/jsk_perception/include/jsk_perception/snake_segmentation.h
@@ -37,18 +37,29 @@
 #ifndef JSK_PERCEPTION_SNAKE_SEGMENTATION_H_
 #define JSK_PERCEPTION_SNAKE_SEGMENTATION_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 #include <jsk_perception/SnakeSegmentationConfig.h>
 #include <dynamic_reconfigure/server.h>
 
 namespace jsk_perception
 {
-  class SnakeSegmentation: public jsk_topic_tools::DiagnosticNodelet
+  class SnakeSegmentation: public jsk_topic_tools::NODELET
   {
   public:
     typedef SnakeSegmentationConfig Config;
-    SnakeSegmentation(): DiagnosticNodelet("SnakeSegmentation") {};
+    SnakeSegmentation(){};
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/subtract_mask_image.h
+++ b/jsk_perception/include/jsk_perception/subtract_mask_image.h
@@ -41,7 +41,18 @@
 #ifndef JSK_PERCEPTION_SUBTRACT_MASK_IMAGE_H__
 #define JSK_PERCEPTION_SUBTRACT_MASK_IMAGE_H__
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 
 #include <message_filters/subscriber.h>
@@ -51,7 +62,7 @@
 
 namespace jsk_perception
 {
-  class SubtractMaskImage: public jsk_topic_tools::DiagnosticNodelet
+  class SubtractMaskImage: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ExactTime<
@@ -61,7 +72,7 @@ namespace jsk_perception
     sensor_msgs::Image,
     sensor_msgs::Image > ApproxSyncPolicy;
     
-    SubtractMaskImage(): DiagnosticNodelet("SubtractMaskImage") {}
+    SubtractMaskImage(){}
     virtual ~SubtractMaskImage();
   protected:
     virtual void onInit();

--- a/jsk_perception/include/jsk_perception/tabletop_color_difference_likelihood.h
+++ b/jsk_perception/include/jsk_perception/tabletop_color_difference_likelihood.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_TABLETOP_COLOR_DIFFERENCE_LIKELIHOOD_H_
 #define JSK_PERCEPTION_TABLETOP_COLOR_DIFFERENCE_LIKELIHOOD_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <jsk_recognition_msgs/PolygonArray.h>
@@ -51,11 +62,11 @@
 #include <jsk_recognition_msgs/HistogramWithRangeBin.h>
 namespace jsk_perception
 {
-  class TabletopColorDifferenceLikelihood: public jsk_topic_tools::DiagnosticNodelet
+  class TabletopColorDifferenceLikelihood: public jsk_topic_tools::NODELET
   {
   public:
     typedef TabletopColorDifferenceLikelihoodConfig Config;
-    TabletopColorDifferenceLikelihood(): DiagnosticNodelet("TabletopColorDifferenceLikelihood") {}
+    TabletopColorDifferenceLikelihood(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/include/jsk_perception/unapply_mask_image.h
+++ b/jsk_perception/include/jsk_perception/unapply_mask_image.h
@@ -37,7 +37,18 @@
 #ifndef JSK_PERCEPTION_UnAPPLY_MASK_IMAGE_H_
 #define JSK_PERCEPTION_UNAPPLY_MASK_IMAGE_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 #include <message_filters/subscriber.h>
 #include <message_filters/synchronizer.h>
@@ -46,7 +57,7 @@
 
 namespace jsk_perception
 {
-  class UnapplyMaskImage: public jsk_topic_tools::DiagnosticNodelet
+  class UnapplyMaskImage: public jsk_topic_tools::NODELET
   {
   public:
     typedef message_filters::sync_policies::ApproximateTime<
@@ -56,7 +67,7 @@ namespace jsk_perception
     sensor_msgs::Image,
     sensor_msgs::Image > SyncPolicy;
 
-    UnapplyMaskImage(): DiagnosticNodelet("UnapplyMaskImage") {}
+    UnapplyMaskImage(){}
     virtual ~UnapplyMaskImage();
   protected:
 

--- a/jsk_perception/include/jsk_perception/virtual_camera_mono.h
+++ b/jsk_perception/include/jsk_perception/virtual_camera_mono.h
@@ -1,7 +1,18 @@
 #ifndef JSK_PERCEPTION_VIRTUAL_CAMERA_MONO_H_
 #define JSK_PERCEPTION_VIRTUAL_CAMERA_MONO_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <jsk_perception/VirtualCameraMonoConfig.h>
 
 #include <dynamic_reconfigure/server.h>
@@ -20,11 +31,11 @@
 
 namespace jsk_perception
 {
-  class VirtualCameraMono: public jsk_topic_tools::DiagnosticNodelet
+  class VirtualCameraMono: public jsk_topic_tools::NODELET
   {
   public:
     typedef VirtualCameraMonoConfig Config;
-    VirtualCameraMono() : DiagnosticNodelet("VirtualCameraMono") {}
+    VirtualCameraMono(){}
 
   protected:
 

--- a/jsk_perception/include/jsk_perception/ycc_decomposer.h
+++ b/jsk_perception/include/jsk_perception/ycc_decomposer.h
@@ -37,15 +37,26 @@
 #ifndef JSK_PERCEPTION_YCC_DECOMPOSER_H_
 #define JSK_PERCEPTION_YCC_DECOMPOSER_H_
 
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 #include <sensor_msgs/Image.h>
 
 namespace jsk_perception
 {
-  class YCCDecomposer: public jsk_topic_tools::DiagnosticNodelet
+  class YCCDecomposer: public jsk_topic_tools::NODELET
   {
   public:
-    YCCDecomposer(): DiagnosticNodelet("YCCDecomposer") {}
+    YCCDecomposer(){}
   protected:
     virtual void onInit();
     virtual void subscribe();

--- a/jsk_perception/src/add_mask_image.cpp
+++ b/jsk_perception/src/add_mask_image.cpp
@@ -44,7 +44,7 @@ namespace jsk_perception
 {
   void AddMaskImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("approximate_sync", approximate_sync_, false);
     pub_ = advertise<sensor_msgs::Image>(
       *pnh_, "output", 1);
@@ -97,7 +97,9 @@ namespace jsk_perception
       src2_msg, src2_msg->encoding)->image;
     cv::Mat result;
     cv::add(src1, src2, result);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(
       cv_bridge::CvImage(src1_msg->header,
                          sensor_msgs::image_encodings::MONO8,

--- a/jsk_perception/src/apply_mask_image.cpp
+++ b/jsk_perception/src/apply_mask_image.cpp
@@ -45,7 +45,7 @@ namespace jsk_perception
 {
   void ApplyMaskImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("approximate_sync", approximate_sync_, false);
     pnh_->param("clip", clip_, true);
     pnh_->param("negative", negative_, false);
@@ -157,7 +157,9 @@ namespace jsk_perception
       cv::bitwise_not(mask, mask);
     }
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_mask_.publish(cv_bridge::CvImage(
                         mask_msg->header,
                         "mono8",

--- a/jsk_perception/src/background_substraction_nodelet.cpp
+++ b/jsk_perception/src/background_substraction_nodelet.cpp
@@ -41,7 +41,7 @@ namespace jsk_perception
 {
   void BackgroundSubstraction::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
@@ -116,7 +116,9 @@ namespace jsk_perception
       = cv_bridge::CvImage(image_msg->header,
                            sensor_msgs::image_encodings::MONO8,
                            fg).toImageMsg();
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     image_pub_.publish(diff_image);
   }
 }

--- a/jsk_perception/src/bing.cpp
+++ b/jsk_perception/src/bing.cpp
@@ -51,7 +51,7 @@ namespace jsk_perception
 {
   void Bing::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_rects_ = advertise<jsk_recognition_msgs::RectArray>(*pnh_, "output", 1);
     pub_objectness_ = advertise<sensor_msgs::Image>(*pnh_, "output/objectness", 1);
     pnh_->param("score_threshold", score_threshold_, 0.0);
@@ -155,7 +155,9 @@ namespace jsk_perception
     }
     // publish proposals
     rects_msg.header = img_msg->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_rects_.publish(rects_msg);
     // publish objectness
     pub_objectness_.publish(

--- a/jsk_perception/src/blob_detector.cpp
+++ b/jsk_perception/src/blob_detector.cpp
@@ -45,7 +45,7 @@ namespace jsk_perception
 {
   void BlobDetector::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (
@@ -85,7 +85,9 @@ namespace jsk_perception
         label_int.at<int>(j, i) = label.at<short>(j, i);
       }
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(
       cv_bridge::CvImage(image_msg->header,
                          sensor_msgs::image_encodings::TYPE_32SC1,

--- a/jsk_perception/src/bounding_box_to_rect.cpp
+++ b/jsk_perception/src/bounding_box_to_rect.cpp
@@ -43,7 +43,7 @@ namespace jsk_perception
 {
   void BoundingBoxToRect::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     tf_listener_ = jsk_recognition_utils::TfListenerSingleton::getInstance();
     pnh_->param("queue_size", queue_size_, 100);
     pnh_->param("approximate_sync", approximate_sync_, false);
@@ -131,7 +131,9 @@ namespace jsk_perception
     internal_msg.header = boxes_msg->header;
     internal_msg.boxes = *boxes_msg;
     internal_msg.camera_info = *info_msg;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_internal_.publish(internal_msg);
   }
 

--- a/jsk_perception/src/bounding_object_mask_image.cpp
+++ b/jsk_perception/src/bounding_object_mask_image.cpp
@@ -44,7 +44,7 @@ namespace jsk_perception
 {
   void BoundingObjectMaskImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<sensor_msgs::Image>(*pnh_, "output", 1);
     onInitPostProcess();
   }
@@ -86,7 +86,9 @@ namespace jsk_perception
       cv::drawContours(object_mask, contours, max_area.get<0>(), cv::Scalar(255), CV_FILLED);
     }
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(cv_bridge::CvImage(
                     mask_msg->header,
                     sensor_msgs::image_encodings::MONO8,

--- a/jsk_perception/src/bounding_rect_mask_image.cpp
+++ b/jsk_perception/src/bounding_rect_mask_image.cpp
@@ -44,7 +44,7 @@ namespace jsk_perception
 {
   void BoundingRectMaskImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<sensor_msgs::Image>(*pnh_, "output", 1);
     onInitPostProcess();
   }
@@ -94,7 +94,9 @@ namespace jsk_perception
     cv::Mat rect_mask = cv::Mat::zeros(mask_msg->height, mask_msg->width, CV_8UC1);
     cv::rectangle(rect_mask, rect, cv::Scalar(255), CV_FILLED);
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(cv_bridge::CvImage(
                     mask_msg->header,
                     sensor_msgs::image_encodings::MONO8,

--- a/jsk_perception/src/color_histogram.cpp
+++ b/jsk_perception/src/color_histogram.cpp
@@ -64,7 +64,7 @@ namespace jsk_perception
 
   void ColorHistogram::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     nh_ = ros::NodeHandle(getNodeHandle(), "image");
     pnh_->param("use_mask", use_mask_, false);
     b_hist_size_ = r_hist_size_ = g_hist_size_ =
@@ -253,7 +253,9 @@ namespace jsk_perception
       else {
         roi_image.copyTo(bgr_image);
       }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       image_pub_.publish(cv_bridge::CvImage(
                            image->header,
                            sensor_msgs::image_encodings::BGR8,
@@ -285,7 +287,9 @@ namespace jsk_perception
         = cv_bridge::CvImage(image->header,
                              sensor_msgs::image_encodings::BGR8,
                              masked_image).toImageMsg();
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       image_pub_.publish(ros_masked_image);
       
       processBGR(bgr_image, mask_image, image->header);

--- a/jsk_perception/src/color_histogram_label_match.cpp
+++ b/jsk_perception/src/color_histogram_label_match.cpp
@@ -44,7 +44,7 @@ namespace jsk_perception
 {
   void ColorHistogramLabelMatch::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (
@@ -292,7 +292,9 @@ namespace jsk_perception
                                             CV_8UC1);
     threshold_image.convertTo(threshold_uchar_image, 8, 255.0);
     // convert image from float to uchar
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_result_.publish(
       cv_bridge::CvImage(image_msg->header,
                          sensor_msgs::image_encodings::MONO8,

--- a/jsk_perception/src/colorize_float_image.cpp
+++ b/jsk_perception/src/colorize_float_image.cpp
@@ -43,7 +43,7 @@ namespace jsk_perception
 {
   void ColorizeFloatImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<sensor_msgs::Image>(*pnh_, "output", 1);
     pnh_->param("channel", channel_, 0);
     onInitPostProcess();
@@ -95,7 +95,9 @@ namespace jsk_perception
         }
       }
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(cv_bridge::CvImage(msg->header,
                                     sensor_msgs::image_encodings::RGB8,
                                     color_image).toImageMsg());

--- a/jsk_perception/src/colorize_labels.cpp
+++ b/jsk_perception/src/colorize_labels.cpp
@@ -45,7 +45,7 @@ namespace jsk_perception
 {
   void ColorizeLabels::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<sensor_msgs::Image>(
       *pnh_, "output", 1);
     onInitPostProcess();
@@ -72,7 +72,9 @@ namespace jsk_perception
     cv::Mat output_image;
     jsk_recognition_utils::labelToRGB(label_image, output_image);
     cv::cvtColor(output_image, output_image, CV_RGB2BGR);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(
       cv_bridge::CvImage(
         label_image_msg->header,

--- a/jsk_perception/src/concave_hull_mask_image.cpp
+++ b/jsk_perception/src/concave_hull_mask_image.cpp
@@ -44,7 +44,7 @@ namespace jsk_perception
 {
   void ConcaveHullMaskImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
@@ -132,7 +132,9 @@ namespace jsk_perception
       cv::drawContours(concave_hull_mask, smoothed_contours, i, cv::Scalar(255), CV_FILLED);
     }
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(cv_bridge::CvImage(mask_msg->header,
                                     sensor_msgs::image_encodings::MONO8,
                                     concave_hull_mask).toImageMsg());

--- a/jsk_perception/src/consensus_tracking.cpp
+++ b/jsk_perception/src/consensus_tracking.cpp
@@ -49,7 +49,7 @@ namespace jsk_perception
 {
   void ConsensusTracking::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     pnh_->param("approximate_sync", approximate_sync_, false);
     pnh_->param("queue_size", queue_size_, 100);
@@ -163,7 +163,9 @@ namespace jsk_perception
     cv::fillConvexPoly(mask, vertices, 4, cv::Scalar(255));
 
     // Publish all.
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_mask_image_.publish(cv_bridge::CvImage(image_msg->header,
                                                sensor_msgs::image_encodings::MONO8,
                                                mask).toImageMsg());

--- a/jsk_perception/src/contour_finder.cpp
+++ b/jsk_perception/src/contour_finder.cpp
@@ -48,7 +48,7 @@ namespace jsk_perception
 {
   void ContourFinder::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_debug_image_ = advertise<sensor_msgs::Image>(*pnh_, "debug", 1);
     pub_convex_image_ = advertise<sensor_msgs::Image>(*pnh_, "output/convex", 1);
     onInitPostProcess();
@@ -97,7 +97,9 @@ namespace jsk_perception
     cv::convexHull(cv::Mat(all_contours), convex_contours[0]);
     cv::Mat convex_image = cv::Mat::zeros(input.size(), CV_8UC1);
     cv::drawContours(convex_image, convex_contours, 0, cv::Scalar(255), CV_FILLED);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_convex_image_.publish(
       cv_bridge::CvImage(
         image_msg->header,

--- a/jsk_perception/src/convex_hull_mask_image.cpp
+++ b/jsk_perception/src/convex_hull_mask_image.cpp
@@ -49,7 +49,7 @@ namespace jsk_perception
 {
   void ConvexHullMaskImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<sensor_msgs::Image>(*pnh_, "output", 1);
     onInitPostProcess();
   }
@@ -91,7 +91,9 @@ namespace jsk_perception
     cv::Mat convex_hull_mask = cv::Mat::zeros(mask_msg->height, mask_msg->width, CV_8UC1);
     cv::drawContours(convex_hull_mask, hull, max_area.get<0>(), cv::Scalar(255), CV_FILLED);
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(cv_bridge::CvImage(
                     mask_msg->header,
                     sensor_msgs::image_encodings::MONO8,

--- a/jsk_perception/src/draw_rects.cpp
+++ b/jsk_perception/src/draw_rects.cpp
@@ -49,7 +49,7 @@ namespace jsk_perception
 
   void DrawRects::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
 
     srv_ = boost::make_shared<dynamic_reconfigure::Server<Config> >(*pnh_);
     typename dynamic_reconfigure::Server<Config>::CallbackType f =
@@ -193,7 +193,9 @@ namespace jsk_perception
       }
     }
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_image_.publish(*cv_bridge::CvImage(image->header, enc::BGR8, img).toImageMsg());
   }
 

--- a/jsk_perception/src/dual_fisheye_to_panorama.cpp
+++ b/jsk_perception/src/dual_fisheye_to_panorama.cpp
@@ -49,7 +49,7 @@ namespace jsk_perception
 {
   void DualFisheyeToPanorama::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("light_compen", enb_lc_, false);
     pnh_->param("refine_align", enb_ra_, false);
     pnh_->param("fovd", fovd_, 195.0f);
@@ -123,7 +123,9 @@ namespace jsk_perception
     cv::Mat pano;
     pano = stitcher_->stitch(img_l, img_r);
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_panorama_image_.publish(cv_bridge::CvImage(image_msg->header,
                                                    image_msg->encoding,
                                                    pano).toImageMsg());

--- a/jsk_perception/src/filter_mask_image_with_size.cpp
+++ b/jsk_perception/src/filter_mask_image_with_size.cpp
@@ -43,7 +43,7 @@ namespace jsk_perception
 {
   void FilterMaskImageWithSize::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("approximate_sync", approximate_sync_, false);
     pnh_->param("queue_size", queue_size_, 100);
     pnh_->param("use_reference", use_reference_, false);
@@ -158,7 +158,9 @@ namespace jsk_perception
         (min_size_ <= size_input) && (size_input <= max_size_) &&
         (min_relative_size_ <= size_relative) && (size_relative <= max_relative_size_))
     {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_.publish(input_msg);
     }
   }

--- a/jsk_perception/src/fisheye_to_panorama.cpp
+++ b/jsk_perception/src/fisheye_to_panorama.cpp
@@ -48,7 +48,7 @@ namespace jsk_perception
 {
   void FisheyeToPanorama::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("use_panorama", use_panorama_, false);
     pnh_->param("simple_panorama", simple_panorama_, false);
     pub_undistorted_image_ = advertise<sensor_msgs::Image>(
@@ -175,7 +175,9 @@ namespace jsk_perception
           }
         }
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
         vital_checker_->poke();
+#endif
         pub_undistorted_image_.publish(
                                        cv_bridge::CvImage(
                                                           image_msg->header,
@@ -210,7 +212,9 @@ namespace jsk_perception
             }
           }
         }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
         vital_checker_->poke();
+#endif
         pub_undistorted_image_.publish(
                                        cv_bridge::CvImage(
                                                           image_msg->header,
@@ -250,7 +254,9 @@ namespace jsk_perception
           }
         }
       }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_undistorted_image_.publish(
                                      cv_bridge::CvImage(
                                                         image_msg->header,

--- a/jsk_perception/src/flow_velocity_thresholding.cpp
+++ b/jsk_perception/src/flow_velocity_thresholding.cpp
@@ -46,7 +46,7 @@ namespace jsk_perception
 {
   void FlowVelocityThresholding::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&FlowVelocityThresholding::configCallback, this, _1, _2);
@@ -155,7 +155,9 @@ namespace jsk_perception
       }
     }
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(cv_bridge::CvImage(
                     flow_msg->header,
                     sensor_msgs::image_encodings::MONO8,

--- a/jsk_perception/src/gaussian_blur.cpp
+++ b/jsk_perception/src/gaussian_blur.cpp
@@ -45,7 +45,7 @@ namespace jsk_perception
 {
   void GaussianBlur::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&GaussianBlur::configCallback, this, _1, _2);
@@ -92,7 +92,9 @@ namespace jsk_perception
     } else {
       cv::GaussianBlur(image, applied_image, cv::Size(kernel_size_+1, kernel_size_+1), sigma_x_, sigma_y_);
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(cv_bridge::CvImage(
                      image_msg->header,
                      image_msg->encoding,

--- a/jsk_perception/src/grabcut_nodelet.cpp
+++ b/jsk_perception/src/grabcut_nodelet.cpp
@@ -42,7 +42,7 @@ namespace jsk_perception
 {
   void GrabCut::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (
@@ -165,7 +165,9 @@ namespace jsk_perception
       image_msg->header, sensor_msgs::image_encodings::MONO8, fgd_mask);
     cv_bridge::CvImage bg_mask_bridge(
       image_msg->header, sensor_msgs::image_encodings::MONO8, bgd_mask);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_foreground_.publish(fg_bridge.toImageMsg());
     pub_background_.publish(bg_bridge.toImageMsg());
     pub_foreground_mask_.publish(fg_mask_bridge.toImageMsg());

--- a/jsk_perception/src/grid_label.cpp
+++ b/jsk_perception/src/grid_label.cpp
@@ -47,7 +47,7 @@ namespace jsk_perception
 {
   void GridLabel::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
@@ -116,7 +116,9 @@ namespace jsk_perception
         ++counter;
       }
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(cv_bridge::CvImage(header,
                                     sensor_msgs::image_encodings::TYPE_32SC1,
                                     label).toImageMsg());

--- a/jsk_perception/src/hsv_decomposer.cpp
+++ b/jsk_perception/src/hsv_decomposer.cpp
@@ -45,7 +45,7 @@ namespace jsk_perception
 {
   void HSVDecomposer::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_h_ = advertise<sensor_msgs::Image>(*pnh_, "output/hue", 1);
     pub_s_ = advertise<sensor_msgs::Image>(*pnh_, "output/saturation", 1);
     pub_v_ = advertise<sensor_msgs::Image>(*pnh_, "output/value", 1);
@@ -98,7 +98,9 @@ namespace jsk_perception
     cv::Mat hue = hsv_planes[0];
     cv::Mat saturation = hsv_planes[1];
     cv::Mat value = hsv_planes[2];
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_h_.publish(cv_bridge::CvImage(
                      image_msg->header,
                      sensor_msgs::image_encodings::MONO8,

--- a/jsk_perception/src/kmeans.cpp
+++ b/jsk_perception/src/kmeans.cpp
@@ -46,7 +46,7 @@ namespace jsk_perception
 {
   void KMeans::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&KMeans::configCallback, this, _1, _2);
@@ -110,7 +110,9 @@ namespace jsk_perception
       ++label_first;
     }
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(cv_bridge::CvImage(
                   image_msg->header,
                   image_msg->encoding,

--- a/jsk_perception/src/lab_decomposer.cpp
+++ b/jsk_perception/src/lab_decomposer.cpp
@@ -45,7 +45,7 @@ namespace jsk_perception
 {
   void LabDecomposer::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_l_ = advertise<sensor_msgs::Image>(*pnh_, "output/l", 1);
     pub_a_ = advertise<sensor_msgs::Image>(*pnh_, "output/a", 1);
     pub_b_ = advertise<sensor_msgs::Image>(*pnh_, "output/b", 1);
@@ -86,7 +86,9 @@ namespace jsk_perception
     cv::Mat l = lab_planes[0];
     cv::Mat a = lab_planes[1];
     cv::Mat b = lab_planes[2];
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_l_.publish(cv_bridge::CvImage(
                      image_msg->header,
                      sensor_msgs::image_encodings::MONO8,

--- a/jsk_perception/src/label_array_to_mask_image.cpp
+++ b/jsk_perception/src/label_array_to_mask_image.cpp
@@ -45,7 +45,7 @@ namespace jsk_perception
 
   void LabelArrayToMaskImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<sensor_msgs::Image>(*pnh_, "output", 1);
     pnh_->param("label_values", label_array_value_, std::vector<int>{});
     onInitPostProcess();
@@ -86,7 +86,9 @@ namespace jsk_perception
         }
       }
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(cv_bridge::CvImage(
           label_msg->header,
           sensor_msgs::image_encodings::MONO8,

--- a/jsk_perception/src/label_to_mask_image.cpp
+++ b/jsk_perception/src/label_to_mask_image.cpp
@@ -44,7 +44,7 @@ namespace jsk_perception
 
   void LabelToMaskImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     // dynamic_reconfigure
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
@@ -95,7 +95,9 @@ namespace jsk_perception
         }
       }
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(cv_bridge::CvImage(
           label_msg->header,
           sensor_msgs::image_encodings::MONO8,

--- a/jsk_perception/src/mask_image_generator.cpp
+++ b/jsk_perception/src/mask_image_generator.cpp
@@ -48,7 +48,7 @@ namespace jsk_perception
 {
   void MaskImageGenerator::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&MaskImageGenerator::configCallback, this, _1, _2);
@@ -91,7 +91,9 @@ namespace jsk_perception
                   cv::Point(min_x, min_y),
                   cv::Point(max_x, max_y),
                   cv::Scalar(255), CV_FILLED);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(cv_bridge::CvImage(msg->header,
                                     sensor_msgs::image_encodings::MONO8,
                                     mask_image).toImageMsg());

--- a/jsk_perception/src/mask_image_to_rect.cpp
+++ b/jsk_perception/src/mask_image_to_rect.cpp
@@ -44,7 +44,7 @@ namespace jsk_perception
 {
   void MaskImageToRect::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<jsk_recognition_msgs::RectArray>(*pnh_, "output", 1);
     onInitPostProcess();
   }
@@ -86,7 +86,9 @@ namespace jsk_perception
       rect.height = mask_rect.height;
       rects.rects.push_back(rect);
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(rects);
   }
 }

--- a/jsk_perception/src/mask_image_to_roi.cpp
+++ b/jsk_perception/src/mask_image_to_roi.cpp
@@ -44,7 +44,7 @@ namespace jsk_perception
 {
   void MaskImageToROI::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<sensor_msgs::CameraInfo>(*pnh_, "output", 1);
     onInitPostProcess();
   }
@@ -94,7 +94,9 @@ namespace jsk_perception
       camera_info.roi.width = mask_rect.width;
       camera_info.roi.height = mask_rect.height;
       camera_info.header = mask_msg->header;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_.publish(camera_info);
     }
     else {

--- a/jsk_perception/src/morphological_operator.cpp
+++ b/jsk_perception/src/morphological_operator.cpp
@@ -46,7 +46,7 @@ namespace jsk_perception
 
   void MorphologicalImageOperatorNodelet::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (
@@ -101,7 +101,9 @@ namespace jsk_perception
       cv::Size(2 * size_ + 1, 2 * size_+1),
       cv::Point(size_, size_));
     apply(image, output_image, element);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(
       cv_bridge::CvImage(image_msg->header,
                          sensor_msgs::image_encodings::MONO8,

--- a/jsk_perception/src/multiply_mask_image.cpp
+++ b/jsk_perception/src/multiply_mask_image.cpp
@@ -44,7 +44,7 @@ namespace jsk_perception
 {
   void MultiplyMaskImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("approximate_sync", approximate_sync_, false);
     pnh_->param("queue_size", queue_size_, 100);
     pub_ = advertise<sensor_msgs::Image>(
@@ -98,7 +98,9 @@ namespace jsk_perception
       src2_msg, src2_msg->encoding)->image;
     cv::Mat result;
     cv::bitwise_and(src1, src2, result);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(
       cv_bridge::CvImage(src1_msg->header,
                          sensor_msgs::image_encodings::MONO8,

--- a/jsk_perception/src/overlay_image_color_on_mono.cpp
+++ b/jsk_perception/src/overlay_image_color_on_mono.cpp
@@ -46,7 +46,7 @@ namespace jsk_perception
 {
   void OverlayImageColorOnMono::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("approximate_sync", approximate_sync_, false);
     pnh_->param("queue_size", queue_size_, 100);
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
@@ -130,7 +130,9 @@ namespace jsk_perception
                                                         color[2] * color_alpha_ + mono * (1 - color_alpha_));
       }
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(cv_bridge::CvImage(color_imgmsg->header,
                                     color_imgmsg->encoding,
                                     overlayed_image).toImageMsg());

--- a/jsk_perception/src/polygon_array_color_histogram.cpp
+++ b/jsk_perception/src/polygon_array_color_histogram.cpp
@@ -48,7 +48,7 @@ namespace jsk_perception
 {
   void PolygonArrayColorHistogram::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     tf_listener_ = jsk_recognition_utils::TfListenerSingleton::getInstance();
     pnh_->param("max_queue_size", max_queue_size_, 10);
     pnh_->param("synchronizer_queue_size", sync_queue_size_, 100);
@@ -169,7 +169,9 @@ namespace jsk_perception
             hist, pixel_min_value_, pixel_max_value_);
         histogram_array.histograms.push_back(histogram);
       }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_debug_polygon_.publish(cv_bridge::CvImage(image_msg->header,
                                                     sensor_msgs::image_encodings::RGB8,
                                                     debug_polygon_image).toImageMsg());

--- a/jsk_perception/src/polygon_array_color_likelihood.cpp
+++ b/jsk_perception/src/polygon_array_color_likelihood.cpp
@@ -42,7 +42,7 @@ namespace jsk_perception
 {
   void PolygonArrayColorLikelihood::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("approximate_sync", approximate_sync_, false);
     pnh_->param("max_queue_size", max_queue_size_, 10);
     pnh_->param("synchronizer_queue_size", sync_queue_size_, 100);
@@ -252,7 +252,9 @@ namespace jsk_perception
         new_msg.likelihood[i] *= d;
       }
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(new_msg);
   }
 }

--- a/jsk_perception/src/polygon_array_to_label_image.cpp
+++ b/jsk_perception/src/polygon_array_to_label_image.cpp
@@ -44,7 +44,7 @@ namespace jsk_perception
 {
   void PolygonArrayToLabelImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<sensor_msgs::Image>(
       *pnh_, "output", 1);
     onInitPostProcess();
@@ -105,7 +105,9 @@ namespace jsk_perception
           }
         }
       }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_.publish(cv_bridge::CvImage(polygon_msg->header,
                                       sensor_msgs::image_encodings::TYPE_32SC1,
                                       mask_image).toImageMsg());

--- a/jsk_perception/src/polygon_to_mask_image.cpp
+++ b/jsk_perception/src/polygon_to_mask_image.cpp
@@ -44,7 +44,7 @@ namespace jsk_perception
 {
   void PolygonToMaskImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<sensor_msgs::Image>(
       *pnh_, "output", 1);
     onInitPostProcess();
@@ -98,7 +98,9 @@ namespace jsk_perception
         }
         cv::fillConvexPoly(mask_image, &(points[0]), points.size(), cv::Scalar(255));
       }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_.publish(cv_bridge::CvImage(polygon_msg->header,
                                       sensor_msgs::image_encodings::MONO8,
                                       mask_image).toImageMsg());

--- a/jsk_perception/src/project_image_point.cpp
+++ b/jsk_perception/src/project_image_point.cpp
@@ -41,7 +41,7 @@ namespace jsk_perception
 {
   void ProjectImagePoint::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&ProjectImagePoint::configCallback, this, _1, _2);
@@ -101,7 +101,9 @@ namespace jsk_perception
     vector.vector.x = ray.x;
     vector.vector.y = ray.y;
     vector.vector.z = ray.z;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_vector_.publish(vector);
     if (ray.z == 0.0) {
       NODELET_ERROR("Z value of projected ray is 0");

--- a/jsk_perception/src/rect_array_actual_size_filter.cpp
+++ b/jsk_perception/src/rect_array_actual_size_filter.cpp
@@ -42,7 +42,7 @@ namespace jsk_perception
 {
   void RectArrayActualSizeFilter::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("approximate_sync", approximate_sync_, false);
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
@@ -165,7 +165,9 @@ namespace jsk_perception
         return;
       }
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(result_msg);
   }
 

--- a/jsk_perception/src/rect_array_to_density_image.cpp
+++ b/jsk_perception/src/rect_array_to_density_image.cpp
@@ -44,7 +44,7 @@ namespace jsk_perception
 {
   void RectArrayToDensityImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("approximate_sync", approximate_sync_, false);
     pnh_->param("queue_size", queue_size_, 100);
     pub_ = advertise<sensor_msgs::Image>(*pnh_, "output", 1);
@@ -110,7 +110,9 @@ namespace jsk_perception
     cv::Mat(density_image - min_image_value).convertTo(
         density_image, CV_32FC1, 1. / (max_image_value - min_image_value));
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(cv_bridge::CvImage(
                     image_msg->header,
                     "32FC1",

--- a/jsk_perception/src/rect_to_mask_image.cpp
+++ b/jsk_perception/src/rect_to_mask_image.cpp
@@ -46,7 +46,7 @@ namespace jsk_perception
 {
   void RectToMaskImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<sensor_msgs::Image>(*pnh_, "output", 1);
     onInitPostProcess();
   }
@@ -84,7 +84,9 @@ namespace jsk_perception
       double height = std::min(max_y - min_y, camera_info_->height - min_y);
       cv::Rect region(min_x, min_y, width, height);
       cv::rectangle(mask_image, region, cv::Scalar(255), CV_FILLED);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_.publish(cv_bridge::CvImage(
                      rect_msg->header,
                      sensor_msgs::image_encodings::MONO8,

--- a/jsk_perception/src/rect_to_roi.cpp
+++ b/jsk_perception/src/rect_to_roi.cpp
@@ -41,7 +41,7 @@ namespace jsk_perception
 {
   void RectToROI::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<sensor_msgs::CameraInfo>(*pnh_, "output", 1);
     onInitPostProcess();
   }
@@ -87,7 +87,9 @@ namespace jsk_perception
       roi.roi.y_offset = (int)min_y;
       roi.roi.height = height;
       roi.roi.width = width;
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_.publish(roi);
     }
     else {

--- a/jsk_perception/src/rgb_decomposer.cpp
+++ b/jsk_perception/src/rgb_decomposer.cpp
@@ -45,7 +45,7 @@ namespace jsk_perception
 {
   void RGBDecomposer::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_r_ = advertise<sensor_msgs::Image>(*pnh_, "output/red", 1);
     pub_g_ = advertise<sensor_msgs::Image>(*pnh_, "output/green", 1);
     pub_b_ = advertise<sensor_msgs::Image>(*pnh_, "output/blue", 1);
@@ -82,7 +82,9 @@ namespace jsk_perception
     cv::Mat red = bgr_planes[2];
     cv::Mat blue = bgr_planes[0];
     cv::Mat green = bgr_planes[1];
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_r_.publish(cv_bridge::CvImage(
                      image_msg->header,
                      sensor_msgs::image_encodings::MONO8,

--- a/jsk_perception/src/robot_to_mask_image.cpp
+++ b/jsk_perception/src/robot_to_mask_image.cpp
@@ -42,7 +42,7 @@ namespace jsk_perception
 {
   void RobotToMaskImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     initSelfMask(*pnh_);
     pnh_->param("max_robot_dist", max_robot_dist_, 10.0);
     pub_ = advertise<sensor_msgs::Image>(*pnh_, "output", 1);
@@ -110,7 +110,9 @@ namespace jsk_perception
       cv::Mat_<double> D = model.distortionCoeffs();
       camera_info_msg.D.resize(D.rows * D.cols);
       for (size_t i = 0; i < D.rows; ++i) for (size_t j = 0; j < D.cols; ++j) camera_info_msg.D[i * D.cols + j] = D(i, j);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_.publish(cv_bridge::CvImage(info_msg->header,
                                       sensor_msgs::image_encodings::MONO8,
                                       mask_image).toImageMsg());

--- a/jsk_perception/src/roi_to_mask_image.cpp
+++ b/jsk_perception/src/roi_to_mask_image.cpp
@@ -44,7 +44,7 @@ namespace jsk_perception
 {
   void ROIToMaskImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<sensor_msgs::Image>(
       *pnh_, "output", 1);
     onInitPostProcess();
@@ -73,7 +73,9 @@ namespace jsk_perception
                   info_msg->roi.width,
                   info_msg->roi.height);
     cv::rectangle(mask_image, rect, cv::Scalar(255), CV_FILLED);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(cv_bridge::CvImage(
                    info_msg->header,
                    sensor_msgs::image_encodings::MONO8,

--- a/jsk_perception/src/roi_to_rect.cpp
+++ b/jsk_perception/src/roi_to_rect.cpp
@@ -41,7 +41,7 @@ namespace jsk_perception
 {
   void ROIToRect::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertise<geometry_msgs::PolygonStamped>(
       *pnh_, "output", 1);
     onInitPostProcess();
@@ -77,7 +77,9 @@ namespace jsk_perception
     rect.polygon.points.push_back(bottom_left_pt);
     rect.polygon.points.push_back(bottom_right_pt);
     rect.polygon.points.push_back(top_right_pt);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(rect);
   }
 }

--- a/jsk_perception/src/saliency_map_generator_node.cpp
+++ b/jsk_perception/src/saliency_map_generator_node.cpp
@@ -8,7 +8,7 @@ namespace jsk_perception
 {
    void SaliencyMapGenerator::onInit()
    {
-      DiagnosticNodelet::onInit();
+      jsk_topic_tools::NODELET::onInit();
       pnh_->getParam("num_threads", this->num_threads_);
       pnh_->getParam("fps", this->print_fps_);
       this->pub_image_ = advertise<sensor_msgs::Image>(*pnh_,
@@ -63,7 +63,9 @@ namespace jsk_perception
       cv_bridge::CvImage pub_img(image_msg->header,
                                  image_msg->encoding,
                                  saliency_map);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       this->pub_image_.publish(pub_img.toImageMsg());
    }
 

--- a/jsk_perception/src/single_channel_histogram.cpp
+++ b/jsk_perception/src/single_channel_histogram.cpp
@@ -43,7 +43,7 @@ namespace jsk_perception
 {
   void SingleChannelHistogram::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("use_mask", use_mask_, false);
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
@@ -122,7 +122,9 @@ namespace jsk_perception
     for (int i = 0; i < hist_size_; i++) {
       histogram.histogram.push_back(hist.at<float>(0, i));
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(histogram);
   }
   

--- a/jsk_perception/src/skeletonization_nodelet.cpp
+++ b/jsk_perception/src/skeletonization_nodelet.cpp
@@ -40,7 +40,7 @@ namespace jsk_perception
 {
     void Skeletonization::onInit()
     {
-       DiagnosticNodelet::onInit();
+       jsk_topic_tools::NODELET::onInit();
        pnh_->getParam("num_threads", this->num_threads_);
        this->pub_image_ = advertise<sensor_msgs::Image>(
           *pnh_, "image_output", 1);
@@ -78,7 +78,9 @@ namespace jsk_perception
        out_msg->header = cv_ptr->header;
        out_msg->encoding = sensor_msgs::image_encodings::TYPE_32FC1;
        out_msg->image = image.clone();
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
        vital_checker_->poke();
+#endif
        this->pub_image_.publish(out_msg->toImageMsg());
     }
 

--- a/jsk_perception/src/sliding_window_object_detector.cpp
+++ b/jsk_perception/src/sliding_window_object_detector.cpp
@@ -13,7 +13,7 @@ namespace jsk_perception
 {
    void SlidingWindowObjectDetector::onInit()
    {
-      DiagnosticNodelet::onInit();
+      jsk_topic_tools::NODELET::onInit();
 
       this->nms_client_ = pnh_->serviceClient<
          jsk_perception::NonMaximumSuppression>("non_maximum_suppression");
@@ -128,7 +128,9 @@ namespace jsk_perception
          out_msg->header = msg->header;
          out_msg->encoding = sensor_msgs::image_encodings::BGR8;
          out_msg->image = bimg.clone();
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
          vital_checker_->poke();
+#endif
          this->pub_rects_.publish(jsk_rect_array);
          this->pub_image_.publish(out_msg->toImageMsg());
       } else if (this->run_type_.compare("BOOTSTRAPER") == 0) {
@@ -151,7 +153,9 @@ namespace jsk_perception
             }
          }
       } else {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
         vital_checker_->poke();
+#endif
          this->pub_image_.publish(cv_ptr->toImageMsg());
          ROS_ERROR("NODELET RUNTYPE IS NOT SET.");
          std::_Exit(EXIT_FAILURE);

--- a/jsk_perception/src/snake_segmentation.cpp
+++ b/jsk_perception/src/snake_segmentation.cpp
@@ -47,7 +47,7 @@ namespace jsk_perception
 {
   void SnakeSegmentation::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (
@@ -137,7 +137,9 @@ namespace jsk_perception
       cv::circle(debug_image, points[i], 2, cv::Scalar(100, 0, 0), 1);
     }
 
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_debug_.publish(cv_bridge::CvImage(
                          image_msg->header,
                          sensor_msgs::image_encodings::BGR8,

--- a/jsk_perception/src/subtract_mask_image.cpp
+++ b/jsk_perception/src/subtract_mask_image.cpp
@@ -49,7 +49,7 @@ namespace jsk_perception
 {
   void SubtractMaskImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("approximate_sync", approximate_sync_, false);
     pnh_->param("queue_size", queue_size_, 100);
     pub_ = advertise<sensor_msgs::Image>(
@@ -112,7 +112,9 @@ namespace jsk_perception
 
     cv::Mat result = cv::Mat::zeros(mask1.size(), mask1.type());
     mask1.copyTo(result, mask2_not);
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_.publish(
       cv_bridge::CvImage(src1_msg->header, enc::MONO8, result).toImageMsg());
   }

--- a/jsk_perception/src/tabletop_color_difference_likelihood.cpp
+++ b/jsk_perception/src/tabletop_color_difference_likelihood.cpp
@@ -52,7 +52,7 @@ namespace jsk_perception
 {
   void TabletopColorDifferenceLikelihood::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("tf_queue_size", tf_queue_size_, 10);
     pnh_->param("cyclic_value", cyclic_value_, true);
     srv_ = boost::make_shared <dynamic_reconfigure::Server<Config> > (*pnh_);
@@ -217,7 +217,9 @@ namespace jsk_perception
           }
         }
       }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
       vital_checker_->poke();
+#endif
       pub_.publish(cv_bridge::CvImage(msg->header,
                                       sensor_msgs::image_encodings::MONO8,
                                       image).toImageMsg());

--- a/jsk_perception/src/unapply_mask_image.cpp
+++ b/jsk_perception/src/unapply_mask_image.cpp
@@ -45,7 +45,7 @@ namespace jsk_perception
 {
   void UnapplyMaskImage::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pnh_->param("approximate_sync", approximate_sync_, false);
     pub_image_ = advertise<sensor_msgs::Image>(
       *pnh_, "output", 1);
@@ -125,7 +125,9 @@ namespace jsk_perception
         }
       }
     }
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_image_.publish(cv_bridge::CvImage(
                          image_msg->header,
                          image_msg->encoding,

--- a/jsk_perception/src/virtual_camera_mono.cpp
+++ b/jsk_perception/src/virtual_camera_mono.cpp
@@ -9,7 +9,7 @@ namespace jsk_perception
 {
   void VirtualCameraMono::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_ = advertiseCamera(*pnh_, "image", 1);
 
     dynamic_reconfigure::Server<jsk_perception::VirtualCameraMonoConfig>::CallbackType f =
@@ -94,7 +94,9 @@ namespace jsk_perception
   void VirtualCameraMono::imageCb(const sensor_msgs::ImageConstPtr& image_msg,
                const sensor_msgs::CameraInfoConstPtr& info_msg)
   {
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     cv_bridge::CvImagePtr cv_ptr;
     cv::Mat image;
     try {

--- a/jsk_perception/src/ycc_decomposer.cpp
+++ b/jsk_perception/src/ycc_decomposer.cpp
@@ -45,7 +45,7 @@ namespace jsk_perception
 {
   void YCCDecomposer::onInit()
   {
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     pub_y_ = advertise<sensor_msgs::Image>(*pnh_, "output/y", 1);
     pub_cr_ = advertise<sensor_msgs::Image>(*pnh_, "output/cr", 1);
     pub_cb_ = advertise<sensor_msgs::Image>(*pnh_, "output/cb", 1);
@@ -86,7 +86,9 @@ namespace jsk_perception
     cv::Mat y = ycc_planes[0];
     cv::Mat cr = ycc_planes[1];
     cv::Mat cb = ycc_planes[2];
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     vital_checker_->poke();
+#endif
     pub_y_.publish(cv_bridge::CvImage(
                      image_msg->header,
                      sensor_msgs::image_encodings::MONO8,

--- a/resized_image_transport/CMakeLists.txt
+++ b/resized_image_transport/CMakeLists.txt
@@ -12,6 +12,7 @@ endif(CCACHE_FOUND)
 find_package(catkin REQUIRED COMPONENTS cv_bridge sensor_msgs image_transport
   std_srvs message_generation dynamic_reconfigure
   nodelet
+  jsk_recognition_utils
   jsk_topic_tools)
 find_package(OpenCV REQUIRED)
 

--- a/resized_image_transport/include/resized_image_transport/image_processing_nodelet.h
+++ b/resized_image_transport/include/resized_image_transport/image_processing_nodelet.h
@@ -26,11 +26,22 @@
 #include <dynamic_reconfigure/server.h>
 #include <jsk_topic_tools/timered_diagnostic_updater.h>
 #include <jsk_topic_tools/diagnostic_utils.h>
-#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <jsk_recognition_utils/jsk_topic_tools_version.h>
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
+  #include <jsk_topic_tools/diagnostic_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET DiagnosticNodelet
+  }
+#else
+  #include <jsk_topic_tools/connection_based_nodelet.h>
+  namespace jsk_topic_tools {
+    #define NODELET ConnectionBasedNodelet
+  }
+#endif
 
 namespace resized_image_transport
 {
-  class ImageProcessing : public jsk_topic_tools::DiagnosticNodelet
+  class ImageProcessing : public jsk_topic_tools::NODELET
   {
   public:
   protected:
@@ -72,9 +83,10 @@ namespace resized_image_transport
     jsk_topic_tools::VitalChecker::Ptr image_vital_;
     jsk_topic_tools::VitalChecker::Ptr info_vital_;
     jsk_topic_tools::TimeredDiagnosticUpdater::Ptr diagnostic_updater_;
-
+#if JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13)
     virtual void updateDiagnostic(
       diagnostic_updater::DiagnosticStatusWrapper &stat);
+#endif
     void onInit();
     void initReconfigure();
     void initParams();
@@ -86,8 +98,7 @@ namespace resized_image_transport
       in_times(boost::circular_buffer<double>(100)),
       out_times(boost::circular_buffer<double>(100)),
       in_bytes(boost::circular_buffer<double>(100)),
-      out_bytes(boost::circular_buffer<double>(100)),
-      DiagnosticNodelet("ImageProcessing")
+      out_bytes(boost::circular_buffer<double>(100))
       { }
     ~ImageProcessing() { }
     

--- a/resized_image_transport/src/image_resizer_nodelet.cpp
+++ b/resized_image_transport/src/image_resizer_nodelet.cpp
@@ -5,7 +5,7 @@ namespace resized_image_transport
   void ImageResizer::onInit() {
     raw_width_ = 0;
     raw_height_ = 0;
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     initParams();
     initReconfigure();
     initPublishersAndSubscribers();

--- a/resized_image_transport/src/log_polar_nodelet.cpp
+++ b/resized_image_transport/src/log_polar_nodelet.cpp
@@ -3,7 +3,7 @@
 namespace resized_image_transport
 {
   void LogPolar::onInit(){
-    DiagnosticNodelet::onInit();
+    jsk_topic_tools::NODELET::onInit();
     initReconfigure();
     initParams();
     initPublishersAndSubscribers();


### PR DESCRIPTION
Modified all `ConnectionBasedNodelets` in jsk_recognition to `DiagnosticNodelet`.

```
$ cd jsk_recognition
$ grep ConnectionBasedNodelet -l -r --include='*.h' . | wc
0       0       0
$ grep ConnectionBasedNodelet -l -r --include='*.hpp' . | wc
0       0       0
```

Also, DiagnosticsNodelet requires poke.
There are many PRs out there that add `poke`, and this PR also added `poke` for all nodelets that do not have `poke`.
https://github.com/jsk-ros-pkg/jsk_recognition/pull/2690
https://github.com/jsk-ros-pkg/jsk_recognition/pull/2710
https://github.com/jsk-ros-pkg/jsk_recognition/pull/2203

```
$ cd jsk_recognition
$ grep 'DiagnosticNodelet::onInit' -r . -l | xargs grep -L poke | sort
./.git/logs/HEAD
./.git/logs/refs/heads/reset-sync-policy
./resized_image_transport/src/image_resizer_nodelet.cpp
./resized_image_transport/src/log_polar_nodelet.cpp
```

The nodes of `resized_image_transport` inherit from `image_processing_nodelet`, and `poke` is called inside `image_processing_nodelet`.
https://github.com/jsk-ros-pkg/jsk_recognition/blob/09cbce5f0ce7102331f6e48b9f9befc2b1fda869/resized_image_transport/src/image_processing_nodelet.cpp#L141-L157
