### PR TITLE
[audio_to_spectrogram] Enable to change spectrum plot from rosparam

### DIFF
--- a/audio_to_spectrogram/README.md
+++ b/audio_to_spectrogram/README.md
@@ -167,6 +167,6 @@ roslaunch audio_to_spectrogram sample_audio_to_spectrogram.launch
 
       Maximum value of amplitude in plot
 
-    - `~queue_size` (`Int`, default: `1000`)
+    - `~queue_size` (`Int`, default: `1`)
 
       Queue size of spectrum subscriber

--- a/audio_to_spectrogram/README.md
+++ b/audio_to_spectrogram/README.md
@@ -157,3 +157,16 @@ roslaunch audio_to_spectrogram sample_audio_to_spectrogram.launch
     - `~spectrum` (`jsk_recognition_msgs/Spectrum`)
 
       Spectrum data calculated from audio by FFT.
+
+  - ### Parameters
+    - `~plot_amp_min` (`Double`, default: `0.0`)
+
+      Minimum value of amplitude in plot
+
+    - `~plot_amp_max` (`Double`, default: `20.0`)
+
+      Maximum value of amplitude in plot
+
+    - `~queue_size` (`Int`, default: `1000`)
+
+      Queue size of spectrum subscriber

--- a/audio_to_spectrogram/scripts/spectrum_plot.py
+++ b/audio_to_spectrogram/scripts/spectrum_plot.py
@@ -27,11 +27,17 @@ class SpectrumPlot(ConnectionBasedTransport):
         self.queue_size = rospy.get_param('~queue_size', 1000)
         # Set matplotlib config
         self.fig = plt.figure(figsize=(8, 5))
-        self.fig.suptitle('Spectrum plot', size=12)
         self.fig.subplots_adjust(left=0.1, right=0.95, top=0.90, bottom=0.1,
                                  wspace=0.2, hspace=0.6)
         self.ax = self.fig.add_subplot(1, 1, 1)
         self.ax.grid(True)
+        # self.fig.suptitle('Spectrum plot', size=12)
+        self.ax.set_title('Spectrum plot', fontsize=12)
+        # Use self.ax.set_title() instead of
+        # self.fig.suptitle() to use self.fig.tight_layout()
+        # preventing characters from being cut off
+        # cf. https://tm23forest.com/contents/matplotlib-tightlayout-with-figure-suptitle
+        #     https://matplotlib.org/2.2.4/tutorials/intermediate/tight_layout_guide.html
         self.ax.set_xlabel('Frequency [Hz]', fontsize=12)
         self.ax.set_ylabel('Amplitude', fontsize=12)
         self.line, = self.ax.plot([0, 0], label='Amplitude of Spectrum')
@@ -54,6 +60,7 @@ class SpectrumPlot(ConnectionBasedTransport):
         self.ax.set_xlim((self.freq.min(), self.freq.max()))
         self.ax.set_ylim((self.plot_amp_min, self.plot_amp_max))
         self.ax.legend(loc='upper right')
+        self.fig.tight_layout()
         if self.pub_img.get_num_connections() > 0:
             bridge = cv_bridge.CvBridge()
             img = convert_matplotlib_to_img(self.fig)

--- a/audio_to_spectrogram/scripts/spectrum_plot.py
+++ b/audio_to_spectrogram/scripts/spectrum_plot.py
@@ -22,6 +22,9 @@ class SpectrumPlot(ConnectionBasedTransport):
 
     def __init__(self):
         super(SpectrumPlot, self).__init__()
+        self.plot_amp_min = rospy.get_param('~plot_amp_min', 0.0)
+        self.plot_amp_max = rospy.get_param('~plot_amp_max', 20.0)
+        self.queue_size = rospy.get_param('~queue_size', 1000)
         # Set matplotlib config
         self.fig = plt.figure(figsize=(8, 5))
         self.fig.suptitle('Spectrum plot', size=12)
@@ -38,7 +41,7 @@ class SpectrumPlot(ConnectionBasedTransport):
 
     def subscribe(self):
         self.sub_spectrum = rospy.Subscriber(
-            '~spectrum', Spectrum, self._cb, queue_size=1000)
+            '~spectrum', Spectrum, self._cb, queue_size=self.queue_size)
 
     def unsubscribe(self):
         self.sub_spectrum.unregister()
@@ -49,7 +52,7 @@ class SpectrumPlot(ConnectionBasedTransport):
         self.freq = np.array(msg.frequency)
         self.line.set_data(self.freq, self.amp)
         self.ax.set_xlim((self.freq.min(), self.freq.max()))
-        self.ax.set_ylim((0.0, 20))
+        self.ax.set_ylim((self.plot_amp_min, self.plot_amp_max))
         self.ax.legend(loc='upper right')
         if self.pub_img.get_num_connections() > 0:
             bridge = cv_bridge.CvBridge()

--- a/audio_to_spectrogram/scripts/spectrum_plot.py
+++ b/audio_to_spectrogram/scripts/spectrum_plot.py
@@ -24,7 +24,7 @@ class SpectrumPlot(ConnectionBasedTransport):
         super(SpectrumPlot, self).__init__()
         self.plot_amp_min = rospy.get_param('~plot_amp_min', 0.0)
         self.plot_amp_max = rospy.get_param('~plot_amp_max', 20.0)
-        self.queue_size = rospy.get_param('~queue_size', 1000)
+        self.queue_size = rospy.get_param('~queue_size', 1)
         # Set matplotlib config
         self.fig = plt.figure(figsize=(8, 5))
         self.fig.subplots_adjust(left=0.1, right=0.95, top=0.90, bottom=0.1,


### PR DESCRIPTION
This PR helps to display spectrum of data other than audio.
Setting `plot_amp_max` to 0.2 generates:
![Screenshot from 2023-01-20 20-13-44](https://user-images.githubusercontent.com/14994939/213682401-ecea3414-4d7f-4d3f-86e3-dafc7f486753.png)
(Force sensor data sensing drill vibration)

Also this PR enables to set `queue_size` because generating plot is slow in my environment (`/spectrum_plot/output/viz` is less than 12Hz).
In this environment, setting `queue_size` to 1 is required if you input spectrum more than 12Hz and also want to prevent plot from being delayed more and more.
~~(Perhaps this is due to #2759 . More debug should be needed.)~~