### PR TITLE
[jsk_perception/apply_mask] Avoid error in cvtColor when masked_image is empty

### DIFF
--- a/jsk_perception/src/apply_mask_image.cpp
+++ b/jsk_perception/src/apply_mask_image.cpp
@@ -194,14 +194,17 @@ namespace jsk_perception
             output_image).toImageMsg());
     }
     else {
-      if (jsk_recognition_utils::isBGRA(image_msg->encoding)) {
-        cv::cvtColor(masked_image, output_image, cv::COLOR_BGR2BGRA);
-      }
-      else if (jsk_recognition_utils::isRGBA(image_msg->encoding)) {
-        cv::cvtColor(masked_image, output_image, cv::COLOR_BGR2RGBA);
-      }
-      else {  // BGR, RGB or GRAY
-        masked_image.copyTo(output_image);
+      // Error in cvtColor when masked_image is empty.
+      if (!masked_image.empty()) {
+        if (jsk_recognition_utils::isBGRA(image_msg->encoding)) {
+          cv::cvtColor(masked_image, output_image, cv::COLOR_BGR2BGRA);
+        }
+        else if (jsk_recognition_utils::isRGBA(image_msg->encoding)) {
+          cv::cvtColor(masked_image, output_image, cv::COLOR_BGR2RGBA);
+        }
+        else {  // BGR, RGB or GRAY
+          masked_image.copyTo(output_image);
+        }
       }
       pub_image_.publish(cv_bridge::CvImage(
             image_msg->header,

--- a/jsk_perception/src/apply_mask_image.cpp
+++ b/jsk_perception/src/apply_mask_image.cpp
@@ -169,14 +169,17 @@ namespace jsk_perception
 
     cv::Mat output_image;
     if (mask_black_to_transparent_) {
-      if (sensor_msgs::image_encodings::isMono(image_msg->encoding)) {
-        cv::cvtColor(masked_image, output_image, CV_GRAY2BGRA);
-      }
-      else if (jsk_recognition_utils::isRGB(image_msg->encoding)) {
-        cv::cvtColor(masked_image, output_image, CV_RGB2BGRA);
-      }
-      else {  // BGR, BGRA or RGBA
-        cv::cvtColor(masked_image, output_image, CV_BGR2BGRA);
+      // Error in cvtColor when masked_image is empty.
+      if (!masked_image.empty()) {
+        if (sensor_msgs::image_encodings::isMono(image_msg->encoding)) {
+          cv::cvtColor(masked_image, output_image, CV_GRAY2BGRA);
+        }
+        else if (jsk_recognition_utils::isRGB(image_msg->encoding)) {
+          cv::cvtColor(masked_image, output_image, CV_RGB2BGRA);
+        }
+        else {  // BGR, BGRA or RGBA
+          cv::cvtColor(masked_image, output_image, CV_BGR2BGRA);
+        }
       }
       for (size_t j=0; j < mask.rows; j++) {
         for (int i=0; i < mask.cols; i++) {


### PR DESCRIPTION
# What is this?

From opencv version 4, cvtColor doesn't support empty matrix.
If `~clip` is true, the output mask size could be `(w, h) = (0, 0)` size.
In that case, the program dies in the `cvtColor` function for `bgra` and `rgba` image.
This PR fixes the bug.

```
In [1]: import cv2
   ...: import numpy as np
   ...: print('cv2.__version__: {}'.format(cv2.__version__))
   ...: cv2.cvtColor(np.empty((0, 0, 3), dtype=np.uint8), cv2.COLOR_BGR2RGB)
   ...:
cv2.__version__: 2.4.8
```
```
In [1]: import cv2
   ...: import numpy as np
   ...: print('cv2.__version__: {}'.format(cv2.__version__))
   ...: cv2.cvtColor(np.empty((0, 0, 3), dtype=np.uint8), cv2.COLOR_BGR2RGB)
   ...:
cv2.__version__: 3.2.0
```
```
In [1]: import cv2
   ...: import numpy as np
   ...: print('cv2.__version__: {}'.format(cv2.__version__))
   ...: cv2.cvtColor(np.empty((0, 0, 3), dtype=np.uint8), cv2.COLOR_BGR2RGB)
   ...:
cv2.__version__: 4.5.1

---------------------------------------------------------------------------
error                                     Traceback (most recent call last)
Input In [1], in <cell line: 4>()
      2 import numpy as np
      3 print('cv2.__version__: {}'.format(cv2.__version__))
----> 4 cv2.cvtColor(np.empty((0, 0, 3), dtype=np.uint8), cv2.COLOR_BGR2RGB)

error: OpenCV(4.5.1) /tmp/pip-req-build-jr1ur_cf/opencv/modules/imgproc/src/color.cpp:182: error: (-215:Assertion failed) !_src.empty() in function 'cvtColor'
```
