### PR TITLE
Add missing ros_environment dependency to package.xml

### DIFF
--- a/audio_to_spectrogram/package.xml
+++ b/audio_to_spectrogram/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>dynamic_reconfigure</build_depend>
+  <build_depend>ros_environment</build_depend>
 
   <exec_depend>audio_capture</exec_depend>
   <exec_depend>audio_common_msgs</exec_depend>

--- a/imagesift/package.xml
+++ b/imagesift/package.xml
@@ -19,6 +19,7 @@
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend>roscpp</build_depend>
+  <build_depend>ros_environment</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>posedetection_msgs</build_depend>

--- a/jsk_pcl_ros/package.xml
+++ b/jsk_pcl_ros/package.xml
@@ -33,6 +33,7 @@
   <build_depend>octomap_server</build_depend>
   <build_depend>pcl_msgs</build_depend>
   <build_depend>pcl_ros</build_depend>
+  <build_depend>ros_environment</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>tf_conversions</build_depend>
   <build_depend>yaml-cpp</build_depend>

--- a/jsk_pcl_ros_utils/package.xml
+++ b/jsk_pcl_ros_utils/package.xml
@@ -58,6 +58,7 @@
   <build_depend>octomap_ros</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION == 2">python-yaml</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION == 3">python3-yaml</build_depend>
+  <build_depend>ros_environment</build_depend>
 
   <!-- <exec_depend>pcl</exec_depend> -->
   <exec_depend>eigen_conversions</exec_depend>

--- a/jsk_perception/package.xml
+++ b/jsk_perception/package.xml
@@ -42,6 +42,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>roseus</build_depend>
   <build_depend>rospack</build_depend>
+  <build_depend>ros_environment</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>tf</build_depend>

--- a/jsk_recognition_utils/package.xml
+++ b/jsk_recognition_utils/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>ros_environment</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION==2">cython</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION==3">cython3</build_depend>
   <build_depend>eigen_conversions</build_depend>


### PR DESCRIPTION
Any package that evaluates `ROS_VERSION`, `ROS_DISTRO` or `ROS_PYTHON_VERSION` at build time should add ros_environment as a dependency.