### PR TITLE
set OpenCV_INCLUDE_DIRS in include_dirs in catkin_package

### DIFF
--- a/jsk_recognition_utils/CMakeLists.txt
+++ b/jsk_recognition_utils/CMakeLists.txt
@@ -49,8 +49,20 @@ generate_dynamic_reconfigure_options(
   cfg/PolygonArrayToPolygon.cfg
 )
 
+find_package(OpenCV REQUIRED core imgproc)
+find_package(PCL REQUIRED)
+find_package(PkgConfig)
+pkg_check_modules(yaml_cpp yaml-cpp REQUIRED)
+IF(${yaml_cpp_VERSION} VERSION_LESS "0.5.0")
+## indigo yaml-cpp : 0.5.0 /  hydro yaml-cpp : 0.3.0
+  add_definitions("-DUSE_OLD_YAML")
+ENDIF()
+
 catkin_package(
- INCLUDE_DIRS include
+ INCLUDE_DIRS
+   include
+   ${OpenCV_INCLUDE_DIRS}
+   ${PCL_INCLUDE_DIRS}
  LIBRARIES jsk_recognition_utils
  CATKIN_DEPENDS jsk_recognition_msgs pcl_ros visualization_msgs message_runtime
 )
@@ -60,14 +72,6 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(UseCython)
 add_subdirectory(python/${PROJECT_NAME})
 
-find_package(OpenCV REQUIRED core imgproc)
-find_package(PCL REQUIRED)
-find_package(PkgConfig)
-pkg_check_modules(yaml_cpp yaml-cpp REQUIRED)
-IF(${yaml_cpp_VERSION} VERSION_LESS "0.5.0")
-## indigo yaml-cpp : 0.5.0 /  hydro yaml-cpp : 0.3.0
-  add_definitions("-DUSE_OLD_YAML")
-ENDIF()
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -z defs")
 endif()


### PR DESCRIPTION
OpenCV_INCLUDE_DIRS is not include in `catkin_package`, which causes build error, when we use `include/geo/convex_polygon.h`.
the true solution is to add `OpenCV_INCLUDE_DIRS` in `image_geometry, but I make this PR for temporary solution.

`include/geo/convex_polygon.h` -> `include/geo/polygon.h` -> `include/sensor_model_utils.h` -> `image_geometry/pinhole_camera_model.h` -> `opencv/core/mat.hpp`