### PR TITLE
[jsk_perception/image_publisher.py] Support bgr16, rgb16, bgra16 and rgba16 encodings  and compressedDepth for 32FC1 depth image

### DIFF
--- a/doc/jsk_perception/nodes/image_publisher.md
+++ b/doc/jsk_perception/nodes/image_publisher.md
@@ -7,6 +7,14 @@ Publish image from loaded file.
 ## Publishing Topics
 * `~output` (`sensor_msgs/Image`)
 
+* `~output/compressed` (`sensor_msgs/CompressedImage`)
+
+  Compressed Image.
+
+* `~output/compressedDepth` (`sensor_msgs/CompressedImage`)
+
+  Compressed Depth Image. This is valid when encoding is `32FC1`.
+
 * `~output/camera_info` (`sensor_msgs/CameraInfo`)
 
 ## Parameters

--- a/jsk_perception/node_scripts/image_publisher.py
+++ b/jsk_perception/node_scripts/image_publisher.py
@@ -167,7 +167,8 @@ class ImagePublisher(object):
     def cv2_to_imgmsg(self, img, encoding):
         bridge = cv_bridge.CvBridge()
         # resolve encoding
-        if getCvType(encoding) in [cv2.CV_8UC1, cv2.CV_16UC1, cv2.CV_32FC1]:
+        cv_type = getCvType(encoding)
+        if cv_type in [cv2.CV_8UC1, cv2.CV_16UC1, cv2.CV_32FC1]:
             # mono8
             if len(img.shape) == 3:
                 if img.shape[2] == 4:
@@ -175,23 +176,23 @@ class ImagePublisher(object):
                 else:
                     code = cv2.COLOR_BGR2GRAY
                 img = cv2.cvtColor(img, code)
-            if getCvType(encoding) == cv2.CV_16UC1:
+            if cv_type == cv2.CV_16UC1:
                 # 16UC1
                 img = img.astype(np.float32)
                 img = np.clip(img / 255.0 * (2 ** 16 - 1), 0, 2 ** 16 - 1)
                 img = img.astype(np.uint16)
-            elif getCvType(encoding) == cv2.CV_32FC1:
+            elif cv_type == cv2.CV_32FC1:
                 # 32FC1
                 img = img.astype(np.float32)
                 img /= 255
-        elif getCvType(encoding) == cv2.CV_8UC3 and len(img.shape) == 3:
+        elif cv_type == cv2.CV_8UC3 and len(img.shape) == 3:
             # 8UC3
             # BGRA, BGR -> BGR
             img = img[:, :, :3]
             # BGR -> RGB
             if encoding == 'rgb8':
                 img = img[:, :, ::-1]
-        elif getCvType(encoding) == cv2.CV_16UC3 and len(img.shape) == 3:
+        elif cv_type == cv2.CV_16UC3 and len(img.shape) == 3:
             # 16UC3
             # BGRA, BGR -> BGR
             img = img[:, :, :3]
@@ -202,13 +203,13 @@ class ImagePublisher(object):
             # BGR -> RGB
             if encoding == 'rgb16':
                 img = img[:, :, ::-1]
-        elif (getCvType(encoding) == cv2.CV_8UC4 and
+        elif (cv_type == cv2.CV_8UC4 and
                 len(img.shape) == 3 and img.shape[2] == 4):
             # 8UC4
             if encoding == 'rgba8':
                 # BGRA -> RGBA
                 img = img[:, :, [2, 1, 0, 3]]
-        elif (getCvType(encoding) == cv2.CV_16UC4 and
+        elif (cv_type == cv2.CV_16UC4 and
                 len(img.shape) == 3 and img.shape[2] == 4):
             # convert to 16UC4 image.
             img = img.astype(np.float32)

--- a/jsk_perception/node_scripts/image_publisher.py
+++ b/jsk_perception/node_scripts/image_publisher.py
@@ -189,12 +189,32 @@ class ImagePublisher(object):
             # BGRA, BGR -> BGR
             img = img[:, :, :3]
             # BGR -> RGB
-            if encoding in ('rgb8', 'rgb16'):
+            if encoding == 'rgb8':
+                img = img[:, :, ::-1]
+        elif getCvType(encoding) == cv2.CV_16UC3 and len(img.shape) == 3:
+            # 16UC3
+            # BGRA, BGR -> BGR
+            img = img[:, :, :3]
+            # convert to 16UC3 image.
+            img = img.astype(np.float32)
+            img = np.clip(img / 255.0 * (2 ** 16 - 1), 0, 2 ** 16 - 1)
+            img = img.astype(np.uint16)
+            # BGR -> RGB
+            if encoding == 'rgb16':
                 img = img[:, :, ::-1]
         elif (getCvType(encoding) == cv2.CV_8UC4 and
                 len(img.shape) == 3 and img.shape[2] == 4):
             # 8UC4
-            if encoding in ('rgba8', 'rgba16'):
+            if encoding == 'rgba8':
+                # BGRA -> RGBA
+                img = img[:, :, [2, 1, 0, 3]]
+        elif (getCvType(encoding) == cv2.CV_16UC4 and
+                len(img.shape) == 3 and img.shape[2] == 4):
+            # convert to 16UC4 image.
+            img = img.astype(np.float32)
+            img = np.clip(img / 255.0 * (2 ** 16 - 1), 0, 2 ** 16 - 1)
+            img = img.astype(np.uint16)
+            if encoding == 'rgba16':
                 # BGRA -> RGBA
                 img = img[:, :, [2, 1, 0, 3]]
         else:

--- a/jsk_perception/node_scripts/image_publisher.py
+++ b/jsk_perception/node_scripts/image_publisher.py
@@ -178,7 +178,7 @@ class ImagePublisher(object):
             if getCvType(encoding) == cv2.CV_16UC1:
                 # 16UC1
                 img = img.astype(np.float32)
-                img = img / 255 * (2 ** 16)
+                img = np.clip(img / 255.0 * (2 ** 16 - 1), 0, 2 ** 16 - 1)
                 img = img.astype(np.uint16)
             elif getCvType(encoding) == cv2.CV_32FC1:
                 # 32FC1

--- a/jsk_perception/sample/sample_image_publisher.launch
+++ b/jsk_perception/sample/sample_image_publisher.launch
@@ -64,7 +64,7 @@
       encoding: bgra8
       publish_info: true
       fovx: 84.1
-      fovy: 53.8
+      fovy: 84.1  <!-- shape of sample_alpha.png is (256, 256). Keep the focal lengths equal. -->
     </rosparam>
   </node>
 
@@ -77,7 +77,7 @@
       encoding: bgra16
       publish_info: true
       fovx: 84.1
-      fovy: 53.8
+      fovy: 84.1  <!-- shape of sample_alpha.png is (256, 256). Keep the focal lengths equal. -->
     </rosparam>
   </node>
 
@@ -90,7 +90,7 @@
       encoding: rgba8
       publish_info: true
       fovx: 84.1
-      fovy: 53.8
+      fovy: 84.1  <!-- shape of sample_alpha.png is (256, 256). Keep the focal lengths equal. -->
     </rosparam>
   </node>
 
@@ -103,7 +103,7 @@
       encoding: rgba16
       publish_info: true
       fovx: 84.1
-      fovy: 53.8
+      fovy: 84.1  <!-- shape of sample_alpha.png is (256, 256). Keep the focal lengths equal. -->
     </rosparam>
   </node>
 

--- a/jsk_perception/sample/sample_image_publisher.launch
+++ b/jsk_perception/sample/sample_image_publisher.launch
@@ -16,6 +16,19 @@
     </rosparam>
   </node>
 
+  <node name="raw_image_bgr_16bit"
+        pkg="jsk_perception" type="image_publisher.py">
+    <remap from="~output" to="~image_color" />
+    <remap from="~output/camera_info" to="~camera_info" />
+    <rosparam subst_value="true">
+      file_name: $(find jsk_perception)/sample/kiva_pod_image_color.jpg
+      encoding: bgr16
+      publish_info: true
+      fovx: 84.1
+      fovy: 53.8
+    </rosparam>
+  </node>
+
   <node name="raw_image_rgb"
         pkg="jsk_perception" type="image_publisher.py">
     <remap from="~output" to="~image_color" />
@@ -23,6 +36,19 @@
     <rosparam subst_value="true">
       file_name: $(find jsk_perception)/sample/kiva_pod_image_color.jpg
       encoding: rgb8
+      publish_info: true
+      fovx: 84.1
+      fovy: 53.8
+    </rosparam>
+  </node>
+
+  <node name="raw_image_rgb_16bit"
+        pkg="jsk_perception" type="image_publisher.py">
+    <remap from="~output" to="~image_color" />
+    <remap from="~output/camera_info" to="~camera_info" />
+    <rosparam subst_value="true">
+      file_name: $(find jsk_perception)/sample/kiva_pod_image_color.jpg
+      encoding: rgb16
       publish_info: true
       fovx: 84.1
       fovy: 53.8
@@ -42,6 +68,19 @@
     </rosparam>
   </node>
 
+  <node name="raw_image_bgra_16bit"
+        pkg="jsk_perception" type="image_publisher.py">
+    <remap from="~output" to="~image_color" />
+    <remap from="~output/camera_info" to="~camera_info" />
+    <rosparam subst_value="true">
+      file_name: $(find jsk_perception)/sample/image/sample_alpha.png
+      encoding: bgra16
+      publish_info: true
+      fovx: 84.1
+      fovy: 53.8
+    </rosparam>
+  </node>
+
   <node name="raw_image_rgba"
         pkg="jsk_perception" type="image_publisher.py">
     <remap from="~output" to="~image_color" />
@@ -55,6 +94,19 @@
     </rosparam>
   </node>
 
+  <node name="raw_image_rgba_16bit"
+        pkg="jsk_perception" type="image_publisher.py">
+    <remap from="~output" to="~image_color" />
+    <remap from="~output/camera_info" to="~camera_info" />
+    <rosparam subst_value="true">
+      file_name: $(find jsk_perception)/sample/image/sample_alpha.png
+      encoding: rgba16
+      publish_info: true
+      fovx: 84.1
+      fovy: 53.8
+    </rosparam>
+  </node>
+
   <node name="mask_image"
         pkg="jsk_perception" type="image_publisher.py">
     <remap from="~output" to="~mask" />
@@ -62,6 +114,19 @@
     <rosparam subst_value="true">
       file_name: $(find jsk_perception)/sample/kiva_pod_mask.jpg
       encoding: mono8
+      publish_info: true
+      fovx: 84.1
+      fovy: 53.8
+    </rosparam>
+  </node>
+
+  <node name="mask_image_16bit"
+        pkg="jsk_perception" type="image_publisher.py">
+    <remap from="~output" to="~mask" />
+    <remap from="~output/camera_info" to="~camera_info" />
+    <rosparam subst_value="true">
+      file_name: $(find jsk_perception)/sample/kiva_pod_mask.jpg
+      encoding: mono16
       publish_info: true
       fovx: 84.1
       fovy: 53.8
@@ -112,13 +177,25 @@
           pkg="image_view" type="image_view">
       <remap from="image" to="raw_image_bgr/image_color" />
     </node>
+    <node name="image_view0_16bit"
+          pkg="image_view" type="image_view">
+      <remap from="image" to="raw_image_bgr_16bit/image_color" />
+    </node>
     <node name="image_view1"
           pkg="image_view" type="image_view">
       <remap from="image" to="raw_image_rgb/image_color" />
     </node>
+    <node name="image_view1_16bit"
+          pkg="image_view" type="image_view">
+      <remap from="image" to="raw_image_rgb_16bit/image_color" />
+    </node>
     <node name="image_view2"
           pkg="image_view" type="image_view">
       <remap from="image" to="mask_image/mask" />
+    </node>
+    <node name="image_view2_16bit"
+          pkg="image_view" type="image_view">
+      <remap from="image" to="mask_image_16bit/mask" />
     </node>
     <node name="image_view3"
           pkg="image_view" type="image_view">
@@ -142,9 +219,17 @@
           pkg="image_view" type="image_view">
       <remap from="image" to="raw_image_bgra/image_color" />
     </node>
+    <node name="image_view6_16bit"
+          pkg="image_view" type="image_view">
+      <remap from="image" to="raw_image_bgra_16bit/image_color" />
+    </node>
     <node name="image_view7"
           pkg="image_view" type="image_view">
       <remap from="image" to="raw_image_rgba/image_color" />
+    </node>
+    <node name="image_view7_16bit"
+          pkg="image_view" type="image_view">
+      <remap from="image" to="raw_image_rgba_16bit/image_color" />
     </node>
   </group>
 

--- a/jsk_perception/test/image_publisher.test
+++ b/jsk_perception/test/image_publisher.test
@@ -36,6 +36,26 @@
       timeout_12: 10
       topic_13: /raw_image_rgba/camera_info
       timeout_13: 10
+      topic_14: /raw_image_bgr_16bit/image_color
+      timeout_14: 10
+      topic_15: /raw_image_bgr_16bit/camera_info
+      timeout_15: 10
+      topic_16: /raw_image_rgb_16bit/image_color
+      timeout_16: 10
+      topic_17: /raw_image_rgb_16bit/camera_info
+      timeout_17: 10
+      topic_18: /mask_image_16bit/mask
+      timeout_18: 10
+      topic_19: /mask_image_16bit/camera_info
+      timeout_19: 10
+      topic_20: /raw_image_bgra_16bit/image_color
+      timeout_20: 10
+      topic_21: /raw_image_bgra_16bit/camera_info
+      timeout_21: 10
+      topic_22: /raw_image_rgba_16bit/image_color
+      timeout_22: 10
+      topic_23: /raw_image_rgba_16bit/camera_info
+      timeout_23: 10
     </rosparam>
   </test>
 

--- a/jsk_recognition_utils/python/jsk_recognition_utils/depth.py
+++ b/jsk_recognition_utils/python/jsk_recognition_utils/depth.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import struct
+
+import cv2
 import numpy as np
 from skimage.segmentation import slic
 from skimage.feature import peak_local_max
 from skimage.morphology import binary_closing
+import sensor_msgs.msg
 
 from jsk_recognition_utils.mask import descent_closing
 
@@ -20,3 +24,32 @@ def split_fore_background(depth_img, footprint=None):
     fg_mask = descent_closing(local_maxi, init_selem=np.ones((3, 3)), n_times=6)
     bg_mask = ~fg_mask
     return fg_mask, bg_mask
+
+
+def depth_to_compressed_depth(depth, depth_max=None, depth_quantization=100,
+                              encoding='32FC1'):
+    if depth_max is None:
+        depth_max = depth.max() + 1.0
+
+    # compressed format is separated by ';'.
+    # https://github.com/ros-perception/image_transport_plugins/blob/f0afd122ed9a66ff3362dc7937e6d465e3c3ccf7/compressed_depth_image_transport/src/codec.cpp#L234  # NOQA
+    compressed_msg = sensor_msgs.msg.CompressedImage()
+    compressed_msg.format = '{}; compressedDepth png'.format(
+        encoding)
+
+    if encoding == '32FC1':
+        depth_quant_a = depth_quantization * (depth_quantization + 1.0)
+        depth_quant_b = 1.0 - depth_quant_a / depth_max
+        inv_depth_img = np.zeros_like(depth, dtype=np.uint16)
+        target_pixel = np.logical_and(depth_max > depth, depth > 0)
+        inv_depth_img[target_pixel] = depth_quant_a / \
+            depth[target_pixel] + depth_quant_b
+
+        compressed_msg.data = struct.pack(
+            'iff', 0, depth_quant_a, depth_quant_b)
+        compressed_msg.data += np.array(
+            cv2.imencode('.png', inv_depth_img)[1]).tostring()
+    else:
+        raise NotImplementedError("Not supported compressedDepth encoding {}"
+                                  .format(encoding))
+    return compressed_msg


### PR DESCRIPTION
# What is this?

In current, `image_publisher.py` not supports  bgr16, rgb16, bgra16 and rgba16 encodings and compressedDepth for 32FC1 depth image.
This PR enables them to publish.

cc: @nakane11 