### PR TITLE
[jsk_recognition_utils] add OpenCV to catkin_depends

### DIFF
--- a/jsk_recognition_utils/CMakeLists.txt
+++ b/jsk_recognition_utils/CMakeLists.txt
@@ -12,6 +12,7 @@ endif(CCACHE_FOUND)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
+  cv_bridge
   dynamic_reconfigure
   jsk_recognition_msgs
   pcl_ros
@@ -52,7 +53,7 @@ generate_dynamic_reconfigure_options(
 catkin_package(
  INCLUDE_DIRS include
  LIBRARIES jsk_recognition_utils
- CATKIN_DEPENDS jsk_recognition_msgs pcl_ros visualization_msgs message_runtime
+ CATKIN_DEPENDS cv_bridge jsk_recognition_msgs pcl_ros visualization_msgs message_runtime
 )
 
 # Cythonize pyx files

--- a/jsk_recognition_utils/package.xml
+++ b/jsk_recognition_utils/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>cv_bridge</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION==2">cython</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION==3">cython3</build_depend>
   <build_depend>eigen_conversions</build_depend>
@@ -35,6 +36,7 @@
   <build_depend>visualization_msgs</build_depend>
   <build_depend>yaml-cpp</build_depend>
   <build_depend>message_generation</build_depend>
+  <exec_depend>cv_bridge</exec_depend>
   <exec_depend>eigen_conversions</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>image_geometry</exec_depend>


### PR DESCRIPTION
The current CMake implementation of `jsk_recognition_utils` does not propagate the need for OpenCV downstream, so I fixed it.

## How to check
Create the package like

package.xml
```xml
<?xml version="1.0"?>
<package format="2">
  <name>test_utils</name>
  <version>0.0.0</version>
  <description>The test_utils package</description>
  <maintainer email="obinata@todo.todo">obinata</maintainer>
  <license>TODO</license>
  <depend>jsk_recognition_utils</depend>
  <buildtool_depend>catkin</buildtool_depend>
</package>
```

CMakeLists.txt
```cmake
cmake_minimum_required(VERSION 3.0.2)
project(test_utils)

find_package(catkin REQUIRED COMPONENTS jsk_recognition_utils)

catkin_package()

include_directories(
  include
  ${catkin_INCLUDE_DIRS}
)

link_directories(
  ${catkin_LIBRARY_DIRS}
)

message(STATUS "catkin_INCLUDE_DIRS: ${catkin_INCLUDE_DIRS}")

add_library(${PROJECT_NAME}
  src/test_utils.cpp
)
```

include/test_utils/test_utils.h
```cpp
#include <jsk_recognition_utils/pcl_conversion_util.h>
```

src/test_utils.cpp
```cpp
#include <test_utils/test_utils.h>
```

Then compare the `cmake` outputs before this PR and after this PR
### before
```
-- catkin_INCLUDE_DIRS: /home/obinata/ros/hsr_ws/devel/.private/jsk_recognition_utils/include;/home/obinata/ros/hsr_ws/devel/.private/jsk_recognition_msgs/include;/home/obinata/ros/hsr_ws/src/jsk_recognition/jsk_recognition_utils/include;/opt/ros/noetic/include;/opt/ros/noetic/share/xmlrpcpp/cmake/../../../include/xmlrpcpp;/usr/include;/usr/include/eigen3;/usr/include/pcl-1.10;/usr/include/vtk-7.1;/usr/include/freetype2;/usr/include/x86_64-linux-gnu
```
and fails to compile with
```
In file included from /home/obinata/ros/hsr_ws/src/test_utils/include/test_utils/test_utils.h:4,
                 from /home/obinata/ros/hsr_ws/src/test_utils/src/test_utils.cpp:1:
/home/obinata/ros/hsr_ws/src/jsk_recognition/jsk_recognition_utils/include/jsk_recognition_utils/pcl_conversion_util.h:56:10: fatal error: opencv2/opencv.hpp: そのようなファイルやディレクトリはありません
   56 | #include <opencv2/opencv.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

### after
```
-- catkin_INCLUDE_DIRS: /home/obinata/ros/hsr_ws/devel/.private/jsk_recognition_utils/include;/home/obinata/ros/hsr_ws/devel/.private/jsk_recognition_msgs/include;/home/obinata/ros/hsr_ws/src/jsk_recognition/jsk_recognition_utils/include;/opt/ros/noetic/include;/opt/ros/noetic/share/xmlrpcpp/cmake/../../../include/xmlrpcpp;/usr/include/opencv4;/usr/include/pcl-1.10;/usr/include/eigen3;/usr/include;/usr/include/vtk-7.1;/usr/include/freetype2;/usr/include/x86_64-linux-gnu;/usr/include/ni;/usr/include/openni2
```
and successfully finds OpenCV