### PR TITLE
Add option 'synchronize' to hinted_plane_detector_nodelet

### DIFF
--- a/doc/jsk_pcl_ros/nodes/hinted_plane_detector.md
+++ b/doc/jsk_pcl_ros/nodes/hinted_plane_detector.md
@@ -49,6 +49,10 @@ Algorithm is:
 ## Parameters
 
 ### Parameters for detecting hint plane
+* `~synchronize` (Double, default: `True`)
+
+  Enable time synchronization of input topics
+
 * `~hint_outlier_threashold` (Double, default: `0.1`)
 
   Outlier threshold to detect hint plane using RANSAC

--- a/jsk_pcl_ros/cfg/HintedPlaneDetector.cfg
+++ b/jsk_pcl_ros/cfg/HintedPlaneDetector.cfg
@@ -9,6 +9,7 @@ from math import pi
 
 gen = ParameterGenerator ()
 
+gen.add('synchronize', bool_t, 0, 'Enable synchronization of input topics', True)
 gen.add("hint_outlier_threashold", double_t, 0, "outlier threshold to detect hint plane", 0.1, 0.0, 1.0)
 gen.add("hint_max_iteration", int_t, 0, "max iteration to detect hint plane", 100, 1, 10000)
 gen.add("hint_min_size", int_t, 0, "minimum number of inliers included in hint plane", 100, 0, 1000)

--- a/jsk_pcl_ros/include/jsk_pcl_ros/hinted_plane_detector.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/hinted_plane_detector.h
@@ -66,6 +66,7 @@ namespace jsk_pcl_ros {
     virtual void onInit();
     virtual void subscribe();
     virtual void unsubscribe();
+    virtual void setHintCloud(const sensor_msgs::PointCloud2::ConstPtr& msg);
     virtual void detect(
       const sensor_msgs::PointCloud2::ConstPtr& cloud_msg,
       const sensor_msgs::PointCloud2::ConstPtr& hint_cloud_msg);
@@ -124,10 +125,14 @@ namespace jsk_pcl_ros {
     ros::Publisher pub_euclidean_filtered_indices_;
     boost::shared_ptr <dynamic_reconfigure::Server<Config> > srv_;
     boost::mutex mutex_;
+    ros::Subscriber sub_cloud_single_;
+    ros::Subscriber sub_hint_cloud_single_;
+    sensor_msgs::PointCloud2::ConstPtr hint_cloud_;
 
     ////////////////////////////////////////////////////////
     // parameters
     ////////////////////////////////////////////////////////
+    bool synchronize_;
     double hint_outlier_threashold_;
     int hint_max_iteration_;
     int hint_min_size_;


### PR DESCRIPTION
The HintedPlaneDetector nodelet originally only accepts synchronized input of a Pointcloud and a hint.
This pull request is to allow input of a hind cloud at any point without synchronization.
The default behavior will not be changed at all.