### PR TITLE
jsk_recognition_msgs : setup.py need src/jsk_recognition_msgs

### DIFF
--- a/jsk_pcl_ros/sample/include/play_rosbag_baxter_realsense_l515.xml
+++ b/jsk_pcl_ros/sample/include/play_rosbag_baxter_realsense_l515.xml
@@ -23,11 +23,28 @@
     </group>
 
     <group ns="aligned_depth_to_color">
+      <node name="info_relay" pkg="topic_tools" type="relay"
+            args="compressed/camera_info camera_info" />
+      <node name="image_relay" pkg="topic_tools" type="relay"
+            args="compressed/image_raw/compressedDepth image_raw/compressedDepth" />
       <node name="republish"
             pkg="image_transport" type="republish"
             args="compressedDepth raw">
         <remap from="in" to="image_raw"/>
         <remap from="out" to="image_raw"/>
+      </node>
+    </group>
+
+    <group ns="depth">
+      <node name="info_relay" pkg="topic_tools" type="relay"
+            args="compressed/camera_info camera_info" />
+      <node name="image_relay" pkg="topic_tools" type="relay"
+            args="compressed/image_rect_raw/compressedDepth image_rect_raw/compressedDepth" />
+      <node name="republish"
+            pkg="image_transport" type="republish"
+            args="compressedDepth raw">
+        <remap from="in" to="image_rect_raw"/>
+        <remap from="out" to="image_rect_raw"/>
       </node>
     </group>
   </group>

--- a/jsk_pcl_ros/scripts/install_sample_data.py
+++ b/jsk_pcl_ros/scripts/install_sample_data.py
@@ -142,7 +142,7 @@ def main():
     download_data(
         path='sample/data/baxter_realsense_l515.bag',
         url='https://drive.google.com/uc?id=1RKZLA4J2_lzhCtvMTWxGQh4ykVVEeSAd',
-        md5='4dab24bd6e6a7fd5b9e86d053352cdfd',
+        md5='2bb80d7c31c62c944192b2dd0a75eddf',
     )
 
     download_data(

--- a/jsk_recognition_msgs/setup.py
+++ b/jsk_recognition_msgs/setup.py
@@ -6,8 +6,12 @@ from setuptools import find_packages
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
-    packages=['jsk_recognition_msgs'],
-    package_dir={'': 'src'},
+    # Uncomment until src/jsk_recognition_msgs
+    # error: package directory 'jsk_recognition_msgs' does not exist
+    # [jsk_recognition_msgs:install]
+    # packages=['jsk_recognition_msgs'],
+    # [jsk_recognition_msgs:install] error: package directory 'src/jsk_recognition_msgs' does not exist
+    # package_dir={'': 'src'},
 )
 
 setup(**d)


### PR DESCRIPTION
with out this fix, master branch fails with
```
[jsk_recognition_msgs:install] + cd /home/k-okada/catkin_ws/ws_recognition/src/jsk_recognition/jsk_recognition_msgs               
[jsk_recognition_msgs:install] + mkdir -p /home/k-okada/catkin_ws/ws_recognition/install/lib/python2.7/dist-packages              
[jsk_recognition_msgs:install] + /usr/bin/env PYTHONPATH=/home/k-okada/catkin_ws/ws_recognition/install/lib/python2.7/dist-packages:/home/k-okada/catkin_ws/ws_recognition/build/jsk_recognition_msgs/lib/python2.7/dist-packages:/home/k-okada/catkin_ws/ws_recognition/install/lib/python2.7/dist-packages:/opt/ros/melodic/lib/python2.7/dist-packages:/home/k-okada/pynaoqi/pynaoqi-python2.7-2.5.5.5-linux64/lib/python2.7/site-packages CATKIN_BINARY_DIR=/home/k-okada/catkin_ws/ws_recognition/build/jsk_recognition_msgs /usr/bin/python2 /home/k-okada/catkin_ws/ws_recognition/src/jsk_recognition/jsk_recognition_msgs/setup.py egg_info --egg-base /home/k-okada/catkin_ws/ws_recognition/build/jsk_recognition_msgs build --build-base /home/k-okada/catkin_ws/ws_recognition/build/jsk_recognition_msgs install --root=/ --install-layout=deb --prefix=/home/k-okada/catkin_ws/ws_recognition/install --install-scripts=/home/k-okada/catkin_ws/ws_recognition/install/bin
[jsk_recognition_msgs:install] running egg_info                                                                                   
[jsk_recognition_msgs:install] writing /home/k-okada/catkin_ws/ws_recognition/build/jsk_recognition_msgs/jsk_recognition_msgs.egg-info/PKG-INFO
[jsk_recognition_msgs:install] writing top-level names to /home/k-okada/catkin_ws/ws_recognition/build/jsk_recognition_msgs/jsk_recognition_msgs.egg-info/top_level.txt
[jsk_recognition_msgs:install] writing dependency_links to /home/k-okada/catkin_ws/ws_recognition/build/jsk_recognition_msgs/jsk_recognition_msgs.egg-info/dependency_links.txt
[jsk_recognition_msgs:install] error: package directory 'src/jsk_recognition_msgs' does not exist                                 
[jsk_recognition_msgs:install] CMake Error at catkin_generated/safe_execute_install.cmake:4 (message):                            
[jsk_recognition_msgs:install]                                                                                                    
[jsk_recognition_msgs:install]   execute_process(/home/k-okada/catkin_ws/ws_recognition/build/jsk_recognition_msgs/catkin_generated/python_distutils_install.sh)
[jsk_recognition_msgs:install]   returned error code                                                                              
[jsk_recognition_msgs:install] Call Stack (most recent call first):                                                               
[jsk_recognition_msgs:install]   cmake_install.cmake:137 (include)                                                                
[jsk_recognition_msgs:install]                                                                                                    
[jsk_recognition_msgs:install]                                                                                                    
[jsk_recognition_msgs:install] Makefile:109: recipe for target 'install' failed   
```

Not sure why CI passed