### PR TITLE
Fix uniform sampling

### DIFF
--- a/jsk_pcl_ros/plugins/nodelet/libjsk_pcl_ros.xml
+++ b/jsk_pcl_ros/plugins/nodelet/libjsk_pcl_ros.xml
@@ -519,4 +519,8 @@
       Calculate container occupancy rate
     </description>
   </class>
+  <class name="jsk_pcl/UniformSampling"
+         type="jsk_pcl_ros::UniformSampling"
+         base_class_type="nodelet::Nodelet">
+  </class>
 </library>

--- a/jsk_pcl_ros/src/uniform_sampling_nodelet.cpp
+++ b/jsk_pcl_ros/src/uniform_sampling_nodelet.cpp
@@ -80,10 +80,10 @@ namespace jsk_pcl_ros
     pcl::PointCloud<pcl::PointXYZ>::Ptr
       cloud (new pcl::PointCloud<pcl::PointXYZ>);
     pcl::fromROSMsg(*msg, *cloud);
-#if ( PCL_MAJOR_VERSION == 1 && PCL_MINOR_VERSION >= 8)
+#if ( PCL_MAJOR_VERSION == 1 && PCL_MINOR_VERSION >= 9)
     pcl::UniformSampling<pcl::PointXYZ> uniform_sampling(true);
 #else
-    pcl::UniformSampling<pcl::PointXYZ> uniform_sampling();
+    pcl::UniformSampling<pcl::PointXYZ> uniform_sampling;
 #endif
     uniform_sampling.setInputCloud(cloud);
     uniform_sampling.setRadiusSearch(search_radius_);

--- a/jsk_pcl_ros/src/uniform_sampling_nodelet.cpp
+++ b/jsk_pcl_ros/src/uniform_sampling_nodelet.cpp
@@ -80,10 +80,10 @@ namespace jsk_pcl_ros
     pcl::PointCloud<pcl::PointXYZ>::Ptr
       cloud (new pcl::PointCloud<pcl::PointXYZ>);
     pcl::fromROSMsg(*msg, *cloud);
-#if ( PCL_MAJOR_VERSION == 1 && PCL_MINOR_VERSION == 7)
-    pcl::UniformSampling<pcl::PointXYZ> uniform_sampling();
-#elif ( PCL_MAJOR_VERSION == 1 && PCL_MINOR_VERSION >= 8)
+#if ( PCL_MAJOR_VERSION == 1 && PCL_MINOR_VERSION >= 8)
     pcl::UniformSampling<pcl::PointXYZ> uniform_sampling(true);
+#else
+    pcl::UniformSampling<pcl::PointXYZ> uniform_sampling();
 #endif
     uniform_sampling.setInputCloud(cloud);
     uniform_sampling.setRadiusSearch(search_radius_);

--- a/jsk_pcl_ros/src/uniform_sampling_nodelet.cpp
+++ b/jsk_pcl_ros/src/uniform_sampling_nodelet.cpp
@@ -80,7 +80,11 @@ namespace jsk_pcl_ros
     pcl::PointCloud<pcl::PointXYZ>::Ptr
       cloud (new pcl::PointCloud<pcl::PointXYZ>);
     pcl::fromROSMsg(*msg, *cloud);
-    pcl::UniformSampling<pcl::PointXYZ> uniform_sampling;
+#if ( PCL_MAJOR_VERSION == 1 && PCL_MINOR_VERSION == 7)
+    pcl::UniformSampling<pcl::PointXYZ> uniform_sampling();
+#elif ( PCL_MAJOR_VERSION == 1 && PCL_MINOR_VERSION >= 8)
+    pcl::UniformSampling<pcl::PointXYZ> uniform_sampling(true);
+#endif
     uniform_sampling.setInputCloud(cloud);
     uniform_sampling.setRadiusSearch(search_radius_);
 #if ( PCL_MAJOR_VERSION == 1 && PCL_MINOR_VERSION == 7)
@@ -90,7 +94,15 @@ namespace jsk_pcl_ros
     pcl::PointCloud<pcl::PointXYZ> output;
     uniform_sampling.filter(output);
     pcl::PointIndicesPtr indices_ptr;
-    std::vector<int> &indices = *uniform_sampling.getIndices();
+    // this is all indices
+    std::vector<int> &all_indices = *uniform_sampling.getIndices();
+    pcl::PointIndices removed_indices;
+    uniform_sampling.getRemovedIndices(removed_indices);
+    std::sort(removed_indices.indices.begin(), removed_indices.indices.end());
+    std::vector<int> indices;
+    std::set_difference(all_indices.begin(), all_indices.end(),
+                        removed_indices.indices.begin(), removed_indices.indices.end(),
+                        std::inserter(indices, indices.begin()));
 #endif
     PCLIndicesMsg ros_indices;
 #if ( PCL_MAJOR_VERSION == 1 && PCL_MINOR_VERSION == 7)


### PR DESCRIPTION
- add UniformSampling in nodelet xml.
- now indices are not correctly registered.
  - `uniform_sampling.getIndices()` returns all indices
  - we need to get the indices from `all_indices - removed_indices`.
  - ref: https://github.com/PointCloudLibrary/pcl/blob/2f9dc390c6769fbd821fafa0e16f4707ed7c5d79/tools/uniform_sampling.cpp#L104-L116