### PR TITLE
Refactor ear clipping algorithm to improve concave and flat triangle detection

### DIFF
--- a/jsk_recognition_utils/src/pcl/ear_clipping_patched.cpp
+++ b/jsk_recognition_utils/src/pcl/ear_clipping_patched.cpp
@@ -141,8 +141,17 @@ pcl::EarClippingPatched::isEar (int u, int v, int w, const Vertices& vertices)
 
   // 1: Avoid flat triangles and concave vertex
   Eigen::Vector3f cross = p_vu.cross(p_vw);
-  if ((cross[2] > 0) || (cross.norm() < eps))
-    return (false);
+
+  // Concave vertex condition:
+  // If the z component of the cross product is less than or equal to zero,
+  // the triangle is concave, meaning the angle between the vectors is greater than 180 degrees.
+  if (cross[2] <= 0) {
+    // Not an ear: concave vertex
+    return false;
+  } else if (cross.norm() < eps) {
+    // Not an ear: flat triangle
+    return false;
+  }
 
   Eigen::Vector3f p;
   // 2: Check if any other vertex is inside the triangle.


### PR DESCRIPTION
- Updated the condition to detect concave vertices: If the z component of the cross product is less than or equal to zero, the triangle is considered concave, indicating that the angle between the vectors is greater than 180 degrees.

Correct the decomposition part of the polygon and resolve the following issues.
https://github.com/jsk-ros-pkg/jsk_recognition/issues/2840