### PR TITLE
[jsk_perception] Poke in dual_fisheye_to_panorama for DiagnosticNodelet

### DIFF
--- a/jsk_perception/sample/sample_dual_fisheye_to_panorama.launch
+++ b/jsk_perception/sample/sample_dual_fisheye_to_panorama.launch
@@ -6,6 +6,7 @@
   <arg name="fovd" default="185.0" doc="Camera's Field of View [degree]" />
   <arg name="save_unwarped" default="false" doc="Save unwarped fisheye images. This is useful to create MLS grids." />
   <arg name="resolution_mode" default="high" doc="Resolution mode, 'high' or 'low'" />
+  <arg name="vital_rate" default="1.0" doc="Rate to determine if the nodelet is in health." />
   <arg name="image_transport" default="raw"/>
 
   <node name="dual_fisheye_to_panorama"
@@ -21,6 +22,7 @@
         command="load"
         file="$(find jsk_perception)/config/dual_fisheye_to_panorama/$(arg resolution_mode)_resolution_config.yaml"
         subst_value="true"/>
+    <param name="vital_rate" value="$(arg vital_rate)" />
   </node>
 
   <group if="$(arg gui)">

--- a/jsk_perception/sample/sample_insta360_air.launch
+++ b/jsk_perception/sample/sample_insta360_air.launch
@@ -27,6 +27,7 @@
   <arg name="panorama_resolution_mode" default="high" />
   <arg name="panorama_image_transport" default="raw"/>
 
+  <arg name="vital_rate" default="1.0" />
   <arg name="gui" default="true" />
 
   <!-- Publish camera image -->
@@ -101,6 +102,7 @@
     <arg name="save_unwarped" value="$(arg save_unwarped)" />
     <arg name="resolution_mode" value="$(arg panorama_resolution_mode)" />
     <arg name="image_transport" value="$(arg panorama_image_transport)" />
+    <arg name="vital_rate" value="$(arg vital_rate)" />
   </include>
 
   <group if="$(arg gui)">


### PR DESCRIPTION
this commits are from `develop/fetch`.
it is similar to #2690 , but i don't know which is better.
@iory @708yamaguchi 