### PR TITLE
[jsk_perception] Use cpp version of split_image in sample_insta360_air.launch

### DIFF
--- a/jsk_perception/sample/sample_dual_fisheye_to_panorama.launch
+++ b/jsk_perception/sample/sample_dual_fisheye_to_panorama.launch
@@ -9,9 +9,17 @@
   <arg name="vital_rate" default="1.0" doc="Rate to determine if the nodelet is in health." />
   <arg name="image_transport" default="raw"/>
 
+  <arg name="launch_manager" default="true" />
+  <arg name="MANAGER" default="dual_fisheye_to_panorama_manager" />
+
+  <node name="$(arg MANAGER)"
+        pkg="nodelet" type="nodelet" args="manager"
+        if="$(arg launch_manager)"
+        output="screen" />
+
   <node name="dual_fisheye_to_panorama"
         pkg="nodelet" type="nodelet"
-        args="standalone jsk_perception/DualFisheyeToPanorama">
+        args="load jsk_perception/DualFisheyeToPanorama $(arg MANAGER)">
     <remap from="~input" to="$(arg INPUT_IMAGE)"/>
     <param name="light_compen" value="false" />
     <param name="refine_align" value="$(arg refine_align)" />

--- a/jsk_perception/sample/sample_insta360_air.launch
+++ b/jsk_perception/sample/sample_insta360_air.launch
@@ -79,7 +79,7 @@
   <group ns="insta360" if="$(arg throttle)">
     <node name="throttle_camera_info"
           pkg="nodelet" type="nodelet"
-          args="standalone jsk_topic_tools/LightweightThrottle"
+          args="load jsk_topic_tools/LightweightThrottle /$(arg MANAGER)"
           respawn="true">
       <remap from="~input" to="camera_info"/>
       <remap from="~output" to="throttled/camera_info" />
@@ -87,7 +87,7 @@
     </node>
     <node name="throttle_rgb"
           pkg="nodelet" type="nodelet"
-          args="standalone jsk_topic_tools/LightweightThrottle"
+          args="load jsk_topic_tools/LightweightThrottle /$(arg MANAGER)"
           respawn="true">
       <remap from="~input" to="image_raw" />
       <remap from="~output" to="throttled/image_raw" />
@@ -95,7 +95,7 @@
     </node>
     <node name="throttle_rgb_compressed"
           pkg="nodelet" type="nodelet"
-          args="standalone jsk_topic_tools/LightweightThrottle"
+          args="load jsk_topic_tools/LightweightThrottle /$(arg MANAGER)"
           respawn="true">
       <remap from="~input" to="image_raw/compressed" />
       <remap from="~output" to="throttled/image_raw/compressed" />

--- a/jsk_perception/sample/sample_insta360_air.launch
+++ b/jsk_perception/sample/sample_insta360_air.launch
@@ -29,6 +29,13 @@
 
   <arg name="vital_rate" default="1.0" />
   <arg name="gui" default="true" />
+  <arg name="launch_manager" default="true" />
+  <arg name="MANAGER" default="insta360_manager" />
+
+  <node name="$(arg MANAGER)"
+        pkg="nodelet" type="nodelet" args="manager"
+        if="$(arg launch_manager)"
+        output="screen" />
 
   <!-- Publish camera image -->
   <group if="$(arg publish_image)">
@@ -60,7 +67,7 @@
   <!-- Split insta360 air image into 2 fisheye image -->
   <node name="split_image"
         pkg="nodelet" type="nodelet"
-        args="standalone jsk_perception/SplitImage"
+        args="load jsk_perception/SplitImage $(arg MANAGER)"
         respawn="true">
     <remap from="~input" to="/insta360/image_raw" />
     <rosparam>
@@ -106,6 +113,8 @@
     <arg name="resolution_mode" value="$(arg panorama_resolution_mode)" />
     <arg name="image_transport" value="$(arg panorama_image_transport)" />
     <arg name="vital_rate" value="$(arg vital_rate)" />
+    <arg name="launch_manager" value="false" />
+    <arg name="MANAGER" value="$(arg MANAGER)" />
   </include>
 
   <group if="$(arg gui)">

--- a/jsk_perception/sample/sample_insta360_air.launch
+++ b/jsk_perception/sample/sample_insta360_air.launch
@@ -58,7 +58,10 @@
   </group>
 
   <!-- Split insta360 air image into 2 fisheye image -->
-  <node pkg="jsk_perception" name="split_image" type="split_image.py" output="screen">
+  <node name="split_image"
+        pkg="nodelet" type="nodelet"
+        args="standalone jsk_perception/SplitImage"
+        respawn="true">
     <remap from="~input" to="/insta360/image_raw" />
     <rosparam>
       vertical_parts: 1


### PR DESCRIPTION
This change was made in response to https://github.com/jsk-ros-pkg/jsk_recognition/pull/2770.

I tested on fetch15 and I have confirmed that cpu usage becomes lower when I use this patch.

- before
<!-- ![fetch15_split_image_py](https://user-images.githubusercontent.com/67531577/236723623-5620efcc-bb2a-427d-9445-fd9c66fd5786.png) -->
![insta360_standalone](https://user-images.githubusercontent.com/67531577/236744396-8e741719-31b5-4167-bc0c-226f58ac7232.png)


- after
<!-- ![fetch15_splitimage_cpp](https://user-images.githubusercontent.com/67531577/236723640-3be8c4d2-0ff1-436f-a8c4-2be1c1e43203.png) -->
![insta360_nodelet](https://user-images.githubusercontent.com/67531577/236744416-277e3ba9-7e24-46d5-956b-ab49bea45b84.png)
