### PR TITLE
[audio_to_spectrogram] Fix when to use catkin_install_python

### DIFF
--- a/audio_to_spectrogram/CMakeLists.txt
+++ b/audio_to_spectrogram/CMakeLists.txt
@@ -17,7 +17,7 @@ install(DIRECTORY launch sample test
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
   USE_SOURCE_PERMISSIONS
 )
-if(NOT $ENV{ROS_DISTRO} STREQUAL "indigo") # on noetic it needs catkin_install_python to support Python3 and it does not work on indigo for some reason...
+if($ENV{ROS_DISTRO} STREQUAL "indigo") # on noetic it needs catkin_install_python to support Python3 and it does not work on indigo for some reason...
   install(DIRECTORY scripts
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
     USE_SOURCE_PERMISSIONS


### PR DESCRIPTION
I found another issue of https://github.com/jsk-ros-pkg/jsk_recognition/pull/2743 other than https://github.com/jsk-ros-pkg/jsk_recognition/pull/2851.

Conditional branch for `catkin_install_python` is wrong only in `audio_to_spectrogram`.

Correct (`jsk_recognition_msgs`):
https://github.com/jsk-ros-pkg/jsk_recognition/blob/c80a511340cd9b9fb112be70056632fd07b58964/jsk_recognition_msgs/CMakeLists.txt#L145-L163
On indigo, `catkin_install_python` is not used.

Wrong (`audio_to_spectrogram`):
https://github.com/jsk-ros-pkg/jsk_recognition/blob/c80a511340cd9b9fb112be70056632fd07b58964/audio_to_spectrogram/CMakeLists.txt#L20-L38
***Not*** on indigo, `catkin_install_python` is not used.