### PR TITLE
[jsk_pcl_ros/attention_clipper] Do not push back empty indices

### DIFF
--- a/jsk_pcl_ros/src/attention_clipper_nodelet.cpp
+++ b/jsk_pcl_ros/src/attention_clipper_nodelet.cpp
@@ -434,7 +434,9 @@ namespace jsk_pcl_ros
         }
         PCLIndicesMsg indices_msg;
         pcl_conversions::fromPCL(non_nan_indices, indices_msg);
-        cluster_indices_msg.cluster_indices.push_back(indices_msg);
+        if (!indices_msg.indices.empty()) {
+          cluster_indices_msg.cluster_indices.push_back(indices_msg);
+        }
         if(prefixes_.size()){
           indices_msg.header = msg->header;
           multiple_pub_indices_[i].publish(indices_msg);


### PR DESCRIPTION
I'm using `~output/cluster_point_indices` of AttentionClipper as `~target` of ClusterPointIndicesDecomposer.
When input BoundingBoxArray crops no points in AttentionClipper, I'd like to receive empty BoundingBoxArray from ClusterPointIndicesDecomposer.

The effect of this change is shown below.
## before
```
$ rostopic echo /attention_clipper/output/cluster_point_indices 
header: 
  seq: 0
  stamp: 
    secs: 1667727103
    nsecs: 637886600
  frame_id: "head_mount_kinect_rgb_optical_frame"
cluster_indices: 
  - 
    header: 
      seq: 0
      stamp: 
        secs: 0
        nsecs:         0
      frame_id: ''
    indices: []
---
```
```
$ rostopic echo /cluster_point_indices_decomposer/boxes 
header: 
  seq: 0
  stamp: 
    secs: 1667727343
    nsecs: 767354410
  frame_id: "base_link"
boxes: 
  - 
    header: 
      seq: 2641
      stamp: 
        secs: 1667727343
        nsecs: 767354410
      frame_id: "base_link"
    pose: 
      position: 
        x: 0.0
        y: 0.0
        z: 0.0
      orientation: 
        x: 0.0
        y: 0.0
        z: 0.0
        w: 0.0
    dimensions: 
      x: 0.0
      y: 0.0
      z: 0.0
    value: 0.0
    label: 0
---
```
## after
```
$ rostopic echo /attention_clipper/output/cluster_point_indices 
header: 
  seq: 3
  stamp: 
    secs: 1667730125
    nsecs: 193064157
  frame_id: "head_mount_kinect_rgb_optical_frame"
cluster_indices: []
---
```
```
$ rostopic echo /cluster_point_indices_decomposer/boxes 
header: 
  seq: 0
  stamp: 
    secs: 1667730081
    nsecs: 546976357
  frame_id: "base_link"
boxes: []
---
```

