### PR TITLE
[GA] fix node-GLIBC issue

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -4,6 +4,9 @@ on:
       - master
   pull_request:
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   ros:
     runs-on: ubuntu-latest


### PR DESCRIPTION
fix the issue

```
0s
Run actions/checkout@v2
  with:
    fetch-depth: 2
    repository: jsk-ros-pkg/jsk_recognition
    token: ***
    ssh-strict: true
    persist-credentials: true
    clean: true
    lfs: false
    submodules: false
    set-safe-directory: true
/usr/bin/docker exec  6[1](https://github.com/jsk-ros-pkg/jsk_recognition/pull/2846/checks#step:5:1)320045d91265fc4c37984b23a6b85c[2](https://github.com/jsk-ros-pkg/jsk_recognition/pull/2846/checks#step:5:2)e25601465c04277e24c4d8812921cb9 sh -c "cat /etc/*release | grep ^ID"
/__e/node20/bin/node: /lib/x86_6[4](https://github.com/jsk-ros-pkg/jsk_recognition/pull/2846/checks#step:5:4)-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
```

for checking out.

See https://github.com/canonical/snapd-glib/pull/171