### PR TITLE
Add ros_environment

### DIFF
--- a/jsk_recognition_msgs/package.xml
+++ b/jsk_recognition_msgs/package.xml
@@ -12,6 +12,7 @@
   <maintainer email="ueda@jsk.t.u-tokyo.ac.jp">Ryohei Ueda</maintainer>
   <license>BSD</license>
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>ros_environment</build_depend>
   <build_depend>pcl_msgs</build_depend>
   <run_depend>pcl_msgs</run_depend>
   <build_depend>std_msgs</build_depend>


### PR DESCRIPTION
So that we can get to `ROS_DISTRO` at build time.

See: https://github.com/lopsided98/nix-ros-overlay/issues/406