### PR TITLE
[jsk_perception] Fix Cosine Similarity description in visualize  string msg of classification_node 

### DIFF
--- a/jsk_perception/src/jsk_perception/vil_inference_client.py
+++ b/jsk_perception/src/jsk_perception/vil_inference_client.py
@@ -155,9 +155,9 @@ class ClipClientNode(DockerInferenceClientBase):
         vis_msg = ""
         for i, label in enumerate(msg.label_names):
             vis_msg += "{}: {:.2f}% ".format(label, msg.probabilities[i]*100)
-        vis_msg += "\n"
+        vis_msg += "\n\nCosine Similarity\n"
         for i, label in enumerate(msg.label_names):
-            vis_msg += "{}: {:.2f}% ".format(label, msg.label_proba[i]*100)
+            vis_msg += "{}: {:.4f} ".format(label, msg.label_proba[i]*100)
         self.vis_pub.publish(vis_msg)
 
     def create_queries(self, goal):

--- a/jsk_perception/src/jsk_perception/vil_inference_client.py
+++ b/jsk_perception/src/jsk_perception/vil_inference_client.py
@@ -157,7 +157,7 @@ class ClipClientNode(DockerInferenceClientBase):
             vis_msg += "{}: {:.2f}% ".format(label, msg.probabilities[i]*100)
         vis_msg += "\n\nCosine Similarity\n"
         for i, label in enumerate(msg.label_names):
-            vis_msg += "{}: {:.4f} ".format(label, msg.label_proba[i]*100)
+            vis_msg += "{}: {:.4f} ".format(label, msg.label_proba[i])
         self.vis_pub.publish(vis_msg)
 
     def create_queries(self, goal):


### PR DESCRIPTION
I updated the output of `/classification/visualize` string of `classification_node.py`, because it was difficult to understand.

| Before  | After |
| ------------- | ------------- |
| ![Screenshot from 2023-10-12 17-34-50](https://github.com/jsk-ros-pkg/jsk_recognition/assets/38127823/8cf610ee-09f2-46d5-973a-3078eaad35dd) | ![Screenshot from 2023-10-13 18-51-16](https://github.com/jsk-ros-pkg/jsk_recognition/assets/38127823/c8ac1210-495d-43d1-926e-c852dd85d881) |


In the result message of `classification_node.py`, `label_proba` shows the cosine similarity between input image and each text label, and `probabilities` are the classification probabilities for each text label, in the order of the text labels in `label_names`. 

Cosine similarity should be in the range -1~1, so the display in the visualisation message has been modified not to multiply by 100.
```
$ rostopic echo /classification/result -n 1 
header: 
  seq: 3
  stamp: 
    secs: 1697100497
    nsecs: 902856588
  frame_id: "camera"
labels: [0, 1, 2, 3, 4, 5]
label_names: 
  - dog
  - cat
  - human
  - kettle
  - cup
  - glass
label_proba: [0.24072265625, 0.2374267578125, 0.208251953125, 0.2012939453125, 0.1949462890625, 0.1668701171875]
probabilities: [0.55517578125, 0.406005859375, 0.0218658447265625, 0.0108184814453125, 0.005794525146484375, 0.0003478527069091797]
classifier: "clip"
target_names: 
  - human
  - kettle
  - cup
  - glass
  - dog
  - cat
---
```
