### PR TITLE
fix for ROS-O

### DIFF
--- a/jsk_perception/package.xml
+++ b/jsk_perception/package.xml
@@ -84,17 +84,17 @@
   <!-- install chainer {{ -->
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-h5py</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-h5py</exec_depend>
-  <exec_depend version_lt="7.0.0">python-chainer-pip</exec_depend>
+  <exec_depend version_lt="7.0.0" condition="$ROS_DISTRO != debian">python-chainer-pip</exec_depend>
   <!-- python-cahiner-pip depends: [cython, python-numpy] in rosdep/python.yaml, which is not installable on python3 environment -->
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-chainercv-pip</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-chainer-mask-rcnn-pip</exec_depend>
   <!-- }} install chainer -->
-  <exec_depend>python-dlib</exec_depend>  <!-- pip -->
+  <exec_depend condition="$ROS_DISTRO != debian">python-dlib</exec_depend>  <!-- pip -->
   <!-- install fcn {{ -->
   <exec_depend>leveldb</exec_depend>
-  <exec_depend>python-fcn-pip</exec_depend>  <!-- pip -->
+  <exec_depend condition="$ROS_DISTRO != debian">python-fcn-pip</exec_depend>  <!-- pip -->
   <!-- }} install fcn -->
-  <exec_depend version_lt="0.3.7">python-pytesseract-pip</exec_depend>
+  <exec_depend version_lt="0.3.7" condition="$ROS_DISTRO != debian">python-pytesseract-pip</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-requests</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-requests</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-sklearn</exec_depend>

--- a/jsk_perception/package.xml
+++ b/jsk_perception/package.xml
@@ -84,17 +84,17 @@
   <!-- install chainer {{ -->
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-h5py</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-h5py</exec_depend>
-  <exec_depend version_lt="7.0.0" condition="$ROS_DISTRO != debian">python-chainer-pip</exec_depend>
+  <exec_depend version_lt="7.0.0">python-chainer-pip</exec_depend>
   <!-- python-cahiner-pip depends: [cython, python-numpy] in rosdep/python.yaml, which is not installable on python3 environment -->
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-chainercv-pip</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-chainer-mask-rcnn-pip</exec_depend>
   <!-- }} install chainer -->
-  <exec_depend condition="$ROS_DISTRO != debian">python-dlib</exec_depend>  <!-- pip -->
+  <exec_depend>python-dlib</exec_depend>  <!-- pip -->
   <!-- install fcn {{ -->
   <exec_depend>leveldb</exec_depend>
-  <exec_depend condition="$ROS_DISTRO != debian">python-fcn-pip</exec_depend>  <!-- pip -->
+  <exec_depend>python-fcn-pip</exec_depend>  <!-- pip -->
   <!-- }} install fcn -->
-  <exec_depend version_lt="0.3.7" condition="$ROS_DISTRO != debian">python-pytesseract-pip</exec_depend>
+  <exec_depend version_lt="0.3.7">python-pytesseract-pip</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-requests</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-requests</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-sklearn</exec_depend>

--- a/sound_classification/CMakeLists.txt
+++ b/sound_classification/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package(catkin REQUIRED
   catkin_virtualenv
   message_generation
   std_msgs
-  roslaunch
   )
 if (${catkin_virtualenv_VERSION} VERSION_LESS "0.3.0")
   message(STATUS "sound_classification requires catkin_virtualenv >= 0.3.0")

--- a/sound_classification/package.xml
+++ b/sound_classification/package.xml
@@ -10,6 +10,7 @@
 
   <build_depend>catkin_virtualenv</build_depend>
   <build_depend>message_generation</build_depend>
+  <build_depend>std_msgs</build_depend>
 
   <exec_depend>audio_capture</exec_depend>
   <exec_depend>audio_to_spectrogram</exec_depend>


### PR DESCRIPTION
add std_mgs build_depends, to fix obase-build (maybe and others)

```
2025-01-03T00:50:28.1527201Z -- BUILD_SHARED_LIBS is on
2025-01-03T00:50:28.2543412Z -- Using these message generators: gencpp;geneus;genlisp;gennodejs;genpy
2025-01-03T00:50:28.2568008Z -- Could NOT find std_msgs (missing: std_msgs_DIR)
2025-01-03T00:50:28.2569369Z -- Could not find the required component 'std_msgs'. The following CMake error indicates that you\
 either need to install the package with the same name or change your environment so that it can be found.
2025-01-03T00:50:28.2584407Z CMake Error at /usr/share/catkin/cmake/catkinConfig.cmake:82 (find_package):
2025-01-03T00:50:28.2585511Z   Could not find a package configuration file provided by "std_msgs" with any
2025-01-03T00:50:28.2586306Z   of the following names:
2025-01-03T00:50:28.2586595Z
2025-01-03T00:50:28.2586761Z     std_msgsConfig.cmake
2025-01-03T00:50:28.2587107Z     std_msgs-config.cmake
2025-01-03T00:50:28.2587292Z
2025-01-03T00:50:28.2587515Z   Add the installation prefix of "std_msgs" to CMAKE_PREFIX_PATH or set
2025-01-03T00:50:28.2588032Z   "std_msgs_DIR" to a directory containing one of the above files.  If
2025-01-03T00:50:28.2588533Z   "std_msgs" provides a separate development package or SDK, be sure it has
2025-01-03T00:50:28.2588941Z   been installed.
2025-01-03T00:50:28.2589180Z Call Stack (most recent call first):
2025-01-03T00:50:28.2589472Z   CMakeLists.txt:4 (find_package)
2025-01-03T00:50:28.2589660Z
```