### PR TITLE
use cv2.putText if font is not found

### DIFF
--- a/jsk_perception/node_scripts/draw_rects.py
+++ b/jsk_perception/node_scripts/draw_rects.py
@@ -148,19 +148,29 @@ class DrawRects(ConnectionBasedTransport):
                           color=color.tolist(),
                           thickness=self.rect_boldness,
                           lineType=cv2.LINE_AA)
-            if self.use_classification_result and osp.exists(self.font_path):
+            if self.use_classification_result:
                 text = class_msg.label_names[i]
                 if self.show_proba and len(class_msg.label_proba) > i:
                     text += ' ({0:.2f})'.format(class_msg.label_proba[i])
                 pos_x = int(rect.x * self.resolution_factor)
                 pos_y = int(rect.y * self.resolution_factor)
                 pos = (pos_x, pos_y)
-                img = put_text_to_image(
-                    img, text, pos, self.font_path,
-                    self.label_size,
-                    color=(255, 255, 255),
-                    background_color=tuple(color),
-                    offset_x=self.rect_boldness / 2.0)
+                if osp.exists(self.font_path):
+                    img = put_text_to_image(
+                        img, text, pos, self.font_path,
+                        self.label_size,
+                        color=(255, 255, 255),
+                        background_color=tuple(color),
+                        offset_x=self.rect_boldness / 2.0)
+                else:
+                    pt1=(int(pos_x), int(pos_y - 16))
+                    pt2=(int(pos_x + rect.width * self.resolution_factor)-10, int(pos_y))
+                    cv2.rectangle(img, pt1, pt2,
+                                  color.tolist(), -1)
+                    cv2.putText(img, text, (pos_x, pos_y - 4),
+                                cv2.FONT_HERSHEY_PLAIN,
+                                fontScale=1, color=(255, 255, 255),
+                                thickness=1, lineType=cv2.LINE_AA)
         if self.transport_hint == 'compressed':
             viz_msg = sensor_msgs.msg.CompressedImage()
             viz_msg.format = "jpeg"

--- a/jsk_recognition_utils/python/jsk_recognition_utils/put_text.py
+++ b/jsk_recognition_utils/python/jsk_recognition_utils/put_text.py
@@ -40,7 +40,12 @@ def put_text_to_image(
         text = text.decode('utf-8')
     pil_font = ImageFont.truetype(font=font_path, size=font_size)
     dummy_draw = ImageDraw.Draw(Image.new("RGB", (0, 0)))
-    text_w, text_h = dummy_draw.textsize(text, font=pil_font)
+    if hasattr(dummy_draw, 'textsize'):
+        text_w, text_h = dummy_draw.textsize(text, font=pil_font)
+    else:  # Pillow>=10.0
+        text_bbox = dummy_draw.textbbox((0,0), text, font=pil_font)
+        text_w = text_bbox[2] - text_bbox[0]
+        text_h = text_bbox[3] - text_bbox[1]
     text_bottom_offset = int(0.1 * text_h)
     x, y = pos
     if loc == 'top':


### PR DESCRIPTION
sample/sample_aws_auto_checkin_app.launch uses 
```
    <node name="draw_rects"
          pkg="jsk_perception" type="draw_rects.py"
          output="screen"
          clear_params="true" >
      <remap from="~input" to="$(arg INPUT_IMAGE)" />
      <remap from="~input/rects" to="output/rects" />
      <remap from="~input/class" to="output/class" />
      <rosparam subst_value="true">                                                                                     
        font_path: $(find jsk_recognition_utils)/font_data/NotoSansJP-Regular.otf                                       
        use_classification_result: true                                                                                 
        label_size: 16                                                                                                  
        approximate_sync: true                                                                                          
        queue_size: 30                                                                                                  
        image_transport: compressed                                                                                     
      </rosparam>
    </node>
```
but `font_data` is not installed for deb package for some reason.

This pr use `cv2.putText` when the font is not found.