### PR TITLE
use xyz instead of xyzrgb in ClusterPointIndicesDecomposer

### DIFF
--- a/jsk_pcl_ros/include/jsk_pcl_ros/cluster_point_indices_decomposer.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/cluster_point_indices_decomposer.h
@@ -111,12 +111,12 @@ namespace jsk_pcl_ros
     boost::mutex mutex_;
 
     void addToDebugPointCloud
-    (const pcl::PointCloud<pcl::PointXYZRGB>::Ptr segmented_cloud,
+    (const pcl::PointCloud<pcl::PointXYZ>::Ptr segmented_cloud,
      size_t i,
      pcl::PointCloud<pcl::PointXYZRGB>& debug_output);
     
     virtual bool computeCenterAndBoundingBox
-    (const pcl::PointCloud<pcl::PointXYZRGB>::Ptr segmented_cloud,
+    (const pcl::PointCloud<pcl::PointXYZ>::Ptr segmented_cloud,
      const std_msgs::Header header,
      const jsk_recognition_msgs::PolygonArrayConstPtr& planes,
      const jsk_recognition_msgs::ModelCoefficientsArrayConstPtr& coefficients,
@@ -125,8 +125,8 @@ namespace jsk_pcl_ros
      bool& publish_tf);
 
     virtual bool transformPointCloudToAlignWithPlane(
-      const pcl::PointCloud<pcl::PointXYZRGB>::Ptr segmented_cloud,
-      pcl::PointCloud<pcl::PointXYZRGB>::Ptr segmented_cloud_transformed,
+      const pcl::PointCloud<pcl::PointXYZ>::Ptr segmented_cloud,
+      pcl::PointCloud<pcl::PointXYZ>::Ptr segmented_cloud_transformed,
       const Eigen::Vector4f center,
       const jsk_recognition_msgs::PolygonArrayConstPtr& planes,
       const jsk_recognition_msgs::ModelCoefficientsArrayConstPtr& coefficients,


### PR DESCRIPTION
currently, ClusterPointIndicesDecomposer assume that there is `XYZRGB` field,
so I see this warning when we use point cloud format `XYZI` again and again

```
Failed to find match for field 'rgb'.                                                                                                    
Failed to find match for field 'rgb'.                                                                                                    
Failed to find match for field 'rgb'.                                                                                                                                                                                                                                             
Failed to find match for field 'rgb'.                                                                                                                                                                                                                                             
Failed to find match for field 'rgb'.                                                                                                                                                                                                                                             
Failed to find match for field 'rgb'.                                                                                                                                                                                                                                             
Failed to find match for field 'rgb'.                                                                                                                                                                                                                                             
Failed to find match for field 'rgb'.                                                                                                                                                                                                                                             
Failed to find match for field 'rgb'.                                                                                                    
Failed to find match for field 'rgb'.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
Failed to find match for field 'rgb'. 
```

this PR suppresses the warning.
Because the computation does not use RGB field, so we can use `XYZ` format for the computation.