### PR TITLE
xacro.py is removed on noetic

### DIFF
--- a/jsk_pcl_ros/sample/include/play_rosbag_pr2_sink.xml
+++ b/jsk_pcl_ros/sample/include/play_rosbag_pr2_sink.xml
@@ -2,7 +2,7 @@
   <arg name="LOAD_URDF" default="false"/>
 
   <param name="/use_sim_time" value="true"/>
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find pr2_description)/robots/pr2.urdf.xacro'"
+  <param name="robot_description" command="$(find xacro)/xacro '$(find pr2_description)/robots/pr2.urdf.xacro'"
          if="$(arg LOAD_URDF)"/>
 
   <node name="rosbag_play" pkg="rosbag" type="play"

--- a/jsk_pcl_ros/sample/sample_octomap_server_contact_pr2.launch
+++ b/jsk_pcl_ros/sample/sample_octomap_server_contact_pr2.launch
@@ -1,5 +1,5 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find pr2_description)/robots/pr2.urdf.xacro'"/>
+  <param name="robot_description" command="$(find xacro)/xacro '$(find pr2_description)/robots/pr2.urdf.xacro'"/>
 
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
     <param name="use_gui" value="true"/>


### PR DESCRIPTION
See https://wiki.ros.org/noetic/Migration#Use_xacro_instead_of_xacro.py
I think `xacro` command has existed since hydro era, so I do not think we have a backward compatibility issue about this PR.