### PR TITLE
[jsk_perception] Catch exception when dynamodb doesn't have entry that matches FaceID

### DIFF
--- a/jsk_perception/node_scripts/aws_auto_checkin_app.py
+++ b/jsk_perception/node_scripts/aws_auto_checkin_app.py
@@ -189,14 +189,19 @@ class AutoCheckIn(ConnectionBasedTransport):
             ret = self.findface(img[image_roi_slice])
             if ret != None:
                 if ret['FaceMatches'] != []:
-                    face_id = self.dynamodb_table.get_item(
-                        Key={'RekognitionId':
-                             ret['FaceMatches'][0]['Face']['FaceId']})['Item']['Name']
-                    rospy.loginfo("FaceId: {}\n Similarity: {}".format(face_id, \
-                                                                       ret['FaceMatches'][0]['Similarity']))
-                    faces.faces.append(Face(face=Rect(cx - w // 2, cy - h // 2, w, h),
-                                            label=face_id,
-                                            confidence=ret['FaceMatches'][0]['Similarity'] / 100.0))
+                    try:
+                        face_id = self.dynamodb_table.get_item(
+                            Key={'RekognitionId':
+                                 ret['FaceMatches'][0]['Face']['FaceId']})['Item']['Name']
+                        rospy.loginfo("FaceId: {}\n Similarity: {}".format(face_id, \
+                                                                           ret['FaceMatches'][0]['Similarity']))
+                        faces.faces.append(Face(face=Rect(cx - w // 2, cy - h // 2, w, h),
+                                                label=face_id,
+                                                confidence=ret['FaceMatches'][0]['Similarity'] / 100.0))
+                    except KeyError as e:
+                        rospy.logwarn(
+                            "{}: Dynamodb does not have FaceID: {}".format(
+                                e, ret['FaceMatches'][0]['Face']['FaceID']))
 
             if self.use_window: # copy colored face rectangle to img_gray
                 img_gray[image_roi_slice] = img[image_roi_slice]


### PR DESCRIPTION
This PR avoids the following error.
This error occurs when dynamodb entry of face images does not exists for some reasons such as mistakenly deleting it.
```
...
[INFO] [1688613945.445521] [/aws_auto_checkin_app]: [[{'Similarity': 96.03959655761719, 'Face': {'FaceId': '2411ca49-43cf-4495-8da6-0e0f9212f1c8', 'BoundingBox': {'Width': 0.1941870003938675, 'Height': 0.3191249966621399, 'Left': 0.4040130078792572, 'Top': 0.25807899236679077}, 'ImageId': '532947df-2b6c-37cd-9b13-68a14501cbdf', 'Confidence': 99.99559783935547}}]]
[ERROR] [1688613945.560723] [/aws_auto_checkin_app]: [bad callback: <bound method Subscriber.callback of <message_filters.Subscriber object at 0x7f09d96fe280>>
Traceback (most recent call last):
  File "/opt/ros/noetic/lib/python3/dist-packages/rospy/topics.py", line 750, in _invoke_callback
    cb(msg)
  File "/opt/ros/noetic/lib/python3/dist-packages/message_filters/__init__.py", line 76, in callback
    self.signalMessage(msg)
  File "/opt/ros/noetic/lib/python3/dist-packages/message_filters/__init__.py", line 58, in signalMessage
    cb(*(msg + args))
  File "/opt/ros/noetic/lib/python3/dist-packages/message_filters/__init__.py", line 330, in add
    self.signalMessage(*msgs)
  File "/opt/ros/noetic/lib/python3/dist-packages/message_filters/__init__.py", line 58, in signalMessage
    cb(*(msg + args))
  File "/home/tsukamoto/ros/robot_ws/src/jsk_recognition/jsk_perception/node_scripts/aws_auto_checkin_app.py", line 194, in callback
    face_id = self.dynamodb_table.get_item(
KeyError: 'Item'
]
```