### PR TITLE
[jsk_perception] Support compressed type image in vil_inference_client.py

### DIFF
--- a/jsk_perception/launch/classification.launch
+++ b/jsk_perception/launch/classification.launch
@@ -5,6 +5,7 @@
   <arg name="gui" default="false" />
   <arg name="run_api" default="false" />
   <arg name="CLASSIFICATION_INPUT_IMAGE" default="image" />
+  <arg name="image_transport" default="raw" />
 
   <node name="classification_api" pkg="jsk_perception" type="run_jsk_vil_api" output="log"
         args="clip -p $(arg port)" if="$(arg run_api)" />
@@ -14,6 +15,7 @@
     <rosparam subst_value="true">
       host: $(arg host)
       port: $(arg port)
+      image_transport: $(arg image_transport)
     </rosparam>
   </node>
 

--- a/jsk_perception/launch/vqa.launch
+++ b/jsk_perception/launch/vqa.launch
@@ -5,6 +5,7 @@
   <arg name="gui" default="false" />
   <arg name="run_api" default="false" />
   <arg name="VQA_INPUT_IMAGE" default="vqa_image" />
+  <arg name="image_transport" default="raw" />
 
   <node name="ofa_api" pkg="jsk_perception" type="run_jsk_vil_api" output="log"
         args="ofa -p $(arg port)" if="$(arg run_api)" />
@@ -14,6 +15,7 @@
     <rosparam subst_value="true">
       host: $(arg host)
       port: $(arg port)
+      image_transport: $(arg image_transport)
     </rosparam>
   </node>
 

--- a/jsk_perception/src/jsk_perception/vil_inference_client.py
+++ b/jsk_perception/src/jsk_perception/vil_inference_client.py
@@ -39,13 +39,27 @@ class DockerInferenceClientBase(object):
         # default inference image
         self.default_img = None
         # ROS
-        self.image_sub = rospy.Subscriber("~image", Image,
-                                          callback=self.topic_cb,
-                                          queue_size=1,
-                                          buff_size=2**26)
+        self.transport_hint = rospy.get_param('~image_transport', 'raw')
+        if self.transport_hint == 'compressed':
+            self.image_sub = rospy.Subscriber(
+                "{}/compressed".format(rospy.resolve_name('~image')),
+                CompressedImage,
+                callback=self.topic_cb,
+                queue_size=1,
+                buff_size=2**26
+            )
+
+        else:
+            self.image_sub = rospy.Subscriber("~image", Image,
+                                              callback=self.topic_cb,
+                                              queue_size=1,
+                                              buff_size=2**26)
         self.result_topic_type = result_topic
         self.result_pub = rospy.Publisher("~result", result_topic, queue_size=1)
-        self.image_pub = rospy.Publisher("~result/image", Image, queue_size=1)
+        if self.transport_hint == 'compressed':
+            self.image_pub = rospy.Publisher("~result/image/compressed", CompressedImage, queue_size=1)
+        else:
+            self.image_pub = rospy.Publisher("~result/image", Image, queue_size=1)
         self.vis_pub = rospy.Publisher("~visualize", String, queue_size=1)
         self.action_server = actionlib.SimpleActionServer("~inference_server",
                                                           action,


### PR DESCRIPTION
I added `image_transport` arg to use compressed image topic.
This PR will reduce heavy network traffic when we send images to vil server frequently.