### PR TITLE
[jsk_perception/robot_to_mask_image] Fix image size considering binning

### DIFF
--- a/doc/jsk_perception/nodes/robot_to_mask_image.md
+++ b/doc/jsk_perception/nodes/robot_to_mask_image.md
@@ -13,6 +13,12 @@ Convert robot model into mask image.
 
   Mask image to fill `~input` polygon.
 
+  The size of the output image will be resized to fit the `roi` and `binnning`.
+
+* `~output/info` (`sensor_msgs/CameraInfo`)
+
+  `CameraInfo` for the output image.
+
 ## Parameters
 * `~max_robot_dist` (Double, default: `10`)
 

--- a/jsk_perception/include/jsk_perception/robot_to_mask_image.h
+++ b/jsk_perception/include/jsk_perception/robot_to_mask_image.h
@@ -59,6 +59,7 @@ namespace jsk_perception
 
     ros::Subscriber sub_;
     ros::Publisher pub_;
+    ros::Publisher pub_camera_info_;
 
     boost::shared_ptr<robot_self_filter::SelfMask<pcl::PointXYZ> > self_mask_;
     tf::TransformListener tf_listener_;

--- a/jsk_perception/sample/sample_robot_to_mask_image.launch
+++ b/jsk_perception/sample/sample_robot_to_mask_image.launch
@@ -1,15 +1,46 @@
 <launch>
   <arg name="gui" default="true"/>
+  <arg name="decimate" default="false" doc="Use decimate input depth image or not." />
+  <arg name="decimation_x" default="4" doc="decimate with respect to x direction. Only valid when decimate is true."/>
+  <arg name="decimation_y" default="4" doc="decimate with respect to y direction. Only valid when decimate is true."/>
+  <arg name="roi_x_offset" default="200" doc="Region of interest's x_offset. Only valid when decimate is true." />
+  <arg name="roi_y_offset" default="100" doc="Region of interest's y_offset. Only valid when decimate is true." />
+  <arg name="roi_width" default="200" doc="Region of interest's width. Only valid when decimate is true." />
+  <arg name="roi_height" default="320" doc="Region of interest's height. Only valid when decimate is true." />
+
+  <arg name="INPUT_CAMERA_INFO" default="/kinect_head/rgb/camera_info" unless="$(arg decimate)" />
+  <arg name="INPUT_CAMERA_INFO" default="/kinect_head/depth_downsample/camera_info" if="$(arg decimate)" />
   <arg name="rosbag_play_args" default="--clock --loop" />
 
   <include file="$(find jsk_perception)/sample/include/play_rosbag_pr2_self_see.xml">
     <arg name="rosbag_play_args" value="$(arg rosbag_play_args)" />
   </include>
 
+  <group ns="kinect_head">
+    <node if="$(arg decimate)"
+          name="crop_decimate"
+          pkg="nodelet" type="nodelet"
+          args="standalone image_proc/crop_decimate"
+          output="screen"
+          clear_params="true" >
+      <remap from="camera/image_raw" to="depth_registered/hw_registered/image_rect" />
+      <remap from="depth_registered/hw_registered/camera_info" to="depth_registered/camera_info" />
+      <remap from="camera_out" to="depth_downsample" />
+      <param name="decimation_x" value="$(arg decimation_x)" />
+      <param name="decimation_y" value="$(arg decimation_y)" />
+      <param name="queue_size" value="1" />
+      <param name="x_offset" type="int" value="$(arg roi_x_offset)" />
+      <param name="y_offset" type="int" value="$(arg roi_y_offset)" />
+      <param name="width" type="int" value="$(arg roi_width)" />
+      <param name="height" type="int" value="$(arg roi_height)" />
+    </node>
+  </group>
+
   <node name="robot_to_mask_image"
         pkg="nodelet" type="nodelet"
-        args="standalone jsk_perception/RobotToMaskImage">
-    <remap from="~input/camera_info" to="/kinect_head/rgb/camera_info"/>
+        args="standalone jsk_perception/RobotToMaskImage"
+        output="screen">
+    <remap from="~input/camera_info" to="$(arg INPUT_CAMERA_INFO)"/>
     <rosparam>
       self_see_links:
         - name: base_link

--- a/jsk_perception/src/robot_to_mask_image.cpp
+++ b/jsk_perception/src/robot_to_mask_image.cpp
@@ -66,10 +66,19 @@ namespace jsk_perception
       image_geometry::PinholeCameraModel model;
       model.fromCameraInfo(info_msg);
 
-      cv::Mat mask_image = cv::Mat::zeros(info_msg->height, info_msg->width, CV_8UC1);
+      int height = info_msg->height;
+      int width = info_msg->width;
+      if(info_msg->binning_y > 0) {
+        height /= info_msg->binning_y;
+      }
+      if(info_msg->binning_x > 0) {
+        width /= info_msg->binning_x;
+      }
+
+      cv::Mat mask_image = cv::Mat::zeros(height, width, CV_8UC1);
       self_mask_->assumeFrame(info_msg->header);
-      for (int u = 0; u < info_msg->width; u++) {
-        for (int v = 0; v < info_msg->height; v++) {
+      for (int u = 0; u < width; u++) {
+        for (int v = 0; v < height; v++) {
           // project to 3d
           cv::Point uv(u, v);
           cv::Point3d p = model.projectPixelTo3dRay(uv);

--- a/jsk_perception/src/robot_to_mask_image.cpp
+++ b/jsk_perception/src/robot_to_mask_image.cpp
@@ -66,12 +66,13 @@ namespace jsk_perception
       image_geometry::PinholeCameraModel model;
       model.fromCameraInfo(info_msg);
 
-      int height = info_msg->height;
-      int width = info_msg->width;
-      if(info_msg->binning_y > 0) {
+      sensor_msgs::RegionOfInterest roi = info_msg->roi;
+      int height = roi.height ? roi.height : info_msg->height;
+      int width = roi.width ? roi.width : info_msg->width;
+      if (info_msg->binning_y > 0) {
         height /= info_msg->binning_y;
       }
-      if(info_msg->binning_x > 0) {
+      if (info_msg->binning_x > 0) {
         width /= info_msg->binning_x;
       }
 


### PR DESCRIPTION
I fixed image size and index for downsampled image.

When image is downsampled, width and height of camerainfo are the same as the original and we can tell the actual size with binning field.
PinholeCameraModel calculates projection matrix considering it:
```
if (binning_x > 1) {
  double scale_x = 1.0 / binning_x;
  K_(0,0) *= scale_x;
  K_(0,2) *= scale_x;
  P_(0,0) *= scale_x;
  P_(0,2) *= scale_x;
  P_(0,3) *= scale_x;
}
```
However, this node makes `info_msg->height` times `info_msg->width` mask image so output mask is distortedly enlarged.

![Screenshot from 2022-07-15 00-18-41](https://user-images.githubusercontent.com/63297509/179019602-a2e82d66-e3bd-4933-be8e-c63e7ffd1fa7.png)

### sample
```
<launch>
  <arg name="gui" default="true"/>
  <arg name="rosbag_play_args" default="--clock --loop" />

  <include file="$(find jsk_perception)/sample/include/play_rosbag_pr2_self_see.xml">
    <arg name="rosbag_play_args" value="$(arg rosbag_play_args)" />
  </include>

  <group ns="kinect_head">
    <node pkg="nodelet" type="nodelet" name="crop_decimate" args="standalone image_proc/crop_decimate" output="screen">
      <remap from="camera/image_raw" to="depth_registered/hw_registered/image_rect" />
      <remap from="depth_registered/hw_registered/camera_info" to="depth_registered/camera_info" />
      <remap from="camera_out" to="depth_downsample" />
      <param name="decimation_x" value="4" />
      <param name="decimation_y" value="4" />
      <param name="queue_size" value="1" />
    </node>
  </group>

  <node name="robot_to_mask_image"
        pkg="nodelet" type="nodelet"
        args="standalone jsk_perception/RobotToMaskImage">
    <remap from="~input/camera_info" to="/kinect_head/depth_downsample/camera_info"/>
    <rosparam>
      self_see_links:
        - name: base_link
        - name: l_shoulder_pan_link
        - name: l_shoulder_lift_link
        - name: l_upper_arm_link
        - name: l_upper_arm_roll_link
        - name: l_elbow_flex_link
        - name: l_forearm_link
        - name: l_forearm_roll_link
        - name: l_wrist_flex_link
        - name: l_wrist_roll_link
        - name: l_gripper_palm_link
        - name: l_gripper_l_finger_link
        - name: l_gripper_l_finger_tip_link
        - name: l_gripper_r_finger_link
        - name: l_gripper_r_finger_tip_link
        - name: r_shoulder_pan_link
        - name: r_shoulder_lift_link
        - name: r_upper_arm_link
        - name: r_upper_arm_roll_link
        - name: r_elbow_flex_link
        - name: r_forearm_link
        - name: r_forearm_roll_link
        - name: r_wrist_flex_link
        - name: r_wrist_roll_link
        - name: r_gripper_palm_link
        - name: r_gripper_l_finger_link
        - name: r_gripper_l_finger_tip_link
        - name: r_gripper_r_finger_link
        - name: r_gripper_r_finger_tip_link
      self_see_default_padding: 0.0
    </rosparam>
  </node>
  
  <group if="$(arg gui)">
    <node name="rviz"
          pkg="rviz" type="rviz"
          args="-d $(find jsk_perception)/sample/config/sample_robot_to_mask_image.rviz"/>
  </group>
</launch>

```