### PR TITLE
[split_image] add cpp version of split_image

### DIFF
--- a/jsk_perception/CMakeLists.txt
+++ b/jsk_perception/CMakeLists.txt
@@ -292,6 +292,7 @@ jsk_add_nodelet(src/gaussian_blur.cpp "jsk_perception/GaussianBlur" "gaussian_bl
 jsk_add_nodelet(src/kmeans.cpp "jsk_perception/KMeans" "kmeans")
 jsk_add_nodelet(src/draw_rects.cpp "jsk_perception/DrawRects" "draw_rects")
 jsk_add_nodelet(src/remove_blurred_frames.cpp "jsk_perception/RemoveBlurredFrames" "remove_blurred_frames")
+jsk_add_nodelet(src/split_image.cpp "jsk_perception/SplitImage" "split_image")
 if("${OpenCV_VERSION}" VERSION_GREATER "2.9.9")  # >= 3.0.0
   jsk_add_nodelet(src/video_to_scene.cpp "jsk_perception/VideoToScene" "video_to_scene")
   jsk_add_nodelet(src/bing.cpp "jsk_perception/Bing" "bing")

--- a/jsk_perception/include/jsk_perception/split_image.h
+++ b/jsk_perception/include/jsk_perception/split_image.h
@@ -1,0 +1,69 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+/*
+ * split_image.h
+ * Author: Yoshiki Obinata <obinata@jsk.imi.i.u-tokyo.ac.jp>
+ */
+
+
+#ifndef SPLIT_IMAGE_H_
+#define SPLIT_IMAGE_H_
+
+#include <cv_bridge/cv_bridge.h>
+#include <jsk_topic_tools/diagnostic_nodelet.h>
+#include <sensor_msgs/Image.h>
+
+namespace jsk_perception{
+
+    class SplitImage : public jsk_topic_tools::DiagnosticNodelet{
+
+    public:
+        SplitImage() : DiagnosticNodelet("SplitImage"){}
+        virtual ~SplitImage();
+    protected:
+        virtual void onInit();
+        virtual void subscribe();
+        virtual void unsubscribe();
+        virtual void splitImage(const sensor_msgs::Image::ConstPtr& image_msg);
+
+        ros::Subscriber sub_;
+        std::vector<ros::Publisher> pubs_;
+        int vertical_parts_;
+        int horizontal_parts_;
+    private:
+    };
+};
+
+#endif // SPLIT_IMAGE_H_

--- a/jsk_perception/node_scripts/split_image.py
+++ b/jsk_perception/node_scripts/split_image.py
@@ -47,5 +47,6 @@ class SplitImage(ConnectionBasedTransport):
 
 if __name__ == '__main__':
     rospy.init_node('split_image')
+    rospy.logwarn("split_image.py would be deprecated. Please use NODELET version of split_image")
     SplitImage()
     rospy.spin()

--- a/jsk_perception/plugins/nodelet/libjsk_perception.xml
+++ b/jsk_perception/plugins/nodelet/libjsk_perception.xml
@@ -302,4 +302,8 @@
          type="jsk_perception::VideoToScene"
          base_class_type="nodelet::Nodelet">
   </class>
+  <class name="jsk_perception/SplitImage"
+         type="jsk_perception::SplitImage"
+         base_class_type="nodelet::Nodelet">
+  </class>
 </library>

--- a/jsk_perception/sample/sample_split_image.launch
+++ b/jsk_perception/sample/sample_split_image.launch
@@ -12,14 +12,16 @@
       publish_info: true
       fovx: 84.1
       fovy: 53.8
+      rate: 60.0
     </rosparam>
   </node>
 
-  <node pkg="jsk_perception" name="split_image" type="split_image.py" output="screen">
+  <node type="split_image" pkg="jsk_perception" name="split_image" output="screen">
     <remap from="~input" to="image_publisher/image_color" />
     <rosparam>
       vertical_parts: 2
       horizontal_parts: 2
+      always_subscribe: true
     </rosparam>
   </node>
 

--- a/jsk_perception/src/split_image.cpp
+++ b/jsk_perception/src/split_image.cpp
@@ -1,0 +1,101 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+/*
+ * split_image.cpp
+ * Author: Yoshiki Obinata <obinata@jsk.imi.i.u-tokyo.ac.jp>
+ */
+
+
+#include "jsk_perception/split_image.h"
+
+namespace jsk_perception{
+
+    void SplitImage::onInit(){
+        DiagnosticNodelet::always_subscribe_ = true;
+        DiagnosticNodelet::onInit();
+        pnh_->param("vertical_parts", vertical_parts_, 1);
+        pnh_->param("horizontal_parts", horizontal_parts_, 1);
+        for(int i=0; i<vertical_parts_; i++){
+            for(int j=0; j<horizontal_parts_; j++){
+                std::string pub_name = "output/vertical0"
+                    + std::to_string(i)
+                    + "/horizontal0"
+                    + std::to_string(j);
+                ros::Publisher pub_ = advertise<sensor_msgs::Image>(*pnh_, pub_name, 1);
+                pubs_.push_back(pub_);
+            }
+        }
+        onInitPostProcess();
+    }
+
+    SplitImage::~SplitImage(){}
+
+    void SplitImage::subscribe(){
+        sub_ = pnh_->subscribe("input", 1, &SplitImage::splitImage, this);
+    }
+
+    void SplitImage::unsubscribe(){
+        sub_.shutdown();
+    }
+
+    void SplitImage::splitImage(const sensor_msgs::Image::ConstPtr& msg){
+        cv_bridge::CvImagePtr cv_ptr;
+        try{
+            cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
+        }catch(cv_bridge::Exception& e){
+            NODELET_ERROR("cv_bridge exception: %s", e.what());
+            return;
+        }
+        cv::Mat image = cv_ptr->image;
+        int height = image.rows;
+        int width = image.cols;
+        int vertical_size = height / vertical_parts_;
+        int horizontal_size = width / horizontal_parts_;
+        for(int i=0; i<vertical_parts_; i++){
+            for(int j=0; j<horizontal_parts_; j++){
+                cv::Mat part_image = image(cv::Rect(horizontal_size*j, vertical_size*i, horizontal_size, vertical_size));
+                cv_bridge::CvImagePtr part_cv_ptr(new cv_bridge::CvImage);
+                part_cv_ptr->header = msg->header;
+                part_cv_ptr->encoding = sensor_msgs::image_encodings::BGR8;
+                part_cv_ptr->image = part_image;
+                sensor_msgs::ImagePtr part_msg = part_cv_ptr->toImageMsg();
+                pubs_.at(i*horizontal_parts_+j).publish(part_msg);
+            }
+        }
+    }
+}
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(jsk_perception::SplitImage, nodelet::Nodelet);

--- a/jsk_perception/src/split_image.cpp
+++ b/jsk_perception/src/split_image.cpp
@@ -50,9 +50,9 @@ namespace jsk_perception{
         for(int i=0; i<vertical_parts_; i++){
             for(int j=0; j<horizontal_parts_; j++){
                 std::string pub_name = "output/vertical0"
-                    + std::to_string(i)
+                    + boost::to_string(i)
                     + "/horizontal0"
-                    + std::to_string(j);
+                    + boost::to_string(j);
                 ros::Publisher pub_ = advertise<sensor_msgs::Image>(*pnh_, pub_name, 1);
                 pubs_.push_back(pub_);
             }


### PR DESCRIPTION
Improvement of https://github.com/jsk-ros-pkg/jsk_recognition/pull/2573.

Before this PR (Python version):
The CPU usage of `split_image.py` is about 112% and hz of `/split_image/output/vertical00/horizontal00` is about 38.

After this PR (cpp version):
The CPU usage of `split_image` is about 40% and hz of `/split_image/output/vertical00/horizontal00` is about 60.

You can try this benchmark to change `jsk_perception/sample/sample_split_image.launch` 's line
```xml
<node type="split_image" pkg="jsk_perception" name="split_image" output="screen">
```
to
```xml
<node type="split_image.py" pkg="jsk_perception" name="split_image" output="screen">
```
