### PR TITLE
do not publish when array_size is zero

### DIFF
--- a/jsk_pcl_ros_utils/src/bounding_box_array_to_bounding_box_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/bounding_box_array_to_bounding_box_nodelet.cpp
@@ -83,6 +83,7 @@ namespace jsk_pcl_ros_utils
     int array_size = bbox_array_msg->boxes.size();
     if (array_size == 0)
     {
+      NODELET_WARN_THROTTLE(10, "bbox array size is 0, skip publishing");
       return;
     } else if (index_ < 0) {
       return;

--- a/jsk_pcl_ros_utils/src/bounding_box_array_to_bounding_box_nodelet.cpp
+++ b/jsk_pcl_ros_utils/src/bounding_box_array_to_bounding_box_nodelet.cpp
@@ -81,7 +81,10 @@ namespace jsk_pcl_ros_utils
     bbox_msg.header = bbox_array_msg->header;
 
     int array_size = bbox_array_msg->boxes.size();
-    if (index_ < 0) {
+    if (array_size == 0)
+    {
+      return;
+    } else if (index_ < 0) {
       return;
     } else if (index_ < array_size) {
       bbox_msg = bbox_array_msg->boxes[index_];


### PR DESCRIPTION
When input `BoundingBoxArray`'s `boxes` size is zero, topic will be subscribed with the initial value (such as `dimensions.x = 0`).
This PR stop publishing when input size is zero.