### PR TITLE
fix tile_image for 24.04

### DIFF
--- a/jsk_perception/node_scripts/tile_image.py
+++ b/jsk_perception/node_scripts/tile_image.py
@@ -48,7 +48,7 @@ class TileImages(ConnectionBasedTransport):
             sys.exit(1)
         self._shape = rospy.get_param('~shape', None)
         if self._shape:
-            if not (isinstance(self._shape, collections.Sequence) and
+            if not (isinstance(self._shape, collections.abc.Sequence) and
                     len(self._shape) == 2):
                 rospy.logerr('~shape must be a list of 2 float values.')
                 sys.exit(1)


### PR DESCRIPTION
`collections.Sequence` is deprecate in latest ubuntu python version

```
 DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
  collections.Sequence
```