### PR TITLE
[jsk_perception/doc/vqa_node] add explanation about model argument

### DIFF
--- a/doc/jsk_perception/nodes/vqa_node.md
+++ b/doc/jsk_perception/nodes/vqa_node.md
@@ -74,9 +74,11 @@ make
 In the remote GPU machine,
 ```shell
 cd jsk_recognition/jsk_perception/docker
-./run_jsk_vil_api --port (Your vacant port) --ofa_task caption --ofa_model_scale huge
+./run_jsk_vil_api ofa --port (Your vacant port) --ofa_task caption --ofa_model_scale huge
 ```
 
+
+You should set a model argument. It should be `ofa` or `clip`.
 
 `--ofa_task` should be `caption` or `vqa`. Empirically, the output results are more natural for VQA tasks with the Caption model than with the VQA model in OFA. 
 


### PR DESCRIPTION
When I executed the below command following https://jsk-docs.readthedocs.io/projects/jsk_recognition/en/latest/jsk_perception/nodes/vqa_node.html#run-inference-container-on-another-host-or-another-terminal
```
kochigami@kochigami-ThinkPad-P16-Gen-1:~/catkin_ws/src/jsk_recognition/jsk_perception/docker$ ./run_jsk_vil_api --port 8888 --ofa_task caption --ofa_model_scale huge
```
I got the following error:
```
usage: run_jsk_vil_api [-h] [-p PORT] [--ofa_task OFA_TASK] [--ofa_model_scale {base,large,huge}] {ofa,clip}
run_jsk_vil_api: error: the following arguments are required: model
```
It seems that we need to set a model argument, but it seems that doc forgets it.
Thus, I added an explanation about model argument.
I'm not sure whether it is a good explanation, so please check this.

Related issue: https://github.com/jsk-ros-pkg/jsk_recognition/issues/2849