### PR TITLE
[ROS-O] Add ParticleCuboid::weightedAverage method

### DIFF
--- a/jsk_pcl_ros/include/jsk_pcl_ros/pcl/particle_cuboid.h
+++ b/jsk_pcl_ros/include/jsk_pcl_ros/pcl/particle_cuboid.h
@@ -302,15 +302,26 @@ namespace pcl
       }
       
       inline jsk_pcl_ros::Cube::Ptr toCube() const
-    {
-      Eigen::Affine3f pose = toEigenMatrix();
-      Eigen::Vector3f dimensions(dx, dy, dz);
-      jsk_pcl_ros::Cube::Ptr cube(new jsk_pcl_ros::Cube(Eigen::Vector3f(pose.translation()),
-                                                        Eigen::Quaternionf(pose.rotation()),
-                                                        dimensions));
-      return cube;
-    }
+      {
+        Eigen::Affine3f pose = toEigenMatrix();
+        Eigen::Vector3f dimensions(dx, dy, dz);
+        jsk_pcl_ros::Cube::Ptr cube(new jsk_pcl_ros::Cube(Eigen::Vector3f(pose.translation()),
+                                                          Eigen::Quaternionf(pose.rotation()),
+                                                          dimensions));
+        return cube;
+      }
 
+      // As of https://github.com/PointCloudLibrary/pcl/pull/5538,
+      // trackers must implements averaging method
+      template <class InputIterator>
+        static ParticleCuboid weightedAverage(InputIterator first, InputIterator last)
+      {
+        ParticleCuboid wa;
+        for (auto cuboid = first; cuboid != last; ++cuboid) {
+          wa = wa + *(cuboid) * cuboid->weight;
+        }
+        return wa;
+      }
 
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     };


### PR DESCRIPTION
This PR implements the ⁠`weightedAverage` method in the ⁠`ParticleCuboid` class, as required by changes in PCL ([PointCloudLibrary/pcl#5538](https://github.com/PointCloudLibrary/pcl/pull/5538)).
Prior to these changes, a ⁠tracker class did not have this method. This PR adds a minimal implementation to restore the functionality to its state before the aforementioned changes, ensuring compatibility with the newer PCL API (I checked it works with PCL 1.16 / Ubuntu noble).

As an advanced update considering RPY (Roll, Pitch, Yaw) in multiple parts of the class might be beneficial for future development. This PR focuses on the minimal change to restore functionality.