### PR TITLE
[jsk_recognition_utils] Add jsk_topic_tools header file to check jsk_topic_tools' version

### DIFF
--- a/jsk_recognition_utils/CMakeLists.txt
+++ b/jsk_recognition_utils/CMakeLists.txt
@@ -29,6 +29,10 @@ find_package(catkin REQUIRED COMPONENTS
   visualization_msgs
 )
 
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/jsk_recognition_utils/jsk_topic_tools_version.h.in
+  ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}/jsk_recognition_utils/jsk_topic_tools_version.h)
+
 
 # ------------------------------------------------------------------------------------
 # Download
@@ -143,6 +147,7 @@ install(TARGETS jsk_recognition_utils
 
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h" # Ignore *_version.h.in files
 )
 
 install(DIRECTORY node_scripts sample test

--- a/jsk_recognition_utils/include/jsk_recognition_utils/jsk_topic_tools_version.h.in
+++ b/jsk_recognition_utils/include/jsk_recognition_utils/jsk_topic_tools_version.h.in
@@ -1,0 +1,48 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2022, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#ifndef JSK_RECOGNITION_UTILS_JSK_TOPIC_TOOLS_VERSION_
+#define JSK_RECOGNITION_UTILS_JSK_TOPIC_TOOLS_VERSION_
+
+#define JSK_TOPIC_TOOLS_VERSION_MAJOR @jsk_topic_tools_VERSION_MAJOR@
+#define JSK_TOPIC_TOOLS_VERSION_MINOR @jsk_topic_tools_VERSION_MINOR@
+#define JSK_TOPIC_TOOLS_VERSION_PATCH @jsk_topic_tools_VERSION_PATCH@
+#define JSK_TOPIC_TOOLS_VERSION_COMBINED(major, minor, patch) (((major) << 20) | ((minor) << 10) | (patch))
+#define JSK_TOPIC_TOOLS_VERSION JSK_TOPIC_TOOLS_VERSION_COMBINED(JSK_TOPIC_TOOLS_VERSION_MAJOR, JSK_TOPIC_TOOLS_VERSION_MINOR, JSK_TOPIC_TOOLS_VERSION_PATCH)
+
+#define JSK_TOPIC_TOOLS_VERSION_GE(major1, minor1, patch1, major2, minor2, patch2) (JSK_TOPIC_TOOLS_VERSION_COMBINED(major1, minor1, patch1) >= JSK_TOPIC_TOOLS_VERSION_COMBINED(major2, minor2, patch2))
+#define JSK_TOPIC_TOOLS_VERSION_MINIMUM(major, minor, patch) JSK_TOPIC_TOOLS_VERSION_GE(JSK_TOPIC_TOOLS_VERSION_MAJOR, JSK_TOPIC_TOOLS_VERSION_MINOR, JSK_TOPIC_TOOLS_VERSION_PATCH, major, minor, patch)
+
+#endif


### PR DESCRIPTION
# What is this?

Related to #2712  https://github.com/jsk-ros-pkg/jsk_recognition/pull/2712#discussion_r918954846
The jsk nodes use `ConnectionBasedNodelet` and `DiagnosticsNodelet`.
If we want to write the following, we need to add a header file like this PR.
```
#if  defined(JSK_TOPIC_TOOLS_VERSION) and JSK_TOPIC_TOOLS_VERSION_MINIMUM(2,2,13))
    #define jsk_topic_tools::NODLET jsk_topic_tools::ConnectionBasedNodelet
#else
    #define jsk_topic_tools::NODLET jsk_topic_tools::DiagnosticNodelet
#endif```

