### PR TITLE
Delete copy constructor of TfListenerSingleton

### DIFF
--- a/jsk_recognition_utils/include/jsk_recognition_utils/tf_listener_singleton.h
+++ b/jsk_recognition_utils/include/jsk_recognition_utils/tf_listener_singleton.h
@@ -50,8 +50,8 @@ namespace jsk_recognition_utils
     static tf::TransformListener* instance_;
     static boost::mutex mutex_;
   private:
-    TfListenerSingleton(TfListenerSingleton const&){};
-    TfListenerSingleton& operator=(TfListenerSingleton const&){};
+    TfListenerSingleton(TfListenerSingleton const&) = delete;
+    TfListenerSingleton& operator=(TfListenerSingleton const&) = delete;
   };
 
   // tf Utility


### PR DESCRIPTION
Otherwise, the copy constructor returns void which is invalid.
