### PR TITLE
[jsk_perception][jsk_pcl_ros_utils][resized_image_transport] Call onInitPostProcess()

### DIFF
--- a/jsk_pcl_ros_utils/src/colorize_distance_from_plane_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/colorize_distance_from_plane_nodelet.cpp
@@ -55,6 +55,7 @@ namespace jsk_pcl_ros_utils
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind (&ColorizeDistanceFromPlane::configCallback, this, _1, _2);
     srv_->setCallback (f);
+    onInitPostProcess();
   }
 
   ColorizeDistanceFromPlane::~ColorizeDistanceFromPlane() {

--- a/jsk_pcl_ros_utils/src/delay_pointcloud_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/delay_pointcloud_nodelet.cpp
@@ -50,6 +50,7 @@ namespace jsk_pcl_ros_utils
     pnh_->param("delay_time", delay_time_, 0.1);
     pnh_->param("queue_size", queue_size_, 1000);
     pub_ = advertise<sensor_msgs::PointCloud2>(*pnh_, "output", queue_size_);
+    onInitPostProcess();
   }
 
   void DelayPointCloud::configCallback(Config &config, uint32_t level)

--- a/jsk_pcl_ros_utils/src/depth_image_error_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/depth_image_error_nodelet.cpp
@@ -45,6 +45,7 @@ namespace jsk_pcl_ros_utils
     ConnectionBasedNodelet::onInit();
     pnh_->param("approximate_sync", approximate_sync_, false);
     depth_error_publisher_ = advertise<jsk_recognition_msgs::DepthErrorResult>(*pnh_, "output", 1);
+    onInitPostProcess();
   }
 
   DepthImageError::~DepthImageError() {

--- a/jsk_pcl_ros_utils/src/normal_concatenater_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/normal_concatenater_nodelet.cpp
@@ -85,6 +85,7 @@ namespace jsk_pcl_ros_utils
     if (!pnh_->getParam("max_queue_size", maximum_queue_size_)) {
       maximum_queue_size_ = 100;
     }
+    onInitPostProcess();
   }
 
   NormalConcatenater::~NormalConcatenater() {

--- a/jsk_pcl_ros_utils/src/polygon_appender_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_appender_nodelet.cpp
@@ -49,6 +49,7 @@ namespace jsk_pcl_ros_utils
     sync_->connectInput(sub_polygon0_, sub_coefficients0_,
                         sub_polygon1_, sub_coefficients1_);
     sync_->registerCallback(boost::bind(&PolygonAppender::callback2, this, _1, _2, _3, _4));
+    onInitPostProcess();
   }
 
   PolygonAppender::~PolygonAppender() {

--- a/jsk_pcl_ros_utils/src/polygon_array_unwrapper_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_array_unwrapper_nodelet.cpp
@@ -51,6 +51,7 @@ namespace jsk_pcl_ros_utils
     dynamic_reconfigure::Server<Config>::CallbackType f =
       boost::bind(&PolygonArrayUnwrapper::configCallback, this, _1, _2);
     srv_->setCallback(f);
+    onInitPostProcess();
   }
 
   PolygonArrayUnwrapper::~PolygonArrayUnwrapper() {

--- a/jsk_pcl_ros_utils/src/polygon_array_wrapper_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/polygon_array_wrapper_nodelet.cpp
@@ -45,6 +45,7 @@ namespace jsk_pcl_ros_utils
     pub_coefficients_array_
       = advertise<jsk_recognition_msgs::ModelCoefficientsArray>(*pnh_,
         "output_coefficients", 1);
+    onInitPostProcess();
   }
 
   PolygonArrayWrapper::~PolygonArrayWrapper() {

--- a/jsk_perception/src/bounding_box_to_rect.cpp
+++ b/jsk_perception/src/bounding_box_to_rect.cpp
@@ -51,7 +51,7 @@ namespace jsk_perception
     pub_ = advertise<jsk_recognition_msgs::RectArray>(*pnh_, "output", 1);
     pub_internal_ = pnh_->advertise<jsk_recognition_msgs::BoundingBoxArrayWithCameraInfo>("internal", 1);
     sub_box_with_info_.subscribe(*pnh_, "internal", 1);
-    //onInitPosrPocess();
+    onInitPostProcess();
   }
 
   BoundingBoxToRect::~BoundingBoxToRect() {

--- a/jsk_perception/src/polygon_array_color_likelihood.cpp
+++ b/jsk_perception/src/polygon_array_color_likelihood.cpp
@@ -59,6 +59,7 @@ namespace jsk_perception
         &PolygonArrayColorLikelihood::configCallback, this, _1, _2);
     srv_->setCallback (f);
     pub_ = advertise<jsk_recognition_msgs::PolygonArray>(*pnh_, "output", 1);
+    onInitPostProcess();
   }
 
   PolygonArrayColorLikelihood::~PolygonArrayColorLikelihood() {

--- a/jsk_perception/src/robot_to_mask_image.cpp
+++ b/jsk_perception/src/robot_to_mask_image.cpp
@@ -47,6 +47,7 @@ namespace jsk_perception
     pnh_->param("max_robot_dist", max_robot_dist_, 10.0);
     pub_ = advertise<sensor_msgs::Image>(*pnh_, "output", 1);
     pub_camera_info_ = advertise<sensor_msgs::CameraInfo>(*pnh_, "output/info", 1);
+    onInitPostProcess();
   }
 
   void RobotToMaskImage::subscribe()

--- a/resized_image_transport/src/image_processing_nodelet.cpp
+++ b/resized_image_transport/src/image_processing_nodelet.cpp
@@ -10,6 +10,7 @@ namespace resized_image_transport
     initReconfigure();
     initParams();
     initPublishersAndSubscribers();
+    onInitPostProcess();
   }
 
   void ImageProcessing::initReconfigure(){

--- a/resized_image_transport/src/log_polar_nodelet.cpp
+++ b/resized_image_transport/src/log_polar_nodelet.cpp
@@ -7,6 +7,7 @@ namespace resized_image_transport
     initReconfigure();
     initParams();
     initPublishersAndSubscribers();
+    onInitPostProcess();
   }
   
 


### PR DESCRIPTION
This node forgets to call `onInitPostProcess()`, so I added it.

Without calling `onInitPostProcess()` on `onInit()` method, nodelet does not subscribe on start even if param always_subscribe is set to true.
