### PR TITLE
[sound_classification] Enable to pass all arguments of audio_to_spectrogram.launch from upper launches

### DIFF
--- a/sound_classification/README.md
+++ b/sound_classification/README.md
@@ -36,8 +36,8 @@ ROS package to classify sound stream.
 
 ## Usage
 
-1. Write your microphone parameters to `audio_to_spectrogram.launch`'s arg tags.
-    - In particular, `device`, `n_channel`, `bitdepth` and `sample_rate` need to be specified.
+1. Check and specify your microphone parameters.
+    - In particular, `device`, `n_channel`, `bitdepth` and `mic_sampling_rate` need to be known.
     - The example bash commands to get these params are below:
         ```bash
         # For device. In this example, card 0 and device 0, so device:="hw:0,0"
@@ -53,7 +53,8 @@ ROS package to classify sound stream.
         $ pactl list short sources
         1       alsa_input.pci-0000_00_1f.3.analog-stereo       module-alsa-card.c      s16le 2ch 44100Hz       SUSPENDED
         ```
-    - If you use `/audio` topic from other computer and do not want to publish `/audio`, set `use_microphone:=false` at each launch flie.
+    - Pass these params to each launch file as arguments when launching (e.g., `device:=hw:0,0 n_channel:=2 bitdepth:=16 mic_sampling_rate:=44100`).
+    - If you use `/audio` topic from other computer and do not want to publish `/audio`, set `use_microphone:=false` at each launch file when launching.
 
 1. Save environmental noise to `train_data/noise.npy`.
     - By subtracting noise, spectrograms become clear.

--- a/sound_classification/launch/audio_to_spectrogram.launch
+++ b/sound_classification/launch/audio_to_spectrogram.launch
@@ -15,7 +15,6 @@
   <arg name="spectrogram_period" default="1" />
 
   <arg name="gui" default="false" />
-  <arg name="threshold" default="0.5" />
 
   <arg name="pause_rosbag" default="true" />
   <arg name="rosbag_args" value="--clock --pause" if="$(arg pause_rosbag)" />

--- a/sound_classification/launch/audio_to_spectrogram.launch
+++ b/sound_classification/launch/audio_to_spectrogram.launch
@@ -49,6 +49,7 @@
     <arg name="launch_audio_capture" value="false" />
     <arg name="bitdepth" value="$(arg bitdepth)" />
     <arg name="mic_sampling_rate" value="$(arg mic_sampling_rate)" />
+    <arg name="n_channel" value="$(arg n_channel)" />
     <arg name="high_cut_freq" value="$(arg high_cut_freq)" />
     <arg name="low_cut_freq" value="$(arg low_cut_freq)" />
     <arg name="spectrogram_period" value="$(arg spectrogram_period)" />

--- a/sound_classification/launch/classify_sound.launch
+++ b/sound_classification/launch/classify_sound.launch
@@ -1,17 +1,36 @@
 <launch>
 
-  <arg name="gpu" default="0" />
+  <!-- audio_to_spectrogram arguments -->
+  <arg name="device" default="hw:0,0" />
+  <arg name="n_channel" default="2" />
+  <arg name="bitdepth" default="16" />
+  <arg name="mic_sampling_rate" default="44100" />
   <arg name="use_rosbag" default="false" />
-  <arg name="pause_rosbag" default="true" />
   <arg name="filename" default="/" />
   <arg name="use_microphone" default="true" />
+  <arg name="high_cut_freq" default="8000" />
+  <arg name="low_cut_freq" default="1" />
+  <arg name="spectrogram_period" default="1" />
+  <arg name="pause_rosbag" default="true" />
+
+  <!-- sound_classifier arguments -->
+  <arg name="gpu" default="0" />
+
+  <!-- visualization arguments -->
   <arg name="gui" default="true" />
 
   <include file="$(find sound_classification)/launch/audio_to_spectrogram.launch" >
+    <arg name="device" value="$(arg device)" />
+    <arg name="n_channel" value="$(arg n_channel)" />
+    <arg name="bitdepth" value="$(arg bitdepth)" />
+    <arg name="mic_sampling_rate" value="$(arg mic_sampling_rate)" />
     <arg name="use_rosbag" value="$(arg use_rosbag)" />
-    <arg name="pause_rosbag" value="$(arg pause_rosbag)" />
     <arg name="filename" value="$(arg filename)" />
     <arg name="use_microphone" value="$(arg use_microphone)" />
+    <arg name="high_cut_freq" value="$(arg high_cut_freq)" />
+    <arg name="low_cut_freq" value="$(arg low_cut_freq)" />
+    <arg name="spectrogram_period" value="$(arg spectrogram_period)" />
+    <arg name="pause_rosbag" value="$(arg pause_rosbag)" />
     <arg name="gui" value="false" />
   </include>
 

--- a/sound_classification/launch/record_audio_rosbag.launch
+++ b/sound_classification/launch/record_audio_rosbag.launch
@@ -1,5 +1,12 @@
 <launch>
+  <!-- rosbag_record arguments -->
   <arg name="filename" />
+
+  <!-- audio_to_spectrogram arguments -->
+  <arg name="device" default="hw:0,0" />
+  <arg name="n_channel" default="2" />
+  <arg name="bitdepth" default="16" />
+  <arg name="mic_sampling_rate" default="44100" />
   <arg name="use_microphone" default="true" />
 
   <node name="rosbag_record"
@@ -12,6 +19,10 @@
   </node>
 
   <include file="$(find sound_classification)/launch/audio_to_spectrogram.launch" >
+    <arg name="device" value="$(arg device)" />
+    <arg name="n_channel" value="$(arg n_channel)" />
+    <arg name="bitdepth" value="$(arg bitdepth)" />
+    <arg name="mic_sampling_rate" value="$(arg mic_sampling_rate)" />
     <arg name="use_microphone" value="$(arg use_microphone)" />
     <arg name="gui" value="true" />
   </include>

--- a/sound_classification/launch/save_noise.launch
+++ b/sound_classification/launch/save_noise.launch
@@ -1,15 +1,34 @@
 <launch>
 
+  <!-- audio_to_spectrogram arguments -->
+  <arg name="device" default="hw:0,0" />
+  <arg name="n_channel" default="2" />
+  <arg name="bitdepth" default="16" />
+  <arg name="mic_sampling_rate" default="44100" />
   <arg name="use_rosbag" default="false" />
   <arg name="filename" default="/" />
   <arg name="use_microphone" default="true" />
+  <arg name="high_cut_freq" default="8000" />
+  <arg name="low_cut_freq" default="1" />
+  <arg name="spectrogram_period" default="1" />
+  <arg name="pause_rosbag" default="true" />
   <arg name="gui" default="true" />
+
+  <!-- noise_saver arguments -->
   <arg name="save_data_rate" default="10" />
 
   <include file="$(find sound_classification)/launch/audio_to_spectrogram.launch" >
+    <arg name="device" value="$(arg device)" />
+    <arg name="n_channel" value="$(arg n_channel)" />
+    <arg name="bitdepth" value="$(arg bitdepth)" />
+    <arg name="mic_sampling_rate" value="$(arg mic_sampling_rate)" />
     <arg name="use_rosbag" value="$(arg use_rosbag)" />
     <arg name="filename" value="$(arg filename)" />
     <arg name="use_microphone" value="$(arg use_microphone)" />
+    <arg name="high_cut_freq" value="$(arg high_cut_freq)" />
+    <arg name="low_cut_freq" value="$(arg low_cut_freq)" />
+    <arg name="spectrogram_period" value="$(arg spectrogram_period)" />
+    <arg name="pause_rosbag" value="$(arg pause_rosbag)" />
     <arg name="gui" value="$(arg gui)" />
   </include>
 

--- a/sound_classification/launch/save_sound.launch
+++ b/sound_classification/launch/save_sound.launch
@@ -16,7 +16,6 @@
     <arg name="filename" value="$(arg filename)" />
     <arg name="use_microphone" value="$(arg use_microphone)" />
     <arg name="gui" value="$(arg gui)" />
-    <arg name="threshold" value="$(arg threshold)" />
   </include>
 
   <!-- Collect spectrogram with sound class, only when the robot is in sound. -->

--- a/sound_classification/launch/save_sound.launch
+++ b/sound_classification/launch/save_sound.launch
@@ -1,20 +1,39 @@
 <launch>
 
+  <!-- audio_to_spectrogram arguments -->
+  <arg name="device" default="hw:0,0" />
+  <arg name="n_channel" default="2" />
+  <arg name="bitdepth" default="16" />
+  <arg name="mic_sampling_rate" default="44100" />
   <arg name="use_rosbag" default="false" />
-  <arg name="pause_rosbag" default="true" />
   <arg name="filename" default="/" />
   <arg name="use_microphone" default="true" />
-  <arg name="gui" default="true"/>
+  <arg name="high_cut_freq" default="8000" />
+  <arg name="low_cut_freq" default="1" />
+  <arg name="spectrogram_period" default="1" />
+  <arg name="pause_rosbag" default="true" />
+  <arg name="gui" default="true" />
+
+  <!-- sound_saver arguments -->
+  <arg name="save_data_rate" default="5"/>
   <arg name="target_class" default="" />
   <arg name="save_when_sound" default="true"/>
+
+  <!-- sound_detector_volume arguments -->
   <arg name="threshold" default="0.5"/>
-  <arg name="save_data_rate" default="5"/>
 
   <include file="$(find sound_classification)/launch/audio_to_spectrogram.launch" >
+    <arg name="device" value="$(arg device)" />
+    <arg name="n_channel" value="$(arg n_channel)" />
+    <arg name="bitdepth" value="$(arg bitdepth)" />
+    <arg name="mic_sampling_rate" value="$(arg mic_sampling_rate)" />
     <arg name="use_rosbag" value="$(arg use_rosbag)" />
-    <arg name="pause_rosbag" value="$(arg pause_rosbag)" />
     <arg name="filename" value="$(arg filename)" />
     <arg name="use_microphone" value="$(arg use_microphone)" />
+    <arg name="high_cut_freq" value="$(arg high_cut_freq)" />
+    <arg name="low_cut_freq" value="$(arg low_cut_freq)" />
+    <arg name="spectrogram_period" value="$(arg spectrogram_period)" />
+    <arg name="pause_rosbag" value="$(arg pause_rosbag)" />
     <arg name="gui" value="$(arg gui)" />
   </include>
 


### PR DESCRIPTION
Currently, we cannot pass some arguments (e.g., `device`, `mic_sampling_rate`) of `audio_to_spectrogram.launch` from upper launches (`record_audio_rosbag.launch`, `save_noise.launch`, `save_sound.launch`, `classify_sound.launch`).
Due to this, we have the following issues in https://github.com/jsk-ros-pkg/jsk_recognition/tree/c4be2499e01a7c67d04fdcf7059964ddc8bb2552/sound_classification#usage if we avoid creating local diffs:
- We cannot use microphones other than the default microphone of `audio_to_spectrogram.launch`:
  https://github.com/jsk-ros-pkg/jsk_recognition/blob/c4be2499e01a7c67d04fdcf7059964ddc8bb2552/sound_classification/launch/audio_to_spectrogram.launch#L2-L7
- We cannot change spectrogram size from the default size of `audio_to_spectrogram.launch`:
  https://github.com/jsk-ros-pkg/jsk_recognition/blob/c4be2499e01a7c67d04fdcf7059964ddc8bb2552/sound_classification/launch/audio_to_spectrogram.launch#L13-L15

This PR fixes these issues by passing all arguments of `audio_to_spectrogram.launch` from upper launches and updates README.
This PR also applies the following small fixes to `audio_to_spectrogram.launch`:
- Removing an unused argument (`threshold`)
- Unifying `n_channel` value

Most parts of this PR were originally extracted from https://github.com/k-okada/jsk_recognition/pull/1.
cf. https://github.com/jsk-ros-pkg/jsk_recognition/pull/2635#issuecomment-1211646236