### PR TITLE
Fix https://github.com/jsk-ros-pkg/jsk_recognition/issues/2860

### DIFF
--- a/imagesift/CMakeLists.txt
+++ b/imagesift/CMakeLists.txt
@@ -109,5 +109,6 @@ if(CATKIN_ENABLE_TESTING)
     # FIXME: jsk_tools/test_topic_published.py does not work on hydro travis/jenkins
     # https://github.com/jsk-ros-pkg/jsk_common/pull/1293#issuecomment-164158260
     add_rostest(test/test_imagesift.test)
+    add_rostest(test/test_two_imagesift.test)
   endif()
 endif()

--- a/imagesift/include/imagesift/imagesift.h
+++ b/imagesift/include/imagesift/imagesift.h
@@ -57,6 +57,9 @@
 
 namespace imagesift
 {
+  // libsiftfast has so many static global variables. It causes segmentation fault when more than 2 imagesift nodelets are loaded into the same nodelet manager. This global variable enable more than 2 threads to use libsiftfast's variables. This means, libsiftfast becomes slow when you load 2 imagesift nodelets.
+  static boost::mutex _g_siftfast_mutex;
+
   class SiftNode: public jsk_topic_tools::DiagnosticNodelet
   {
   public:

--- a/imagesift/src/imagesift.cpp
+++ b/imagesift/src/imagesift.cpp
@@ -72,6 +72,8 @@ namespace imagesift
     }
 
     SiftNode::~SiftNode() {
+        boost::lock_guard<boost::mutex> g(_g_siftfast_mutex);
+        DestroyAllResources();
         // message_filters::Synchronizer needs to be called reset
         // before message_filters::Subscriber is freed.
         // Calling reset fixes the following error on shutdown of the nodelet:
@@ -125,6 +127,7 @@ namespace imagesift
     bool SiftNode::detect(posedetection_msgs::Feature0D& features, const sensor_msgs::Image& imagemsg,
                           const sensor_msgs::Image::ConstPtr& mask_ptr)
     {
+        boost::lock_guard<boost::mutex> g(_g_siftfast_mutex);
         boost::mutex::scoped_lock lock(_mutex);
         Image imagesift = NULL;
         cv::Rect region;

--- a/imagesift/test/test_two_imagesift.test
+++ b/imagesift/test/test_two_imagesift.test
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<launch>
+  <node name="static_virtual_camera"
+        pkg="jsk_recognition_utils" type="static_virtual_camera.py" />
+
+  <node name="nodelet_manager"
+        pkg="nodelet" type="nodelet"
+        args="manager" />
+  <node name="imagesift1"
+        pkg="nodelet" type="nodelet"
+        args="load imagesift/ImageSift nodelet_manager"
+        respawn="true" >
+    <remap from="image" to="static_virtual_camera/image_color" />
+    <remap from="camera_info" to="static_virtual_camera/camera_info" />
+    <remap from="Feature0D" to="/imagesift1/Feature0D" />
+    <remap from="Feature0DDetect" to="/imagesift1/Feature0DDetect" />
+    <remap from="ImageFeature0D" to="/imagesift1/ImageFeature0D" />
+    <param name="image_transport" value="raw" />
+  </node>
+  <node name="imagesift2"
+        pkg="nodelet" type="nodelet"
+        args="load imagesift/ImageSift nodelet_manager"
+        respawn="true" >
+    <remap from="image" to="static_virtual_camera/image_color" />
+    <remap from="camera_info" to="static_virtual_camera/camera_info" />
+    <remap from="Feature0D" to="/imagesift2/Feature0D" />
+    <remap from="Feature0DDetect" to="/imagesift2/Feature0DDetect" />
+    <remap from="ImageFeature0D" to="/imagesift2/ImageFeature0D" />
+    <param name="image_transport" value="raw" />
+  </node>
+
+  <test test-name="test_imagesift"
+        name="test_imagesift"
+        pkg="jsk_tools" type="test_topic_published.py"
+        retry="3">
+    <rosparam>
+      topic_0: /imagesift1/ImageFeature0D
+      timeout_0: 10
+      topic_1: /imagesift2/ImageFeature0D
+      timeout_1: 10
+      check_after_kill_node: true
+      node_names: [imagesift1, imagesift2]
+    </rosparam>
+  </test>
+
+</launch>


### PR DESCRIPTION
close #2860 

`libsiftfast` has so many static global variables, so it is not thread-safe when called from multiple nodelets. This PR adds a global mutex to restrict the access to those variables to make it thread-safe.

Since the entire mutex is taken, if n imagesift nodelet are loaded, the time required to compute each feature is n times longer. But I think it is fine because the node is implemented with ConnectionBasedNodelet. If the user doesn't subscribe, the slow calculation doesn't occur.  Making the user code work is much important.

The clean method is to make [libsiftfast](https://github.com/jsk-ros-pkg/jsk_3rdparty/tree/master/3rdparty/libsiftfast) thread-safe, but I think we should write it from scratch or use OpenCV if we do so. 

You can try the bug occurs just reverting 365b2d00050e6ef9a853ad21a046ac59adf07308 and execute `test_two_imagesift.test`