### PR TITLE
[doc] Fix documentation of aws_detect_faces.py

### DIFF
--- a/doc/jsk_perception/nodes/aws_detect_faces.rst
+++ b/doc/jsk_perception/nodes/aws_detect_faces.rst
@@ -22,7 +22,7 @@ Subscribing Topic
 Publishing Topic
 ----------------
 
-* ``~faces`` (``opencv_msgs/FaceArrayStamped``)
+* ``~faces`` (``opencv_apps/FaceArrayStamped``)
 
   Detected face positions, facial landmarks, emotions, presence of beard, sunglasses, and so on.
 


### PR DESCRIPTION
This PR fixes documentation of `aws_detect_faces.py`

`msg` name is wrong. (`opencv_msg` --> `opencv_apps`)